### PR TITLE
Do not show WebGL1 warnings when Engine v2 is active

### DIFF
--- a/src/editor/inspector/assets/texture.ts
+++ b/src/editor/inspector/assets/texture.ts
@@ -1085,6 +1085,11 @@ class TextureAssetInspector extends Container {
         this._webgl1NonPotWithoutAddressClampWarning.hidden = true;
         this._webgl1NonPotWithMipmapsWarning.hidden = true;
 
+        // Don't show WebGL1 warnings when running in Engine v2 mode
+        if (editor.projectEngineV2) {
+            return;
+        }
+
         const assets = this._assets;
         // Show the warnings if any of the assets have an issue
 


### PR DESCRIPTION
Fixes #1276

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
