### PR TITLE
fix(asset-panel): do not auto-select newly created asset if it would disrupt workflow

### DIFF
--- a/src/editor/assets/assets-context-menu.ts
+++ b/src/editor/assets/assets-context-menu.ts
@@ -1,4 +1,4 @@
-import { Asset } from '@playcanvas/editor-api';
+import { Asset, Entity } from '@playcanvas/editor-api';
 import { Menu, MenuItem } from '@playcanvas/pcui';
 
 editor.once('load', () => {
@@ -224,6 +224,14 @@ editor.once('load', () => {
                     }
                 }
 
+                const selectAsset = (asset) => {
+                    // Reason for skipping the selection can be read here: https://github.com/playcanvas/editor/issues/1063
+                    const isFocusedOnEntity = editor.api.globals.selection.items.some(item => item instanceof Entity);
+                    if (!isFocusedOnEntity) {
+                        editor.api.globals.selection.set([asset]);
+                    }
+                };
+
                 if (key === 'upload') {
                     editor.call('assets:upload:picker', args);
                 } else if (key === 'script') {
@@ -234,9 +242,7 @@ editor.once('load', () => {
                             editor.call('assets:create:script', {
                                 filename: filename,
                                 parent: folder
-                            }, (asset) => {
-                                editor.api.globals.selection.set([asset]);
-                            });
+                            }, selectAsset);
                         });
                     }
                 } else {
@@ -245,9 +251,7 @@ editor.once('load', () => {
                             folder: folder,
                             preload
                         })
-                        .then((asset) => {
-                            editor.api.globals.selection.set([asset]);
-                        })
+                        .then(selectAsset)
                         .catch((err) => {
                             editor.call('status:error', err);
                         });


### PR DESCRIPTION
Fixes #1063 

### What has changed?

* Newly created assets are not focused anymore, if the user was focused on an entity just like as described in the workflow in #1063. Otherwise, if the user some other inspector panel open (e.g. asset or settings), the focus is still performed because it still gives a better UX (e.g. assurance that the file was created just like in any file explorer).

https://github.com/user-attachments/assets/a0f7af8e-972a-4161-8a3d-240114627263

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
