### PR TITLE
Add Code Editor Start Event

### DIFF
--- a/src/code-editor/editor.ts
+++ b/src/code-editor/editor.ts
@@ -13,6 +13,8 @@ class CodeEditor extends Editor {
         this.once('loaded', () => {
             this.emit('start');
 
+            window.opener?.postMessage('start');
+
             // if there is a merge in progress for our branch
             if (config.self.branch.merge && !config.self.branch.merge.conflict) {
                 this.call('picker:versioncontrol:mergeOverlay');

--- a/src/code-editor/editor.ts
+++ b/src/code-editor/editor.ts
@@ -13,7 +13,9 @@ class CodeEditor extends Editor {
         this.once('loaded', () => {
             this.emit('start');
 
-            window.opener?.postMessage('start');
+            // Send and event to the opener
+            const openerOrigin = new URL(document.referrer).origin;
+            window.opener.postMessage('start', openerOrigin);
 
             // if there is a merge in progress for our branch
             if (config.self.branch.merge && !config.self.branch.merge.conflict) {

--- a/src/code-editor/editor.ts
+++ b/src/code-editor/editor.ts
@@ -13,7 +13,7 @@ class CodeEditor extends Editor {
         this.once('loaded', () => {
             this.emit('start');
 
-            // Send and event to the opener
+            // Send an event to the opener
             const openerOrigin = new URL(document.referrer).origin;
             window.opener.postMessage('start', openerOrigin);
 


### PR DESCRIPTION
When opening the code editor from the editor, it would be handy to have an event indicating the code editor is ready.  

This would make it unnecessary to [poll the opened for ready state](https://github.com/playcanvas/editor/pull/1361/files/e155950baeda5cee1bb2d8c96a7ff104a3873b35#diff-6ebead14a23a9398e8394b6387373192492cdc96f0634d2764f4789d97eeb0c3R60-R72)

