### PR TITLE
Support SOG

### DIFF
--- a/src/editor/assets/assets-upload.ts
+++ b/src/editor/assets/assets-upload.ts
@@ -28,7 +28,8 @@ editor.once('load', () => {
         'mjs': true,
         'atlas': true,
         'ply': true,
-        'wasm': true
+        'wasm': true,
+        'sog': true
     };
 
     const typeToExt = {
@@ -42,7 +43,7 @@ editor.once('load', () => {
         'shader': ['glsl', 'frag', 'vert'],
         'script': ['js', 'mjs'],
         'font': ['ttf', 'ttc', 'otf', 'dfont'],
-        'gsplat': ['ply'],
+        'gsplat': ['ply', 'sog'],
         'wasm': ['wasm']
     };
 

--- a/src/editor/inspector/assets/gsplat.ts
+++ b/src/editor/inspector/assets/gsplat.ts
@@ -17,7 +17,7 @@ const META_ATTRIBUTES: Attribute[] = [{
 }, {
     label: 'SH Bands',
     alias: 'bands',
-    path:'meta.bands',
+    path: 'meta.bands',
     type: 'label',
 }, {
     label: 'Bound Min',

--- a/src/editor/inspector/assets/gsplat.ts
+++ b/src/editor/inspector/assets/gsplat.ts
@@ -18,7 +18,7 @@ const META_ATTRIBUTES: Attribute[] = [{
     label: 'SH Bands',
     alias: 'bands',
     path: 'meta.bands',
-    type: 'label',
+    type: 'label'
 }, {
     label: 'Bound Min',
     alias: 'bounds.min',
@@ -62,7 +62,7 @@ class GSplatAssetInspector extends Container {
         this.unlink();
         this._metaAttributesInspector.link(assets);
 
-        ['meta.bounds.min', 'meta.bounds.max'].forEach(path => {
+        ['meta.bounds.min', 'meta.bounds.max'].forEach((path) => {
             this._metaAttributesInspector.getField(path).enabled = false;
         });
     }

--- a/src/editor/inspector/assets/gsplat.ts
+++ b/src/editor/inspector/assets/gsplat.ts
@@ -12,13 +12,23 @@ const META_ATTRIBUTES: Attribute[] = [{
 }, {
     label: 'Splats',
     alias: 'splats',
-    path: 'meta.elements.vertex.count',
+    path: 'meta.count',
     type: 'label'
 }, {
-    label: 'Properties',
-    alias: 'properties',
-    path: 'meta.properties',
-    type: 'label'
+    label: 'SH Bands',
+    alias: 'bands',
+    path:'meta.bands',
+    type: 'label',
+}, {
+    label: 'Bound Min',
+    alias: 'bounds.min',
+    path: 'meta.bounds.min',
+    type: 'vec3'
+}, {
+    label: 'Bound Max',
+    alias: 'bounds.max',
+    path: 'meta.bounds.max',
+    type: 'vec3'
 }];
 
 const DOM = parent => [
@@ -52,17 +62,9 @@ class GSplatAssetInspector extends Container {
         this.unlink();
         this._metaAttributesInspector.link(assets);
 
-        const props = {};
-        assets.forEach((asset) => {
-            const properties = asset.get('meta.elements.vertex.properties');
-            if (properties) {
-                Object.assign(props, properties);
-            }
+        ['meta.bounds.min', 'meta.bounds.max'].forEach(path => {
+            this._metaAttributesInspector.getField(path).enabled = false;
         });
-
-        const text = Object.keys(props).join(', ');
-        const field = this._metaAttributesInspector.getField('meta.properties');
-        field.values = assets.map(asset => text);
     }
 
     unlink() {

--- a/src/editor/viewport/viewport-drop-gsplat.ts
+++ b/src/editor/viewport/viewport-drop-gsplat.ts
@@ -91,7 +91,7 @@ editor.once('load', () => {
             for (let i = 0; i < assets.length; i++) {
                 const assetEngine = app.assets.get(assets[i].get('id'));
                 if (assetEngine?.resource) {
-                    assetEngine.resource.splatData.calcAabb(gsplatAabb);
+                    assetEngine.resource.gsplatData.calcAabb(gsplatAabb);
                     if (first) {
                         first = false;
                         aabb.copy(gsplatAabb);
@@ -145,6 +145,7 @@ editor.once('load', () => {
                     parent: parent,
                     name: name,
                     position: [vecC.x, vecC.y, vecC.z],
+                    rotation: [0, 0, 180],
                     components: {
                         gsplat: component
                     }


### PR DESCRIPTION
This PR:
- adds support for .sog file assets
- updates the asset inspector to the latest format
- automatically rotates the entity by (0, 0, 180) since this is the default orientation
- fixes a bug where bounds are incorrectly calculated with latest engine

## Notes
- .sog support was added in engine v2.11.0