### PR TITLE
Enhance tooltips and attribute warnings in inspector

### DIFF
--- a/sass/editor/_editor-asset-script-inspector.scss
+++ b/sass/editor/_editor-asset-script-inspector.scss
@@ -43,3 +43,50 @@
 .script-asset-inspector-attribute:hover {
     background-color: #313e41;
 }
+
+.script-asset-inspector-warning {
+    color: $status-warn;
+}
+
+.script-asset-inspector-attribute-warning {
+    color: $status-warn;
+    
+    &::before {
+        @extend .font-icon;
+
+        content: '\E218';
+        margin-right: 6px;
+    }
+}
+
+.script-asset-inspector-attribute-warning.clickable-warning {
+    cursor: pointer;
+    
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.script-asset-inspector-attribute-error {
+    &::before {
+        @extend .font-icon;
+
+        content: '\E368';
+        margin-right: 6px;
+    }
+}
+
+// Tooltip warnings styling
+.warnings-title.script-asset-inspector-warning {
+    // Normal text color for the header
+}
+
+.warning-item.script-asset-inspector-warning {
+    color: var(--pcui-warning-color);
+    font-size: 11px;
+}
+
+.open-console {
+    text-decoration: underline;
+    cursor: pointer;
+}

--- a/src/common/tooltips.ts
+++ b/src/common/tooltips.ts
@@ -72,6 +72,20 @@ export const tooltipRefItem = ({
         hidden: !reference.code
     }));
 
+    // Optional warnings section (if provided by caller)
+    if (Array.isArray((reference as any).warnings) && (reference as any).warnings.length > 0) {
+        item.append(new Label({
+            class: ['warnings-title', 'script-asset-inspector-warning'],
+            text: 'Warnings'
+        }));
+        (reference as any).warnings.forEach((warningText: string) => {
+            item.append(new Label({
+                class: ['warning-item', 'script-asset-inspector-warning'],
+                text: warningText
+            }));
+        });
+    }
+
     const btnUrl = new Button({
         class: 'api',
         text: 'API REFERENCE',

--- a/src/editor/inspector/attributes-inspector.ts
+++ b/src/editor/inspector/attributes-inspector.ts
@@ -333,6 +333,10 @@ class AttributesInspector extends Container {
                         tooltipData = attr.tooltip;
                     }
 
+                    // If attribute has warnings, add yellow styling with icon
+                    if (attr.warning) {
+                        labelGroup.class.add('script-asset-inspector-attribute-warning');
+                    }
                     tooltipGroup = this._createTooltipGroup(labelGroup, tooltipData);
                 } else {
                     this.append(field);
@@ -342,6 +346,9 @@ class AttributesInspector extends Container {
                 }
             } else if (attr.type === 'asset') {
                 field.text = attr.label;
+                if (attr.warning) {
+                    field.class.add('script-asset-inspector-attribute-warning');
+                }
                 this.append(field);
                 if (index >= 0) {
                     this.move(field, index);
@@ -360,6 +367,10 @@ class AttributesInspector extends Container {
                     collapsible: true,
                     flex: true
                 });
+
+                if (attr.warning && panel.header) {
+                    panel.header.class.add('script-asset-inspector-attribute-warning');
+                }
 
                 panel.append(field);
 

--- a/src/workers/esm-script.worker.ts
+++ b/src/workers/esm-script.worker.ts
@@ -14,6 +14,7 @@ const PLAYCANVAS_ATTRIBUTE_DOCS_URL = {
 /**
  * @typedef {Object} SerializableParsingError
  * @property {string} message - The error message
+ * @property {string} attributeName - The name of the attribute that caused the error
  * @property {string} file - The source file
  * @property {string} type - The category of the error
  * @property {string} name - The name of the error
@@ -91,7 +92,8 @@ workerServer.once('init', async (frontendURL) => {
                 const script = attributes[key];
                 const attributesOrder = Object.keys(script.attributes);
                 acc[key] = {
-                    attributesInvalid: [],
+                    attributesInvalid: script.errors.map(toSerializableError),
+                    attributesInvalid: script.errors.map(toSerializableError).filter(Boolean),
                     attributesOrder,
                     attributes: script.attributes
                 };


### PR DESCRIPTION
This PR replicates the functionality of https://github.com/playcanvas/editor/pull/1361 of the script inspector and uses it in the script component inspector 

* Added optional warnings section to tooltips for better user feedback.
* Implemented warning styling for attributes in the inspector to highlight potential issues.
