### PR TITLE
Asset Panel Type fixes

### DIFF
--- a/src/common/pcui/element/element-table-row.ts
+++ b/src/common/pcui/element/element-table-row.ts
@@ -22,6 +22,31 @@ const CLASS_SELECTED_ROW = `${CLASS_ROW}-selected`;
  */
 class TableRow extends Container {
     /**
+     * @type {boolean}
+     */
+    _header;
+
+    /**
+     * @type {Table}
+     */
+    _table;
+
+    /**
+     * @type {boolean}
+     */
+    _selected;
+
+    /**
+     * @type {Function}
+     */
+    _domEvtFocus;
+
+    /**
+     * @type {Function}
+     */
+    _domEvtBlur;
+
+    /**
      * Creates new TableRow.
      *
      * @param {TableRowArgs & ContainerArgs} [args] - The arguments.

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -315,12 +315,24 @@ class AssetPanel extends Panel {
      */
     _btnDelete;
 
+    /**
+     * @type {Button}
+     */
     _btnBack;
 
+    /**
+     * @type {Button}
+     */
     _btnLargeGrid;
 
+    /**
+     * @type {Button}
+     */
     _btnSmallGrid;
 
+    /**
+     * @type {Button}
+     */
     _btnDetailsView;
 
     /**

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -386,7 +386,7 @@ class AssetPanel extends Panel {
      */
     _hoveredAsset;
 
-    /**
+     * @type {Array}
      * @type {[]]}
      */
     _eventsDropManager;


### PR DESCRIPTION
This PR fixes many of the type error in the `asset-panel.ts` and `element-table-row.ts`

- Converts static members like `AssetPanel.MEMBER` to `static MEMER`
- Declares field declarations for class members with JSdoc types
- Few minor type fixes.