### PR TITLE
Rename Asset Tasks to Asset Import

### DIFF
--- a/sass/editor.scss
+++ b/sass/editor.scss
@@ -43,7 +43,7 @@
 @import 'editor/editor-settings-rendering-panel';
 @import 'editor/editor-settings-layers-panel';
 @import 'editor/editor-settings-batchgroups-panel';
-@import 'editor/editor-settings-asset-tasks';
+@import 'editor/editor-settings-asset-import';
 @import 'editor/editor-settings-ai';
 @import 'editor/editor-settings-scripts-panel';
 @import 'editor/editor-sprite-editor';

--- a/sass/editor/_editor-settings-asset-import.scss
+++ b/sass/editor/_editor-settings-asset-import.scss
@@ -1,8 +1,8 @@
-.asset-tasks-settings-panel-section {
+.asset-import-settings-panel-section {
     margin: 0 $element-margin;
 }
 
-.asset-tasks-settings-panel-attributes {
+.asset-import-settings-panel-attributes {
     .pcui-label-group > .pcui-label {
         width: 42% !important;
     }

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -312,19 +312,19 @@ editor.once('load', () => {
     }, {
         name: 'settings:asset-import:texturePot',
         title: 'Texture power of two',
-        description: 'When a texture is imported it will be resized to use the nearest power of two resolution.'
+        description: 'When a texture is imported, it will be resized to the nearest power-of-two resolution.'
     }, {
         name: 'settings:asset-import:textureDefaultToAtlas',
         title: 'Create Atlases',
-        description: 'If enabled, when a texture is imported it will be converted to a Texture Atlas asset instead of a Texture asset.'
+        description: 'If enabled, imported textures are converted to Texture Atlas assets instead of Texture assets.'
     }, {
         name: 'settings:asset-import:searchRelatedAssets',
         title: 'Search related assets',
-        description: 'If enabled, importing a source asset will update target assets where ever they are located. If disabled, assets will only be updated if they are in the same folder, otherwise new assets will be created.'
+        description: 'If enabled, importing a source asset updates related target assets wherever they are located. If disabled, assets are updated only when in the same folder; otherwise, new assets are created.'
     }, {
         name: 'settings:asset-import:preserveMapping',
         title: 'Preserve model material mappings',
-        description: 'If enabled, after importing an existing source model we will try to preserve the material mappings that were set by the user on the existing model.'
+        description: 'If enabled, when reimporting an existing source model, the Editor attempts to preserve existing user-defined material mappings.'
     }, {
         name: 'settings:asset-import:useGlb',
         title: 'Use GLB format',
@@ -332,7 +332,7 @@ editor.once('load', () => {
     }, {
         name: 'settings:asset-import:useContainers',
         title: 'Import Hierarchy',
-        description: 'Generate a template asset when importing 3D assets (FBX etc). The template asset will contain the full entity hierarchy from the imported file.'
+        description: 'Generates a template asset when importing 3D assets (FBX, etc.). The template asset contains the full entity hierarchy from the imported file.'
     }, {
         name: 'settings:asset-import:meshCompression',
         title: 'Mesh Compression Type',
@@ -340,23 +340,23 @@ editor.once('load', () => {
     }, {
         name: 'settings:asset-import:dracoDecodeSpeed',
         title: 'Draco Decode Speed',
-        description: 'Specify the speed of mesh decoding. A smaller value will result in slower decoding, but smaller file sizes.'
+        description: 'Specify the speed of mesh decoding. A lower value results in slower decoding but smaller file sizes.'
     }, {
         name: 'settings:asset-import:dracoMeshSize',
         title: 'Draco Mesh Size',
-        description: 'Specify the size factor to use when compressing mesh attributes. A smaller value will result in fewer bits being used to compress mesh attributes and so a smaller file but less detail and potentially some artifacts.'
+        description: 'Specify the size factor used when compressing mesh attributes. A lower value uses fewer bits to compress attributes, resulting in a smaller file but less detail and potential artifacts.'
     }, {
         name: 'settings:asset-import:createFBXFolder',
         title: 'Create FBX Folder',
-        description: 'Create a new folder in the current directory when importing an FBX file, which will store all the imported FBX contents.'
+        description: 'Creates a new folder in the current directory when importing an FBX file to store the imported FBX contents.'
     }, {
         name: 'settings:asset-import:animSampleRate',
         title: 'Animation Sample Rate',
-        description: 'Rate at which to sample animation curves in samples per second. Specify 0 to disable sampling and use input keys instead.'
+        description: 'The rate at which to sample animation curves (samples per second). Specify 0 to disable sampling and use input keys instead.'
     }, {
         name: 'settings:asset-import:animCurveTolerance',
         title: 'Animation Curve Tolerance',
-        description: 'Tolerance to use when optimizing linear animation curve segments. Specify 0 to disable curve optimization.'
+        description: 'The tolerance used when optimizing linear animation curve segments. Specify 0 to disable curve optimization.'
     }, {
         name: 'settings:asset-import:animEnableCubic',
         title: 'Animation Cubic Curves',
@@ -364,39 +364,39 @@ editor.once('load', () => {
     }, {
         name: 'settings:asset-import:animUseFbxFilename',
         title: 'Animation Naming Strategy (for GLB only)',
-        description: 'Choose the naming strategy when importing animations. Select \'Use Take Name\' to name the animation after the take name assigned in the FBX file. Select \'Use FBX Filename\' to name the animation after the FBX filename.'
+        description: 'Choose the naming strategy for imported animations. Select \'Use Take Name\' to name the animation after the take name assigned in the FBX file. Select \'Use FBX Filename\' to name the animation after the FBX filename.'
     }, {
         name: 'settings:asset-import:unwrapUv',
         title: 'Unwrap Uv',
-        description: 'Generate a set of unwrapped uv coordinates.'
+        description: 'Generates a set of unwrapped UV coordinates.'
     }, {
         name: 'settings:asset-import:unwrapUvTexelsPerMeter',
         title: 'Padding',
-        description: 'When uv unwrapping is enabled, the number of texels per meter. Defaults to 16.'
+        description: 'Specifies the number of texels per meter when UV unwrapping is enabled. Default: 16.'
     }, {
         name: 'settings:asset-import:importMorphNormals',
         title: 'Import Morph Target Normals',
-        description: 'When importing a model, import the normals of morph targets. Disable this option if the normals on morph targets look incorrect.'
+        description: 'Imports morph target normals when importing a model. Disable this if morph target normals look incorrect.'
     }, {
         name: 'settings:asset-import:defaultAssetPreload',
         title: 'Preload new assets',
-        description: 'Create new assets with the preload option selected. Script assets will be created with preload enabled regardless of this setting.'
+        description: 'Creates new assets with the preload option enabled. Script assets are always created with preload enabled.'
     }, {
         name: 'settings:asset-import:overwrite:model',
         title: 'Overwrite models',
-        description: 'When a model is imported, overwrite a previously imported model asset.'
+        description: 'When a model is imported, overwrites any previously imported model asset.'
     }, {
         name: 'settings:asset-import:overwrite:animation',
         title: 'Overwrite animations',
-        description: 'When a model is imported, overwrite previously imported animation assets.'
+        description: 'When a model is imported, overwrites previously imported animation assets.'
     }, {
         name: 'settings:asset-import:overwrite:material',
         title: 'Overwrite materials',
-        description: 'When a model is imported, overwrite previously imported material assets.'
+        description: 'When a model is imported, overwrites previously imported material assets.'
     }, {
         name: 'settings:asset-import:overwrite:texture',
         title: 'Overwrite textures',
-        description: 'When a model is imported, overwrite previously imported texture assets.'
+        description: 'When a model is imported, overwrites previously imported texture assets.'
     }, {
         name: 'settings:lightmapping',
         title: 'Lightmapping',

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -306,95 +306,95 @@ editor.once('load', () => {
         title: 'Change Zoom Sensitivity',
         description: 'Change this value if you want to adjust the zoom sensitivity in the Editor viewport.'
     }, {
-        name: 'settings:asset-tasks',
-        title: 'Asset Tasks',
-        description: 'Settings for defining default behavior rules for asset pipeline jobs: assets extracting, textures resizing, etc.'
+        name: 'settings:asset-import',
+        title: 'Asset Import',
+        description: 'Settings for controlling how assets are imported into your project.'
     }, {
-        name: 'settings:asset-tasks:texturePot',
+        name: 'settings:asset-import:texturePot',
         title: 'Texture power of two',
         description: 'When a texture is imported it will be resized to use the nearest power of two resolution.'
     }, {
-        name: 'settings:asset-tasks:textureDefaultToAtlas',
+        name: 'settings:asset-import:textureDefaultToAtlas',
         title: 'Create Atlases',
         description: 'If enabled, when a texture is imported it will be converted to a Texture Atlas asset instead of a Texture asset.'
     }, {
-        name: 'settings:asset-tasks:searchRelatedAssets',
+        name: 'settings:asset-import:searchRelatedAssets',
         title: 'Search related assets',
         description: 'If enabled, importing a source asset will update target assets where ever they are located. If disabled, assets will only be updated if they are in the same folder, otherwise new assets will be created.'
     }, {
-        name: 'settings:asset-tasks:preserveMapping',
+        name: 'settings:asset-import:preserveMapping',
         title: 'Preserve model material mappings',
         description: 'If enabled, after importing an existing source model we will try to preserve the material mappings that were set by the user on the existing model.'
     }, {
-        name: 'settings:asset-tasks:useGlb',
+        name: 'settings:asset-import:useGlb',
         title: 'Use GLB format',
         description: 'Create model assets in GLB format.'
     }, {
-        name: 'settings:asset-tasks:useContainers',
+        name: 'settings:asset-import:useContainers',
         title: 'Import Hierarchy',
         description: 'Generate a template asset when importing 3D assets (FBX etc). The template asset will contain the full entity hierarchy from the imported file.'
     }, {
-        name: 'settings:asset-tasks:meshCompression',
+        name: 'settings:asset-import:meshCompression',
         title: 'Mesh Compression Type',
         description: 'Specify the mesh compression to apply to imported models.'
     }, {
-        name: 'settings:asset-tasks:dracoDecodeSpeed',
+        name: 'settings:asset-import:dracoDecodeSpeed',
         title: 'Draco Decode Speed',
         description: 'Specify the speed of mesh decoding. A smaller value will result in slower decoding, but smaller file sizes.'
     }, {
-        name: 'settings:asset-tasks:dracoMeshSize',
+        name: 'settings:asset-import:dracoMeshSize',
         title: 'Draco Mesh Size',
         description: 'Specify the size factor to use when compressing mesh attributes. A smaller value will result in fewer bits being used to compress mesh attributes and so a smaller file but less detail and potentially some artifacts.'
     }, {
-        name: 'settings:asset-tasks:createFBXFolder',
+        name: 'settings:asset-import:createFBXFolder',
         title: 'Create FBX Folder',
         description: 'Create a new folder in the current directory when importing an FBX file, which will store all the imported FBX contents.'
     }, {
-        name: 'settings:asset-tasks:animSampleRate',
+        name: 'settings:asset-import:animSampleRate',
         title: 'Animation Sample Rate',
         description: 'Rate at which to sample animation curves in samples per second. Specify 0 to disable sampling and use input keys instead.'
     }, {
-        name: 'settings:asset-tasks:animCurveTolerance',
+        name: 'settings:asset-import:animCurveTolerance',
         title: 'Animation Curve Tolerance',
         description: 'Tolerance to use when optimizing linear animation curve segments. Specify 0 to disable curve optimization.'
     }, {
-        name: 'settings:asset-tasks:animEnableCubic',
+        name: 'settings:asset-import:animEnableCubic',
         title: 'Animation Cubic Curves',
         description: 'Output cubic curves when they are encountered. Disable to convert all curves to linear segments.'
     }, {
-        name: 'settings:asset-tasks:animUseFbxFilename',
+        name: 'settings:asset-import:animUseFbxFilename',
         title: 'Animation Naming Strategy (for GLB only)',
         description: 'Choose the naming strategy when importing animations. Select \'Use Take Name\' to name the animation after the take name assigned in the FBX file. Select \'Use FBX Filename\' to name the animation after the FBX filename.'
     }, {
-        name: 'settings:asset-tasks:unwrapUv',
+        name: 'settings:asset-import:unwrapUv',
         title: 'Unwrap Uv',
         description: 'Generate a set of unwrapped uv coordinates.'
     }, {
-        name: 'settings:asset-tasks:unwrapUvTexelsPerMeter',
+        name: 'settings:asset-import:unwrapUvTexelsPerMeter',
         title: 'Padding',
         description: 'When uv unwrapping is enabled, the number of texels per meter. Defaults to 16.'
     }, {
-        name: 'settings:asset-tasks:importMorphNormals',
+        name: 'settings:asset-import:importMorphNormals',
         title: 'Import Morph Target Normals',
         description: 'When importing a model, import the normals of morph targets. Disable this option if the normals on morph targets look incorrect.'
     }, {
-        name: 'settings:asset-tasks:defaultAssetPreload',
+        name: 'settings:asset-import:defaultAssetPreload',
         title: 'Preload new assets',
         description: 'Create new assets with the preload option selected. Script assets will be created with preload enabled regardless of this setting.'
     }, {
-        name: 'settings:asset-tasks:overwrite:model',
+        name: 'settings:asset-import:overwrite:model',
         title: 'Overwrite models',
         description: 'When a model is imported, overwrite a previously imported model asset.'
     }, {
-        name: 'settings:asset-tasks:overwrite:animation',
+        name: 'settings:asset-import:overwrite:animation',
         title: 'Overwrite animations',
         description: 'When a model is imported, overwrite previously imported animation assets.'
     }, {
-        name: 'settings:asset-tasks:overwrite:material',
+        name: 'settings:asset-import:overwrite:material',
         title: 'Overwrite materials',
         description: 'When a model is imported, overwrite previously imported material assets.'
     }, {
-        name: 'settings:asset-tasks:overwrite:texture',
+        name: 'settings:asset-import:overwrite:texture',
         title: 'Overwrite textures',
         description: 'When a model is imported, overwrite previously imported texture assets.'
     }, {

--- a/src/editor/inspector/settings-panel.ts
+++ b/src/editor/inspector/settings-panel.ts
@@ -2,7 +2,7 @@ import { Container } from '@playcanvas/pcui';
 
 import { AttributesInspector } from './attributes-inspector.ts';
 import { AISettingsPanel } from './settings-panels/ai.ts';
-import { AssetTasksSettingsPanel } from './settings-panels/asset-tasks.ts';
+import { AssetImportSettingsPanel } from './settings-panels/asset-import.ts';
 import { BatchGroupsSettingsPanel } from './settings-panels/batchgroups.ts';
 import { EditorSettingsPanel } from './settings-panels/editor.ts';
 import { EngineSettingsPanel } from './settings-panels/engine.ts';
@@ -29,7 +29,7 @@ const CLASS_ROOT = 'settings';
 const SETTINGS_PANELS = [
     EngineSettingsPanel,
     EditorSettingsPanel,
-    AssetTasksSettingsPanel,
+    AssetImportSettingsPanel,
     AISettingsPanel,
     PhysicsSettingsPanel,
     RenderingSettingsPanel,

--- a/src/editor/inspector/settings-panels/asset-import.ts
+++ b/src/editor/inspector/settings-panels/asset-import.ts
@@ -6,7 +6,7 @@ import { BaseSettingsPanel } from './base.ts';
  * @import { Attribute } from '../attribute.type.d.ts'
  */
 
-const CLASS_ROOT = 'asset-tasks-settings-panel';
+const CLASS_ROOT = 'asset-import-settings-panel';
 const CLASS_SECTION = `${CLASS_ROOT}-section`;
 const CLASS_ATTRIBUTES = `${CLASS_ROOT}-attributes`;
 
@@ -19,7 +19,7 @@ const ATTRIBUTES = [
         label: 'Search related assets',
         type: 'boolean',
         alias: 'asset-tasks:searchRelatedAssets',
-        reference: 'settings:asset-tasks:searchRelatedAssets',
+        reference: 'settings:asset-import:searchRelatedAssets',
         path: 'editor.pipeline.searchRelatedAssets'
     },
     {
@@ -27,7 +27,7 @@ const ATTRIBUTES = [
         label: 'Assets default to preload',
         type: 'boolean',
         alias: 'asset-tasks:defaultAssetPreload',
-        reference: 'settings:asset-tasks:defaultAssetPreload',
+        reference: 'settings:asset-import:defaultAssetPreload',
         path: 'editor.pipeline.defaultAssetPreload'
     },
     {
@@ -35,7 +35,7 @@ const ATTRIBUTES = [
         label: 'Textures POT',
         type: 'boolean',
         alias: 'asset-tasks:texturePot',
-        reference: 'settings:asset-tasks:texturePot',
+        reference: 'settings:asset-import:texturePot',
         path: 'editor.pipeline.texturePot'
     },
     {
@@ -43,7 +43,7 @@ const ATTRIBUTES = [
         label: 'Create Atlases',
         type: 'boolean',
         alias: 'asset-tasks:textureDefaultToAtlas',
-        reference: 'settings:asset-tasks:textureDefaultToAtlas',
+        reference: 'settings:asset-import:textureDefaultToAtlas',
         path: 'editor.pipeline.textureDefaultToAtlas'
     },
     {
@@ -51,7 +51,7 @@ const ATTRIBUTES = [
         label: 'Preserve material mappings',
         type: 'boolean',
         alias: 'asset-tasks:preserveMapping',
-        reference: 'settings:asset-tasks:preserveMapping',
+        reference: 'settings:asset-import:preserveMapping',
         path: 'editor.pipeline.preserveMapping'
     },
     {
@@ -59,7 +59,7 @@ const ATTRIBUTES = [
         label: 'Overwrite Models',
         type: 'boolean',
         alias: 'asset-tasks:overwrite.model',
-        reference: 'settings:asset-tasks:overwrite:model',
+        reference: 'settings:asset-import:overwrite:model',
         path: 'editor.pipeline.overwriteModel'
     },
     {
@@ -67,7 +67,7 @@ const ATTRIBUTES = [
         label: 'Overwrite Animations',
         type: 'boolean',
         alias: 'asset-tasks:overwrite.animation',
-        reference: 'settings:asset-tasks:overwrite:animation',
+        reference: 'settings:asset-import:overwrite:animation',
         path: 'editor.pipeline.overwriteAnimation'
     },
     {
@@ -75,7 +75,7 @@ const ATTRIBUTES = [
         label: 'Overwrite Materials',
         type: 'boolean',
         alias: 'asset-tasks:overwrite.material',
-        reference: 'settings:asset-tasks:overwrite:material',
+        reference: 'settings:asset-import:overwrite:material',
         path: 'editor.pipeline.overwriteMaterial'
     },
     {
@@ -83,7 +83,7 @@ const ATTRIBUTES = [
         label: 'Overwrite Textures',
         type: 'boolean',
         alias: 'asset-tasks:overwrite.texture',
-        reference: 'settings:asset-tasks:overwrite:texture',
+        reference: 'settings:asset-import:overwrite:texture',
         path: 'editor.pipeline.overwriteTexture'
     },
     {
@@ -91,7 +91,7 @@ const ATTRIBUTES = [
         label: 'Convert to GLB',
         type: 'boolean',
         alias: 'asset-tasks:useGlb',
-        reference: 'settings:asset-tasks:useGlb',
+        reference: 'settings:asset-import:useGlb',
         path: 'editor.pipeline.useGlb'
     },
     {
@@ -99,7 +99,7 @@ const ATTRIBUTES = [
         label: 'Import Hierarchy',
         type: 'boolean',
         alias: 'asset-tasks:useContainers',
-        reference: 'settings:asset-tasks:useContainers',
+        reference: 'settings:asset-import:useContainers',
         path: 'editor.pipeline.useContainers'
     },
     {
@@ -107,7 +107,7 @@ const ATTRIBUTES = [
         label: 'Mesh Compression',
         type: 'select',
         alias: 'asset-tasks:meshCompression',
-        reference: 'settings:asset-tasks:meshCompression',
+        reference: 'settings:asset-import:meshCompression',
         path: 'editor.pipeline.meshCompression',
         args: {
             type: 'string',
@@ -122,7 +122,7 @@ const ATTRIBUTES = [
         label: 'Draco Decode Speed',
         type: 'slider',
         alias: 'asset-tasks:dracoDecodeSpeed',
-        reference: 'settings:asset-tasks:dracoDecodeSpeed',
+        reference: 'settings:asset-import:dracoDecodeSpeed',
         path: 'editor.pipeline.dracoDecodeSpeed',
         args: {
             precision: 1,
@@ -136,7 +136,7 @@ const ATTRIBUTES = [
         label: 'Draco Mesh Size',
         type: 'slider',
         alias: 'asset-tasks:dracoMeshSize',
-        reference: 'settings:asset-tasks:dracoMeshSize',
+        reference: 'settings:asset-import:dracoMeshSize',
         path: 'editor.pipeline.dracoMeshSize',
         args: {
             precision: 1,
@@ -150,7 +150,7 @@ const ATTRIBUTES = [
         label: 'Unwrap Uv',
         type: 'boolean',
         alias: 'asset-tasks:unwrapUv',
-        reference: 'settings:asset-tasks:unwrapUv',
+        reference: 'settings:asset-import:unwrapUv',
         path: 'editor.pipeline.unwrapUv'
     },
     {
@@ -158,7 +158,7 @@ const ATTRIBUTES = [
         label: 'Texels Per Meter',
         type: 'number',
         alias: 'asset-tasks:unwrapUvTexelsPerMeter',
-        reference: 'settings:asset-tasks:unwrapUvTexelsPerMeter',
+        reference: 'settings:asset-import:unwrapUvTexelsPerMeter',
         path: 'editor.pipeline.unwrapUvTexelsPerMeter',
         args: {
             min: 0
@@ -169,7 +169,7 @@ const ATTRIBUTES = [
         label: 'Import Morph Normals',
         type: 'boolean',
         alias: 'asset-tasks:importMorphNormals',
-        reference: 'settings:asset-tasks:importMorphNormals',
+        reference: 'settings:asset-import:importMorphNormals',
         path: 'editor.pipeline.importMorphNormals'
     },
     {
@@ -177,7 +177,7 @@ const ATTRIBUTES = [
         label: 'Create FBX Folder',
         type: 'boolean',
         alias: 'asset-tasks:createFBXFolder',
-        reference: 'settings:asset-tasks:createFBXFolder',
+        reference: 'settings:asset-import:createFBXFolder',
         path: 'editor.pipeline.createFBXFolder'
     },
     {
@@ -192,14 +192,14 @@ const ATTRIBUTES = [
             ]
         },
         alias: 'asset-tasks:animUseFbxFilename',
-        reference: 'settings:asset-tasks:animUseFbxFilename',
+        reference: 'settings:asset-import:animUseFbxFilename',
         path: 'editor.pipeline.animUseFbxFilename'
     },
     {
         observer: 'settings',
         label: 'Sample Rate',
         alias: 'asset-tasks:animSampleRate',
-        reference: 'settings:asset-tasks:animSampleRate',
+        reference: 'settings:asset-import:animSampleRate',
         path: 'editor.pipeline.animSampleRate',
         type: 'select',
         args: {
@@ -225,7 +225,7 @@ const ATTRIBUTES = [
         label: 'Curve Tolerance',
         type: 'number',
         alias: 'asset-tasks:animCurveTolerance',
-        reference: 'settings:asset-tasks:animCurveTolerance',
+        reference: 'settings:asset-import:animCurveTolerance',
         path: 'editor.pipeline.animCurveTolerance'
     },
     {
@@ -233,18 +233,18 @@ const ATTRIBUTES = [
         label: 'Cubic Curves',
         type: 'boolean',
         alias: 'asset-tasks:animEnableCubic',
-        reference: 'settings:asset-tasks:animEnableCubic',
+        reference: 'settings:asset-import:animEnableCubic',
         path: 'editor.pipeline.animEnableCubic'
     }
 ];
 
-class AssetTasksSettingsPanel extends BaseSettingsPanel {
+class AssetImportSettingsPanel extends BaseSettingsPanel {
     constructor(args) {
         args = Object.assign({}, args);
-        args.headerText = 'ASSET TASKS';
+        args.headerText = 'ASSET IMPORT';
         args.attributes = ATTRIBUTES;
         args.userOnlySettings = true;
-        args._tooltipReference = 'settings:asset-tasks';
+        args._tooltipReference = 'settings:asset-import';
 
         super(args);
 
@@ -342,4 +342,4 @@ class AssetTasksSettingsPanel extends BaseSettingsPanel {
     }
 }
 
-export { AssetTasksSettingsPanel };
+export { AssetImportSettingsPanel };


### PR DESCRIPTION
Rather than just update the UI strings, this PR also renames files, class names, CSS, etc. The only thing left that references `asset-tasks` is the `alias` property used to access the settings observer which is obviously harder to change.

Tooltip descriptions for asset import are also improved.

Fixes #1379 

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
