### PR TITLE
feat(messenger): enhance WebSocket connection handling with automatic…

### DIFF
--- a/src/editor/relay/relay-server.ts
+++ b/src/editor/relay/relay-server.ts
@@ -44,6 +44,12 @@ class RelayServer extends Events {
             this._userId = data.userId;
             this._ping();
         });
+
+        // If the users connection is restored, reconnect immediately
+        window.addEventListener('online', () => {
+            this._connectAttempts = 0;
+            this.reconnect();
+        });
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where the Messenger WebSocket connection was failing to reconnect after network interruptions due to a logic error and and inconsistent retry strategy.

- Removed the early return which was preventing multiple retries
- Uses exponential back-off during retries which matches the relay-server - Prevents a situation where relay-server re-connects, but not Messenger
- Resets the exponential backoff and reconnects immediately for both relay and messenger when the network becomes available. Allows immediate reconnection.

This fixes #995 where scripts parsing stalls UI after a reconnect. This occurs because the Messenger would not reconnect

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
