### PR TITLE
Remove unused sprite preview controls panel

### DIFF
--- a/sass/editor/_editor-sprite-editor.scss
+++ b/sass/editor/_editor-sprite-editor.scss
@@ -157,15 +157,6 @@
                         }
                     }
 
-                    .ui-panel.preview-controls {
-                        position: absolute;
-                        bottom: 0;
-                        z-index: 1;
-                        background: transparent;
-                        width: 100%;
-                        display: none; // hide for now
-                    }
-
                     .ui-panel.add-frames-info,
                     .ui-panel.import-error {
                         border: 1px solid $text-active;

--- a/src/editor/pickers/sprite-editor/sprite-editor-preview-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-preview-panel.ts
@@ -1,5 +1,3 @@
-import { LegacyPanel } from '../../../common/ui/panel.ts';
-
 /**
  * @import { Panel } from '@playcanvas/pcui'
  */
@@ -33,10 +31,6 @@ editor.once('load', () => {
 
         parent.class.add('asset-preview');
         parent.dom.insertBefore(previewContainer, parent.domContent);
-
-        const panelControls = new LegacyPanel();
-        panelControls.class.add('preview-controls');
-        previewContainer.appendChild(panelControls.element);
 
         let time = 0;
         let playing = true;
@@ -98,8 +92,6 @@ editor.once('load', () => {
             previewContainer = null;
 
             playing = false;
-
-            panelControls.destroy();
 
             for (let i = 0, len = events.length; i < len; i++) {
                 events[i].unbind();


### PR DESCRIPTION
Remove an unused and empty legacy UI panel that presumably was intended to hold play/pause/step/etc buttons for controlling playback of animated sprites.

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
