### PR TITLE
fix(hotkeys): Use physical keys instead of key values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "9.32.0",
         "filenamify": "6.0.0",
         "highlight.js": "11.9.0",
+        "keyboard-event-key-type": "^1.5.0",
         "markdown-it": "14.0.0",
         "mocha": "^11.1.0",
         "monaco-editor": "^0.47.0",
@@ -5094,6 +5095,13 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/keyboard-event-key-type": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/keyboard-event-key-type/-/keyboard-event-key-type-1.5.0.tgz",
+      "integrity": "sha512-d/yMrq4BREH4isBf/Tj8aQqxP+zudhsfeA91nRVllvkxvGsM5IJVgCiQtZQ+qhM1mpZY3kAjoneUIXRvdABEWw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "9.32.0",
     "filenamify": "6.0.0",
     "highlight.js": "11.9.0",
+    "keyboard-event-key-type": "^1.5.0",
     "markdown-it": "14.0.0",
     "mocha": "^11.1.0",
     "monaco-editor": "^0.47.0",

--- a/src/code-editor/menu-panel/edit/undo-redo.ts
+++ b/src/code-editor/menu-panel/edit/undo-redo.ts
@@ -21,7 +21,7 @@ editor.once('load', () => {
 
     // hotkeys
     editor.call('hotkey:register', 'undo', {
-        key: 'z',
+        key: 'KeyZ',
         ctrl: true,
         skipPreventDefault: true,
         callback: function (e) {
@@ -48,7 +48,7 @@ editor.once('load', () => {
 
     // hotkeys
     editor.call('hotkey:register', 'redo', {
-        key: 'y',
+        key: 'KeyY',
         ctrl: true,
         skipPreventDefault: true,
         callback: function (e) {
@@ -62,7 +62,7 @@ editor.once('load', () => {
     });
 
     editor.call('hotkey:register', 'redo-2', {
-        key: 'z',
+        key: 'KeyZ',
         ctrl: true,
         shift: true,
         skipPreventDefault: true,

--- a/src/code-editor/menu-panel/file/close.ts
+++ b/src/code-editor/menu-panel/file/close.ts
@@ -45,7 +45,7 @@ editor.once('load', () => {
 
     // hotkeys
     editor.call('hotkey:register', 'close-selected', {
-        key: 'w',
+        key: 'KeyW',
         alt: true,
         callback: function () {
             editor.call('editor:command:close');
@@ -53,7 +53,7 @@ editor.once('load', () => {
     });
 
     editor.call('hotkey:register', 'close-all', {
-        key: 'w',
+        key: 'KeyW',
         alt: true,
         shift: true,
         callback: function () {

--- a/src/code-editor/menu-panel/file/save.ts
+++ b/src/code-editor/menu-panel/file/save.ts
@@ -43,7 +43,7 @@ editor.once('load', () => {
 
     // hotkeys
     editor.call('hotkey:register', 'save', {
-        key: 's',
+        key: 'KeyS',
         ctrl: true,
         callback: function () {
             editor.call('editor:command:save');

--- a/src/code-editor/menu-panel/navigate/fuzzy.ts
+++ b/src/code-editor/menu-panel/navigate/fuzzy.ts
@@ -27,7 +27,7 @@ editor.once('load', () => {
     // hotkey
     if (!editor.call('editor:resolveConflictMode')) {
         editor.call('hotkey:register', 'go-to-file', {
-            key: 'p',
+            key: 'KeyP',
             ctrl: true,
             callback: function () {
                 editor.call('editor:command:goToFile');

--- a/src/code-editor/menu-panel/navigate/tabs.ts
+++ b/src/code-editor/menu-panel/navigate/tabs.ts
@@ -21,7 +21,7 @@ editor.once('load', () => {
 
     // hotkey
     editor.call('hotkey:register', 'next-tab', {
-        key: '.',
+        key: 'Period',
         ctrl: true,
         alt: true,
         callback: function () {
@@ -61,7 +61,7 @@ editor.once('load', () => {
 
     // hotkey
     editor.call('hotkey:register', 'prev-tab', {
-        key: ',',
+        key: 'Comma',
         ctrl: true,
         alt: true,
         callback: function () {

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -751,7 +751,7 @@ class AssetPanel extends Panel {
 
             // copy
             editor.call('hotkey:register', 'asset:copy', {
-                key: 'c',
+                key: 'KeyC',
                 ctrl: true,
                 skipPreventDefault: true,
                 callback: this._onCopyAssets.bind(this)
@@ -759,14 +759,14 @@ class AssetPanel extends Panel {
 
             // paste
             editor.call('hotkey:register', 'asset:paste', {
-                key: 'v',
+                key: 'KeyV',
                 ctrl: true,
                 callback: () => this._onPasteAssets()
             });
 
             // paste (keep folder structure)
             editor.call('hotkey:register', 'asset:paste:keepFolderStructure', {
-                key: 'v',
+                key: 'KeyV',
                 ctrl: true,
                 shift: true,
                 callback: () => this._onPasteAssets(true)

--- a/src/editor/assets/assets-panel.ts
+++ b/src/editor/assets/assets-panel.ts
@@ -50,7 +50,7 @@ editor.once('load', () => {
     // // select all hotkey
     // // ctrl + a
     editor.call('hotkey:register', 'asset:select-all', {
-        key: 'a',
+        key: 'KeyA',
         ctrl: true,
         callback: () => {
             const assets = assetsPanel.visibleAssets;

--- a/src/editor/assets/assets-rename-select.ts
+++ b/src/editor/assets/assets-rename-select.ts
@@ -33,7 +33,7 @@ editor.once('load', () => {
     editor.method('assets:rename-select', onRename);
 
     editor.call('hotkey:register', 'assets:rename-select', {
-        key: 'n',
+        key: 'KeyN',
         callback: onRename
     });
 

--- a/src/editor/attributes/attributes-history.ts
+++ b/src/editor/attributes/attributes-history.ts
@@ -135,7 +135,7 @@ editor.once('load', () => {
     });
 
     editor.call('hotkey:register', 'selector:return', {
-        key: 'z',
+        key: 'KeyZ',
         shift: true,
         callback: () => {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {

--- a/src/editor/entities/entities-hotkeys.ts
+++ b/src/editor/entities/entities-hotkeys.ts
@@ -1,7 +1,7 @@
 editor.once('load', () => {
     // new
     editor.call('hotkey:register', 'entity:new', {
-        key: 'e',
+        key: 'KeyE',
         ctrl: true,
         callback: function () {
             if (!editor.call('permissions:write')) {
@@ -32,7 +32,7 @@ editor.once('load', () => {
 
     // duplicate
     editor.call('hotkey:register', 'entity:duplicate', {
-        key: 'd',
+        key: 'KeyD',
         ctrl: true,
         callback: function () {
             if (!editor.call('permissions:write')) {
@@ -101,7 +101,7 @@ editor.once('load', () => {
 
     // copy
     editor.call('hotkey:register', 'entity:copy', {
-        key: 'c',
+        key: 'KeyC',
         ctrl: true,
         skipPreventDefault: true,
         callback: function () {
@@ -130,7 +130,7 @@ editor.once('load', () => {
 
     // paste
     editor.call('hotkey:register', 'entity:paste', {
-        key: 'v',
+        key: 'KeyV',
         ctrl: true,
         callback: function () {
             // write permissions only (perhaps we could also allow read permissions)

--- a/src/editor/help/controls.ts
+++ b/src/editor/help/controls.ts
@@ -213,7 +213,7 @@ editor.once('load', () => {
 
     // hotkey
     editor.call('hotkey:register', 'help:controls', {
-        key: '?',
+        key: 'Slash', // Shift + Slash = '?'
         shift: true,
         callback: function () {
             editor.call('help:controls');

--- a/src/editor/help/howdoi.ts
+++ b/src/editor/help/howdoi.ts
@@ -525,7 +525,7 @@ editor.once('load', () => {
 
     // hotkey
     editor.call('hotkey:register', 'help:howdoi', {
-        key: ' ',
+        key: 'Space',
         ctrl: true,
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {

--- a/src/editor/history/history-hotkeys.ts
+++ b/src/editor/history/history-hotkeys.ts
@@ -9,7 +9,7 @@ editor.once('load', () => {
 
     // hotkey undo
     editor.call('hotkey:register', 'history:undo', {
-        key: 'z',
+        key: 'KeyZ',
         ctrl: true,
         callback: function () {
             if (!editor.call('permissions:write')) {
@@ -26,7 +26,7 @@ editor.once('load', () => {
 
     // hotkey redo
     editor.call('hotkey:register', 'history:redo', {
-        key: 'z',
+        key: 'KeyZ',
         ctrl: true,
         shift: true,
         callback: function () {
@@ -44,7 +44,7 @@ editor.once('load', () => {
 
     // hotkey redo
     editor.call('hotkey:register', 'history:redo:y', {
-        key: 'y',
+        key: 'KeyY',
         ctrl: true,
         callback: function () {
             if (!editor.call('permissions:write')) {

--- a/src/editor/pickers/sprite-editor/sprite-editor-trim.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-trim.ts
@@ -7,7 +7,7 @@ editor.once('load', () => {
     editor.on('picker:sprites:open', () => {
         // Trim selected frames
         editor.call('hotkey:register', 'sprite-editor-trim', {
-            key: 't',
+            key: 'KeyT',
             callback: function () {
                 const spriteAsset = editor.call('picker:sprites:selectedSprite');
                 if (spriteAsset) {

--- a/src/editor/pickers/sprite-editor/sprite-editor.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor.ts
@@ -1635,7 +1635,7 @@ editor.once('load', () => {
 
         // 'F' hotkey to focus canvas
         editor.call('hotkey:register', 'sprite-editor-focus', {
-            key: 'f',
+            key: 'KeyF',
             callback: function () {
                 editor.call('picker:sprites:focus');
             }

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -1421,7 +1421,7 @@ editor.once('load', () => {
 
     // hotkey to create new checkpoint
     editor.call('hotkey:register', 'new-checkpoint', {
-        key: 's',
+        key: 'KeyS',
         ctrl: true,
         callback: function (e) {
             if (!editor.call('permissions:write')) {

--- a/src/editor/toolbar/toolbar-code-editor.ts
+++ b/src/editor/toolbar/toolbar-code-editor.ts
@@ -83,7 +83,7 @@ editor.once('load', () => {
     });
 
     editor.call('hotkey:register', 'code-editor', {
-        key: 'i',
+        key: 'KeyI',
         ctrl: true,
         callback: function () {
             editor.call('picker:codeeditor');

--- a/src/editor/toolbar/toolbar-gizmos.ts
+++ b/src/editor/toolbar/toolbar-gizmos.ts
@@ -167,7 +167,7 @@ editor.once('load', () => {
 
     // translate hotkey
     editor.call('hotkey:register', 'gizmo:translate', {
-        key: '1',
+        key: 'Digit1',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;
@@ -178,7 +178,7 @@ editor.once('load', () => {
 
     // rotate hotkey
     editor.call('hotkey:register', 'gizmo:rotate', {
-        key: '2',
+        key: 'Digit2',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;
@@ -189,7 +189,7 @@ editor.once('load', () => {
 
     // scale hotkey
     editor.call('hotkey:register', 'gizmo:scale', {
-        key: '3',
+        key: 'Digit3',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;
@@ -200,7 +200,7 @@ editor.once('load', () => {
 
     // resize hotkey
     editor.call('hotkey:register', 'gizmo:resize', {
-        key: '4',
+        key: 'Digit4',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;
@@ -211,7 +211,7 @@ editor.once('load', () => {
 
     // world/local hotkey
     editor.call('hotkey:register', 'gizmo:world', {
-        key: 'l',
+        key: 'KeyL',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;
@@ -222,7 +222,7 @@ editor.once('load', () => {
 
     // focus
     editor.call('hotkey:register', 'viewport:focus', {
-        key: 'f',
+        key: 'KeyF',
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {
                 return;

--- a/src/editor/toolbar/toolbar-lightmapper.ts
+++ b/src/editor/toolbar/toolbar-lightmapper.ts
@@ -83,7 +83,7 @@ editor.once('load', () => {
 
     // hotkey ctrl+b
     editor.call('hotkey:register', 'lightmapper:bake', {
-        key: 'b',
+        key: 'KeyB',
         ctrl: true,
         callback: function () {
             if (editor.call('picker:isOpen:otherThan', 'curve')) {

--- a/src/editor/viewport/viewport-expand.ts
+++ b/src/editor/viewport/viewport-expand.ts
@@ -33,7 +33,7 @@ editor.once('load', () => {
 
     // expand hotkey
     editor.call('hotkey:register', 'viewport:expand', {
-        key: ' ',
+        key: 'Space',
         callback: function () {
             editor.call('viewport:expand');
         }


### PR DESCRIPTION
Fixes #48 

### What has changed?

- We should now use the physical keys instead of the key values for the shortcuts. 
- From this [article](https://kb.parallels.com/129916), it seems like the most frequently used shortcuts (e.g. Undo, Redo, Select All) are also mapped to the same physical keys as in the US layout.

- TODO: Check with users it would disrupt their workflow if they had already adjusted to the "wrong layout"

### Side note

- Using `KeyboardEvent#code` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)) so that the physical keys get recognised instead of their values
- Good tool to check the different keyboard codes: https://www.toptal.com/developers/keycode

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
