### PR TITLE
Refactor JSDoc handling in attribute autofill logic

### DIFF
--- a/src/workers/esm-script.worker.ts
+++ b/src/workers/esm-script.worker.ts
@@ -17,7 +17,7 @@ const PLAYCANVAS_ATTRIBUTE_DOCS_URL = {
  * @property {string} file - The source file
  * @property {string} type - The category of the error
  * @property {string} name - The name of the error
- * @property {number} startLine - The start line number of the error
+ * @property {number} start - The start line number of the error
  * @property {number} startColumn - The start column number of the error
  * @property {number} endLine - The end line number of the error
  * @property {number} endColumn - The end column number of the error


### PR DESCRIPTION
This PR significantly refactors the user flow to promote attributes and class members are handled in the Code editor.

Before:

![Clipboard-20250807-142557-940](https://github.com/user-attachments/assets/45869432-3700-4402-8bc0-77ca15684ae0)

- UX to promote a class member is via nested quick fix
- Remove attribute destroys all JSDoc tags
- Quick fix displays arbitrary json

After:

![Clipboard-20250807-142415-921](https://github.com/user-attachments/assets/e9785c45-325f-425a-84bc-5bd1bf68e90e)

- UX to promote a member is up-front and clear
- Remove attribute only destroys attribute tags, not other tags ie @description or @title
- No arbitrary json displayed

## Summary

* Introduced JSDocUtils class for managing JSDoc operations, including analysis, creation, and cleaning of JSDoc blocks.
* Enhanced modifyJSDocAttribute function to handle adding and removing JSDoc attributes more effectively.
* Updated code lens provider to support new JSDoc actions for attributes, including adding slider functionality.
* Improved error handling in the ESM script worker by clarifying error property names in documentation.
