### PR TITLE
Fix asset panel folders resizing handle when scrolled down

### DIFF
--- a/sass/editor/_editor-assets-panel.scss
+++ b/sass/editor/_editor-assets-panel.scss
@@ -348,13 +348,18 @@
     > .pcui-panel-content {
         height: 100%;
 
-        > .pcui-asset-panel-folders {
+        > .pcui-asset-panel-left {
             flex-shrink: 0;
             max-width: 100%;
+            height: 100%;
             border-top: 1px solid $border-primary;
 
-            .pcui-treeview-item-icon::after {
-                content: '\E139';
+            > .pcui-asset-panel-folders {
+                height: 100%;
+
+                .pcui-treeview-item-icon::after {
+                    content: '\E139';
+                }
             }
 
             // this is to prevent flashing when we drag assets

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -26,6 +26,7 @@ import { tooltip, tooltipSimpleItem } from '../../common/tooltips.ts';
 import { bytesToHuman, naturalCompare } from '../../common/utils.ts';
 
 const CLASS_ROOT = 'pcui-asset-panel';
+const CLASS_LEFT = `${CLASS_ROOT}-left`;
 const CLASS_FOLDERS = `${CLASS_ROOT}-folders`;
 const CLASS_CURRENT_FOLDER = `${CLASS_ROOT}-current-folder`;
 const CLASS_ASSET_HIGHLIGHTED = `${CLASS_ROOT}-highlighted-asset`;
@@ -417,15 +418,21 @@ class AssetPanel extends Panel {
         this._createTooltip('Open Store', btnStore);
 
         // folders tree view
-        this._containerFolders = new Container({
-            class: CLASS_FOLDERS,
+        this._containerLeft = new Container({
+            class: CLASS_LEFT,
             resizable: 'right',
             resizeMin: 100,
             resizeMax: 600,
-            width: 200,
+            width: 200
+        });
+        this.append(this._containerLeft);
+
+        // folders tree view
+        this._containerFolders = new Container({
+            class: CLASS_FOLDERS,
             scrollable: true
         });
-        this.append(this._containerFolders);
+        this._containerLeft.append(this._containerFolders);
 
         this._foldersView = new TreeView({
             allowReordering: false,

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -417,7 +417,7 @@ class AssetPanel extends Panel {
 
         this._createTooltip('Open Store', btnStore);
 
-        // folders tree view
+        // resizable container for a scrollable folders container
         this._containerLeft = new Container({
             class: CLASS_LEFT,
             resizable: 'right',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "skipLibCheck": true,
         "noEmit": true,
         "target": "esnext",
-        "moduleResolution": "bundler",
+        "moduleResolution": "node",
         "outDir": "dist",
         "lib": ["es6", "dom", "webworker"]
     },


### PR DESCRIPTION
Fixes #1277

It seems that there is an inherit issue with PCUI container element, if it is set to be scrollable as well as resizable, then scrollable style is set on the parent element, leading to resizing handle to be overflow-cut.
In Editor other panels, like hierarchy panel have multiple containers - one for resizing, and then inside of it one for scrolling.
This PR does the same - it adds a new container in for resizing, and then container with files for scrolling as before.

Also tested that auto-scrolling when dragging - still works.

This also fixes the horizontal scroll issue, below are two screens before and after the change (green highlight for the screen):
<img width="205" height="481" alt="image" src="https://github.com/user-attachments/assets/b891e218-3354-488f-a86d-10c0aed2a662" /> <img width="220" height="484" alt="image" src="https://github.com/user-attachments/assets/de42b4c0-4bdd-4b2a-a650-65f307b8937d" />


- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
