### PR TITLE
Use KeyboardEvent#code in camera-fly.ts

### DIFF
--- a/src/editor/viewport/camera/camera-fly.ts
+++ b/src/editor/viewport/camera/camera-fly.ts
@@ -22,25 +22,28 @@ editor.once('viewport:load', (app) => {
     };
 
     const keyMappings = new Map([
-        ['arrowup', 'forward'],
-        ['w', 'forward'],
-        ['arrowleft', 'left'],
-        ['a', 'left'],
-        ['arrowdown', 'back'],
-        ['s', 'back'],
-        ['arrowright', 'right'],
-        ['d', 'right'],
-        ['e', 'up'],
-        ['pageup', 'up'],
-        ['q', 'down'],
-        ['pagedown', 'down']
+        // Arrow keys
+        ['ArrowUp', 'forward'],
+        ['ArrowLeft', 'left'],
+        ['ArrowDown', 'back'],
+        ['ArrowRight', 'right'],
+        // WASD
+        ['KeyW', 'forward'],
+        ['KeyA', 'left'],
+        ['KeyS', 'back'],
+        ['KeyD', 'right'],
+        // Vertical
+        ['KeyE', 'up'],
+        ['PageUp', 'up'],
+        ['KeyQ', 'down'],
+        ['PageDown', 'down']
     ]);
 
     // Helper functions
     const isInputOrTextarea = target => /input|textarea/i.test(target.tagName);
 
     const setKeyState = (key, state) => {
-        const action = keyMappings.get(key.toLowerCase());
+        const action = keyMappings.get(key);
         if (action) {
             keys[action] = state;
         }
@@ -73,11 +76,11 @@ editor.once('viewport:load', (app) => {
         }
 
         // Check if the pressed key corresponds to a flying action
-        if (!keyMappings.has(evt.key.toLowerCase())) {
+        if (!keyMappings.has(evt.code)) {
             return;
         }
 
-        setKeyState(evt.key, true);
+        setKeyState(evt.code, true);
         updateDirection();
 
         if (!flying) {
@@ -96,7 +99,7 @@ editor.once('viewport:load', (app) => {
             return;
         }
 
-        setKeyState(evt.key, false);
+        setKeyState(evt.code, false);
         updateDirection();
 
         if (Object.values(keys).every(state => !state)) {


### PR DESCRIPTION
Fixes #1451 specifically

### What has changed?
- Using `KeyboardEvent#code` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) ) for orbit control, so that the physical keys 
- Good tool to check the different keyboard codes: https://www.toptal.com/developers/keycode

---

Will raise another PR to fix the #48 , but the current ~63 editor hotkeys don't seem to clash with the WASDQE (physical keys), so I think it's safe to merge separately

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
