### PR TITLE
Gizmos settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "monaco-themes": "^0.4.2",
         "nodemon": "3.1.7",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "^2.11.3",
+        "playcanvas": "^2.11.4",
         "postcss": "8.4.48",
         "rollup": "4.25.0",
         "rollup-plugin-copy": "3.5.0",
@@ -6110,9 +6110,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.11.3.tgz",
-      "integrity": "sha512-iWhbtWGbTtBxqqvNXNA6VwlxUNG7NX8dqbt9cqhIYW5icrtsZsdBaR7R+Qpnbgfn8aWxUStpXbwTKzfLCBK0KQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.11.4.tgz",
+      "integrity": "sha512-GoPr4JiLflMQ98BYtxQUGb/Xf5iRnVLaUKWmRxoaY1GGcb5HMwqNfQEjUusfA0lNfMEBJdSuPMjSHltwp5+50Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "monaco-themes": "^0.4.2",
     "nodemon": "3.1.7",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "^2.11.3",
+    "playcanvas": "^2.11.4",
     "postcss": "8.4.48",
     "rollup": "4.25.0",
     "rollup-plugin-copy": "3.5.0",

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -47,7 +47,7 @@ editor.once('load', () => {
         description: 'Set the gizmo size in the editor viewport.'
     }, {
         name: 'settings:gizmoPreset',
-        description: 'Set the gizmo preset in the editor viewport. This affects the transform gizmos\'s color, size, features and interaction behavior.'
+        description: 'Set the gizmo preset in the editor viewport. This affects the transform gizmos\'s style and interaction behavior.'
     }, {
         name: 'settings:showFog',
         description: 'Enable fog rendering in the viewport.'

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -43,6 +43,12 @@ editor.once('load', () => {
         name: 'settings:cameraGammaCorrection',
         description: 'Set the editor camera gamma correction. This setting does not affect the game.'
     }, {
+        name: 'settings:gizmoSize',
+        description: 'Set the gizmo size in the editor viewport.'
+    }, {
+        name: 'settings:gizmoPreset',
+        description: 'Set the gizmo preset in the editor viewport. This affects the transform gizmos\'s color, size, features and interaction behavior.'
+    }, {
         name: 'settings:showFog',
         description: 'Enable fog rendering in the viewport.'
     }, {

--- a/src/editor/inspector/settings-panels/editor.ts
+++ b/src/editor/inspector/settings-panels/editor.ts
@@ -169,12 +169,12 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
             type: 'string',
             options: [
                 {
-                    v: 'classic',
-                    t: 'Classic'
-                },
-                {
                     v: 'default',
                     t: 'Default'
+                },
+                {
+                    v: 'classic',
+                    t: 'Classic'
                 }
             ]
         }

--- a/src/editor/inspector/settings-panels/editor.ts
+++ b/src/editor/inspector/settings-panels/editor.ts
@@ -180,26 +180,6 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
         }
     },
     {
-        observer: 'settings',
-        label: 'Gizmo Rotation Mode',
-        path: 'editor.gizmoRotationMode',
-        reference: 'settings:gizmoRotationMode',
-        type: 'select',
-        args: {
-            type: 'string',
-            options: [
-                {
-                    v: 'orbit',
-                    t: 'Orbit'
-                },
-                {
-                    v: 'absolute',
-                    t: 'Absolute'
-                }
-            ]
-        }
-    },
-    {
         alias: 'divider:2',
         type: 'divider'
     },

--- a/src/editor/inspector/settings-panels/editor.ts
+++ b/src/editor/inspector/settings-panels/editor.ts
@@ -149,6 +149,62 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
     },
     {
         observer: 'settings',
+        label: 'Gizmo Size',
+        type: 'slider',
+        reference: 'settings:gizmoSize',
+        path: 'editor.gizmoSize',
+        args: {
+            min: 0.1,
+            max: 5,
+            step: 0.1
+        }
+    },
+    {
+        observer: 'settings',
+        label: 'Gizmo Preset',
+        path: 'editor.gizmoPreset',
+        reference: 'settings:gizmoPreset',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                {
+                    v: 'classic',
+                    t: 'Classic'
+                },
+                {
+                    v: 'default',
+                    t: 'Default'
+                }
+            ]
+        }
+    },
+    {
+        observer: 'settings',
+        label: 'Gizmo Rotation Mode',
+        path: 'editor.gizmoRotationMode',
+        reference: 'settings:gizmoRotationMode',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                {
+                    v: 'orbit',
+                    t: 'Orbit'
+                },
+                {
+                    v: 'absolute',
+                    t: 'Absolute'
+                }
+            ]
+        }
+    },
+    {
+        alias: 'divider:2',
+        type: 'divider'
+    },
+    {
+        observer: 'settings',
         label: 'Show Fog',
         path: 'editor.showFog',
         alias: 'showFog',

--- a/src/editor/viewport/gizmo/gizmo-transform.ts
+++ b/src/editor/viewport/gizmo/gizmo-transform.ts
@@ -9,7 +9,45 @@ import {
     type Layer
 } from 'playcanvas';
 
-const GIZMO_SIZE = 1.2;
+import { Defer } from '../../../common/defer.ts';
+
+type GizmoNodeTransform = {
+    position: number[];
+    rotation: number[];
+    scale: number[];
+};
+
+type GizmoAxis = Parameters<TransformGizmo['enableShape']>[0];
+type GizmoTheme = TransformGizmo['theme'];
+type GizmoDragMode = TransformGizmo['dragMode'];
+
+type GizmoPreset = {
+    translate: {
+        theme: GizmoTheme;
+        flipAxes: boolean;
+        dragMode: GizmoDragMode;
+        axisLineThickness: number;
+        axisPlaneGap: number;
+        disableShapes: GizmoAxis[];
+    };
+    rotate: {
+        theme: GizmoTheme;
+        dragMode: GizmoDragMode
+        faceTubeRadius: number;
+        xyzTubeRadius: number;
+        angleGuideThickness: number;
+        disableShapes: GizmoAxis[];
+    };
+    scale: {
+        theme: GizmoTheme;
+        flipAxes: boolean;
+        dragMode: GizmoDragMode;
+        axisLineThickness: number;
+        disableShapes: GizmoAxis[];
+    };
+}
+
+const GIZMO_AXES = ['x', 'y', 'z', 'xy', 'xz', 'yz', 'xyz', 'f'] as GizmoAxis[];
 const GIZMO_ANGLE_MULT = 5;
 
 let translate: TranslateGizmo | null = null;
@@ -18,11 +56,84 @@ let scale: ScaleGizmo | null = null;
 
 let write: boolean = false;
 
-type GizmoNodeTransform = {
-    position: number[];
-    rotation: number[];
-    scale: number[];
+const loaded = new Defer<void>();
+
+const CLASSIC_THEME: GizmoTheme = {
+    shapeBase: {
+        x: pc.Color.RED,
+        y: pc.Color.GREEN,
+        z: pc.Color.BLUE,
+        xyz: pc.Color.WHITE,
+        f: pc.Color.YELLOW
+    },
+    shapeHover: {
+        x: pc.Color.WHITE,
+        y: pc.Color.WHITE,
+        z: pc.Color.WHITE,
+        xyz: pc.Color.WHITE,
+        f: pc.Color.WHITE
+    },
+    guideBase: {
+        x: pc.Color.WHITE,
+        y: pc.Color.WHITE,
+        z: pc.Color.WHITE,
+        f: pc.Color.WHITE
+    },
+    guideOcclusion: 0.9,
+    disabled: new pc.Color(0, 0, 0, 0)
 };
+const CLASSIC_PRESET: GizmoPreset = {
+    translate: {
+        theme: CLASSIC_THEME,
+        flipAxes: false,
+        dragMode: 'hide',
+        axisLineThickness: 0.01,
+        axisPlaneGap: 0,
+        disableShapes: ['xyz'] // TODO: hide center sphere for now
+    },
+    rotate: {
+        theme: CLASSIC_THEME,
+        dragMode: 'selected',
+        faceTubeRadius: 0.0075,
+        xyzTubeRadius: 0.0075,
+        angleGuideThickness: 0.015,
+        disableShapes: ['xyz'] // TODO: hide ball rotation for now
+    },
+    scale: {
+        theme: CLASSIC_THEME,
+        flipAxes: false,
+        dragMode: 'hide',
+        axisLineThickness: 0.01,
+        disableShapes: ['xy', 'xz', 'yz'] // TODO: disable planes as scaling unintuitive right now
+    }
+};
+const presets = new Map<string, GizmoPreset>();
+presets.set('classic', CLASSIC_PRESET);
+
+const cloneTheme = (theme: GizmoTheme): GizmoTheme => ({
+    shapeBase: {
+        x: theme.shapeBase.x.clone(),
+        y: theme.shapeBase.y.clone(),
+        z: theme.shapeBase.z.clone(),
+        xyz: theme.shapeBase.xyz.clone(),
+        f: theme.shapeBase.f.clone()
+    },
+    shapeHover: {
+        x: theme.shapeHover.x.clone(),
+        y: theme.shapeHover.y.clone(),
+        z: theme.shapeHover.z.clone(),
+        xyz: theme.shapeHover.xyz.clone(),
+        f: theme.shapeHover.f.clone()
+    },
+    guideBase: {
+        x: theme.guideBase.x.clone(),
+        y: theme.guideBase.y.clone(),
+        z: theme.guideBase.z.clone(),
+        f: theme.guideBase.f.clone()
+    },
+    guideOcclusion: theme.guideOcclusion,
+    disabled: theme.disabled.clone()
+});
 
 const selection = (): EntityObserver[] => {
     const type = editor.call('selector:type');
@@ -32,80 +143,25 @@ const selection = (): EntityObserver[] => {
     return editor.call('selector:items');
 };
 
-const getTRS = (item: EntityObserver): GizmoNodeTransform => {
-    const position: number[] = item.entity.getLocalPosition().toArray();
-    const rotation: number[] = item.entity.getLocalEulerAngles().toArray();
-    const scale: number[] = item.entity.getLocalScale().toArray();
-    item.set('position', position);
-    item.set('rotation', rotation);
-    item.set('scale', scale);
+const getTRS = (observer: EntityObserver): GizmoNodeTransform => {
+    const position: number[] = observer.entity.getLocalPosition().toArray();
+    const rotation: number[] = observer.entity.getLocalEulerAngles().toArray();
+    const scale: number[] = observer.entity.getLocalScale().toArray();
+    observer.set('position', position);
+    observer.set('rotation', rotation);
+    observer.set('scale', scale);
     return { position, rotation, scale };
 };
-const setTRS = (item: EntityObserver, trs: GizmoNodeTransform, history: boolean = true) => {
-    const historyEnabled = item.history.enabled;
-    item.history.enabled = history;
-    item.set('position', trs.position);
-    item.set('rotation', trs.rotation);
-    item.set('scale', trs.scale);
-    item.history.enabled = historyEnabled;
+const setTRS = (observer: EntityObserver, trs: GizmoNodeTransform, history: boolean = true) => {
+    const historyEnabled = observer.history.enabled;
+    observer.history.enabled = history;
+    observer.set('position', trs.position);
+    observer.set('rotation', trs.rotation);
+    observer.set('scale', trs.scale);
+    observer.history.enabled = historyEnabled;
 };
 
 const initGizmo = <T extends TransformGizmo>(gizmo: T) => {
-    // general settings
-    gizmo.size = GIZMO_SIZE;
-    gizmo.setTheme({
-        shapeBase: {
-            x: pc.Color.RED,
-            y: pc.Color.GREEN,
-            z: pc.Color.BLUE,
-            xyz: pc.Color.WHITE,
-            f: pc.Color.YELLOW
-        },
-        shapeHover: {
-            x: pc.Color.WHITE,
-            y: pc.Color.WHITE,
-            z: pc.Color.WHITE,
-            xyz: pc.Color.WHITE,
-            f: pc.Color.WHITE
-        },
-        guideBase: {
-            x: pc.Color.WHITE,
-            y: pc.Color.WHITE,
-            z: pc.Color.WHITE,
-            f: pc.Color.WHITE
-        },
-        guideOcclusion: 0.9,
-        disabled: new pc.Color(0, 0, 0, 0)
-    });
-
-    // gizmo specific settings
-    if (gizmo instanceof pc.TranslateGizmo) {
-        gizmo.flipAxes = false;
-        gizmo.dragMode = 'hide';
-        gizmo.axisLineThickness = 0.01;
-        gizmo.axisPlaneGap = 0;
-
-        gizmo.enableShape('xyz', false); // TODO: hide center sphere for now
-    }
-    if (gizmo instanceof pc.RotateGizmo) {
-        gizmo.dragMode = 'selected';
-        gizmo.orbitRotation = true;
-        gizmo.faceTubeRadius = 0.0075;
-        gizmo.xyzTubeRadius = 0.0075;
-        gizmo.angleGuideThickness = 0.015;
-
-        gizmo.enableShape('xyz', false); // TODO: hide ball rotation for now
-    }
-    if (gizmo instanceof pc.ScaleGizmo) {
-        gizmo.flipAxes = false;
-        gizmo.dragMode = 'hide';
-        gizmo.axisLineThickness = 0.01;
-
-        gizmo.enableShape('xy', false); // TODO: disable planes as scaling unintuitive right now
-        gizmo.enableShape('xz', false); // TODO: disable planes as scaling unintuitive right now
-        gizmo.enableShape('yz', false); // TODO: disable planes as scaling unintuitive right now
-    }
-
     // call viewport render when gizmo fires update
     gizmo.on(pc.Gizmo.EVENT_RENDERUPDATE, () => {
         editor.call('viewport:render');
@@ -124,38 +180,38 @@ const initGizmo = <T extends TransformGizmo>(gizmo: T) => {
     // track history
     const cache: GizmoNodeTransform[] = [];
     gizmo.on(pc.TransformGizmo.EVENT_TRANSFORMSTART, () => {
-        const items = selection();
-        if (!items.length) {
+        const observers = selection();
+        if (!observers.length) {
             return;
         }
-        for (let i = 0; i < items.length; i++) {
-            cache[i] = getTRS(items[i]);
-            items[i].history.enabled = false;
+        for (let i = 0; i < observers.length; i++) {
+            cache[i] = getTRS(observers[i]);
+            observers[i].history.enabled = false;
         }
 
         editor.call('camera:toggle', false);
         editor.call('viewport:pick:state', false);
     });
     gizmo.on(pc.TransformGizmo.EVENT_TRANSFORMMOVE, () => {
-        const items = selection();
-        if (!items.length) {
+        const observers = selection();
+        if (!observers.length) {
             return;
         }
-        for (let i = 0; i < items.length; i++) {
-            getTRS(items[i]);
+        for (let i = 0; i < observers.length; i++) {
+            getTRS(observers[i]);
         }
     });
     gizmo.on(pc.TransformGizmo.EVENT_TRANSFORMEND, () => {
-        const items = selection();
-        if (!items.length) {
+        const observers = selection();
+        if (!observers.length) {
             return;
         }
 
         // record discrete action
         const action: [GizmoNodeTransform, GizmoNodeTransform][] = [];
-        for (let i = 0; i < items.length; i++) {
-            action.push([cache[i], getTRS(items[i])]);
-            items[i].history.enabled = true;
+        for (let i = 0; i < observers.length; i++) {
+            action.push([cache[i], getTRS(observers[i])]);
+            observers[i].history.enabled = true;
         }
         cache.length = 0;
 
@@ -164,13 +220,13 @@ const initGizmo = <T extends TransformGizmo>(gizmo: T) => {
             name: 'entities.translate',
             combine: false,
             undo: () => {
-                for (let i = 0; i < items.length; i++) {
-                    setTRS(items[i].latest() as EntityObserver, action[i][0], false);
+                for (let i = 0; i < observers.length; i++) {
+                    setTRS(observers[i].latest() as EntityObserver, action[i][0], false);
                 }
             },
             redo: () => {
-                for (let i = 0; i < items.length; i++) {
-                    setTRS(items[i].latest() as EntityObserver, action[i][1], false);
+                for (let i = 0; i < observers.length; i++) {
+                    setTRS(observers[i].latest() as EntityObserver, action[i][1], false);
                 }
             }
         });
@@ -190,23 +246,51 @@ editor.on('scene:load', () => {
     const camera: Entity = editor.call('camera:current');
     const layer: Layer = editor.call('gizmo:layers', 'Axis Gizmo Immediate');
 
-    translate = initGizmo(new pc.TranslateGizmo(camera.camera, layer));
-    rotate = initGizmo(new pc.RotateGizmo(camera.camera, layer));
-    scale = initGizmo(new pc.ScaleGizmo(camera.camera, layer));
+    if (!translate) {
+        translate = initGizmo(new pc.TranslateGizmo(camera.camera, layer));
+    }
+    if (!rotate) {
+        rotate = initGizmo(new pc.RotateGizmo(camera.camera, layer));
+    }
+    if (!scale) {
+        scale = initGizmo(new pc.ScaleGizmo(camera.camera, layer));
+    }
+
+    // save default preset if not already set
+    if (!presets.has('default')) {
+        presets.set('default', {
+            translate: {
+                theme: cloneTheme(translate.theme),
+                flipAxes: translate.flipAxes,
+                dragMode: translate.dragMode,
+                axisLineThickness: translate.axisLineThickness,
+                axisPlaneGap: translate.axisPlaneGap,
+                disableShapes: GIZMO_AXES.filter(axis => !translate.isShapeEnabled(axis))
+            },
+            rotate: {
+                theme: cloneTheme(rotate.theme),
+                dragMode: rotate.dragMode,
+                faceTubeRadius: rotate.faceTubeRadius,
+                xyzTubeRadius: rotate.xyzTubeRadius,
+                angleGuideThickness: rotate.angleGuideThickness,
+                disableShapes: GIZMO_AXES.filter(axis => !rotate.isShapeEnabled(axis))
+            },
+            scale: {
+                theme: cloneTheme(scale.theme),
+                flipAxes: scale.flipAxes,
+                dragMode: scale.dragMode,
+                axisLineThickness: scale.axisLineThickness,
+                disableShapes: GIZMO_AXES.filter(axis => !scale.isShapeEnabled(axis))
+            }
+        });
+    }
+
+    loaded.resolve();
 });
 editor.on('scene:unload', () => {
-    if (translate) {
-        translate.destroy();
-        translate = null;
-    }
-    if (rotate) {
-        rotate.destroy();
-        rotate = null;
-    }
-    if (scale) {
-        scale.destroy();
-        scale = null;
-    }
+    translate.detach();
+    rotate.detach();
+    scale.detach();
 });
 
 editor.on('permissions:writeState', (state) => {
@@ -251,33 +335,34 @@ const reflow = () => {
     }
 
     // skip if not selecting entities (can be assets)
-    const selectorType: string = editor.call('selector:type');
-    if (selectorType !== 'entity') {
+    const observers = selection();
+    if (!observers.length) {
         translate.detach();
         rotate.detach();
         scale.detach();
         return;
     }
 
+    // set gizmo based on type
     const gizmoType: string = editor.call('gizmo:type');
-    const items = editor.call('selector:items').map(item => item.entity);
+    const nodes = observers.map(observer => observer.entity);
     switch (gizmoType) {
         case 'translate': {
-            translate.attach(items);
+            translate.attach(nodes);
             rotate.detach();
             scale.detach();
             break;
         }
         case 'rotate': {
             translate.detach();
-            rotate.attach(items);
+            rotate.attach(nodes);
             scale.detach();
             break;
         }
         case 'scale': {
             translate.detach();
             rotate.detach();
-            scale.attach(items);
+            scale.attach(nodes);
             break;
         }
         default: {
@@ -304,3 +389,67 @@ const enable = (state: boolean = true) => {
     scale.enabled = enabled;
 };
 editor.on('gizmo:transform:visible', enable);
+
+editor.once('settings:projectUser:load', async () => {
+    // ensure gizmos loaded
+    await loaded.promise;
+
+    const settings = editor.call('settings:projectUser');
+    const bind = (path: string, callback: (value: any) => void) => {
+        settings.on(`${path}:set`, callback);
+        settings.emit(`${path}:set`, settings.get(path));
+    };
+
+    // gizmo size
+    bind('editor.gizmoSize', (value: number) => {
+        translate.size = value;
+        rotate.size = value;
+        scale.size = value;
+
+        editor.call('viewport:render');
+    });
+
+    // gizmo preset
+    bind('editor.gizmoPreset', (value: 'classic' | 'default') => {
+        const preset = presets.get(value);
+        if (!preset) {
+            return;
+        }
+
+        const setShapes = (gizmo: TransformGizmo, disabled: GizmoAxis[]) => {
+            GIZMO_AXES.forEach((axis) => {
+                gizmo.enableShape(axis, !disabled.includes(axis));
+            });
+        };
+
+        // translate
+        translate.setTheme(preset.translate.theme);
+        translate.flipAxes = preset.translate.flipAxes;
+        translate.dragMode = preset.translate.dragMode;
+        translate.axisLineThickness = preset.translate.axisLineThickness;
+        translate.axisPlaneGap = preset.translate.axisPlaneGap;
+        setShapes(translate, preset.translate.disableShapes);
+
+        // rotate
+        rotate.setTheme(preset.rotate.theme);
+        rotate.dragMode = preset.rotate.dragMode;
+        rotate.faceTubeRadius = preset.rotate.faceTubeRadius;
+        rotate.xyzTubeRadius = preset.rotate.xyzTubeRadius;
+        rotate.angleGuideThickness = preset.rotate.angleGuideThickness;
+        setShapes(rotate, preset.rotate.disableShapes);
+
+        // scale
+        scale.setTheme(preset.scale.theme);
+        scale.flipAxes = preset.scale.flipAxes;
+        scale.dragMode = preset.scale.dragMode;
+        scale.axisLineThickness = preset.scale.axisLineThickness;
+        setShapes(scale, preset.scale.disableShapes);
+
+        editor.call('viewport:render');
+    });
+
+    // gizmo rotation mode
+    bind('editor.gizmoRotationMode', (value: 'orbit' | 'absolute') => {
+        rotate.orbitRotation = value === 'orbit';
+    });
+});

--- a/src/editor/viewport/gizmo/gizmo-transform.ts
+++ b/src/editor/viewport/gizmo/gizmo-transform.ts
@@ -24,15 +24,16 @@ type GizmoDragMode = TransformGizmo['dragMode'];
 type GizmoPreset = {
     translate: {
         theme: GizmoTheme;
-        flipAxes: boolean;
         dragMode: GizmoDragMode;
+        flipAxes: boolean;
         axisLineThickness: number;
         axisPlaneGap: number;
         disableShapes: GizmoAxis[];
     };
     rotate: {
         theme: GizmoTheme;
-        dragMode: GizmoDragMode
+        dragMode: GizmoDragMode;
+        orbitRotation: boolean;
         faceTubeRadius: number;
         xyzTubeRadius: number;
         angleGuideThickness: number;
@@ -40,8 +41,8 @@ type GizmoPreset = {
     };
     scale: {
         theme: GizmoTheme;
-        flipAxes: boolean;
         dragMode: GizmoDragMode;
+        flipAxes: boolean;
         axisLineThickness: number;
         disableShapes: GizmoAxis[];
     };
@@ -85,8 +86,8 @@ const CLASSIC_THEME: GizmoTheme = {
 const CLASSIC_PRESET: GizmoPreset = {
     translate: {
         theme: CLASSIC_THEME,
-        flipAxes: false,
         dragMode: 'hide',
+        flipAxes: false,
         axisLineThickness: 0.01,
         axisPlaneGap: 0,
         disableShapes: ['xyz'] // TODO: hide center sphere for now
@@ -94,6 +95,7 @@ const CLASSIC_PRESET: GizmoPreset = {
     rotate: {
         theme: CLASSIC_THEME,
         dragMode: 'selected',
+        orbitRotation: true,
         faceTubeRadius: 0.0075,
         xyzTubeRadius: 0.0075,
         angleGuideThickness: 0.015,
@@ -101,8 +103,8 @@ const CLASSIC_PRESET: GizmoPreset = {
     },
     scale: {
         theme: CLASSIC_THEME,
-        flipAxes: false,
         dragMode: 'hide',
+        flipAxes: false,
         axisLineThickness: 0.01,
         disableShapes: ['xy', 'xz', 'yz'] // TODO: disable planes as scaling unintuitive right now
     }
@@ -261,8 +263,8 @@ editor.on('scene:load', () => {
         presets.set('default', {
             translate: {
                 theme: cloneTheme(translate.theme),
-                flipAxes: translate.flipAxes,
                 dragMode: translate.dragMode,
+                flipAxes: translate.flipAxes,
                 axisLineThickness: translate.axisLineThickness,
                 axisPlaneGap: translate.axisPlaneGap,
                 disableShapes: GIZMO_AXES.filter(axis => !translate.isShapeEnabled(axis))
@@ -270,6 +272,7 @@ editor.on('scene:load', () => {
             rotate: {
                 theme: cloneTheme(rotate.theme),
                 dragMode: rotate.dragMode,
+                orbitRotation: rotate.orbitRotation,
                 faceTubeRadius: rotate.faceTubeRadius,
                 xyzTubeRadius: rotate.xyzTubeRadius,
                 angleGuideThickness: rotate.angleGuideThickness,
@@ -277,8 +280,8 @@ editor.on('scene:load', () => {
             },
             scale: {
                 theme: cloneTheme(scale.theme),
-                flipAxes: scale.flipAxes,
                 dragMode: scale.dragMode,
+                flipAxes: scale.flipAxes,
                 axisLineThickness: scale.axisLineThickness,
                 disableShapes: GIZMO_AXES.filter(axis => !scale.isShapeEnabled(axis))
             }
@@ -424,8 +427,8 @@ editor.once('settings:projectUser:load', async () => {
 
         // translate
         translate.setTheme(preset.translate.theme);
-        translate.flipAxes = preset.translate.flipAxes;
         translate.dragMode = preset.translate.dragMode;
+        translate.flipAxes = preset.translate.flipAxes;
         translate.axisLineThickness = preset.translate.axisLineThickness;
         translate.axisPlaneGap = preset.translate.axisPlaneGap;
         setShapes(translate, preset.translate.disableShapes);
@@ -433,6 +436,7 @@ editor.once('settings:projectUser:load', async () => {
         // rotate
         rotate.setTheme(preset.rotate.theme);
         rotate.dragMode = preset.rotate.dragMode;
+        rotate.orbitRotation = preset.rotate.orbitRotation;
         rotate.faceTubeRadius = preset.rotate.faceTubeRadius;
         rotate.xyzTubeRadius = preset.rotate.xyzTubeRadius;
         rotate.angleGuideThickness = preset.rotate.angleGuideThickness;
@@ -440,16 +444,11 @@ editor.once('settings:projectUser:load', async () => {
 
         // scale
         scale.setTheme(preset.scale.theme);
-        scale.flipAxes = preset.scale.flipAxes;
         scale.dragMode = preset.scale.dragMode;
+        scale.flipAxes = preset.scale.flipAxes;
         scale.axisLineThickness = preset.scale.axisLineThickness;
         setShapes(scale, preset.scale.disableShapes);
 
         editor.call('viewport:render');
-    });
-
-    // gizmo rotation mode
-    bind('editor.gizmoRotationMode', (value: 'orbit' | 'absolute') => {
-        rotate.orbitRotation = value === 'orbit';
     });
 });


### PR DESCRIPTION
### Requires
- Backend schema update for project user settings
- https://github.com/playcanvas/engine/pull/7961

### Description
- Adds gizmo customisation settings under `Editor` settings header
  - Gizmo size project user setting. Defaults to `1.2`
  - Gizmo preset project user setting (`default` or `classic`). Defaults to `default`.

### Preview
<img width="846" height="180" alt="image" src="https://github.com/user-attachments/assets/ba65b743-4abf-437a-b8ca-eac99e2a6f8b" />
