### PR TITLE
fix(diff-view): avoid truncation in conflict section row label

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -10009,7 +10009,8 @@ strong {
 
                                                         > .content {
                                                             > .ui-label.name {
-                                                                width: 160px;
+                                                                white-space: normal;
+                                                                line-height: 1em;
                                                             }
 
                                                             .value {

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -82,7 +82,7 @@ class ConflictSectionRow extends Events {
             let label = null;
             if (self._name) {
                 label = new LegacyLabel({
-                    text: `${args.prettify ? this._prettifyName(self._name) : self._name} :`
+                    text: `${args.prettify ? this._prettifyName(self._name) : self._name}:`
                 });
                 label.class.add('name');
                 panel.append(label);


### PR DESCRIPTION
Fixes #1416

### What has changed?

* Just changed some CSS to make it wrap normally for these elements as shown in the picture (e.g. "Components Render Light Mapped" instead of "Components Re...")

<img width="961" height="470" alt="Screenshot 2025-09-16 at 15 09 52" src="https://github.com/user-attachments/assets/7530f186-c42a-446b-91a4-6443c6303dd4" />


- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
