### PR TITLE
fix(tokenizer): improve JSDoc parsing rules single line attributes

### DIFF
--- a/src/code-editor/monaco/tokenizer-rules.ts
+++ b/src/code-editor/monaco/tokenizer-rules.ts
@@ -27,13 +27,13 @@ const NUMBER_STATE = [
 
 export const jsRules = {
     jsdoc: [
+        [/\*\//, 'comment.doc', '@pop'],
         ...(CUSTOM_TAGS.number.map(tag => ([`([@]${tag})`, 'keyword', '@jsdocNumber']))),
-        ...(CUSTOM_TAGS.string.map(tag => ([`([@]${tag})(\\s*.+)`, ['keyword', 'identifier']]))),
+        ...(CUSTOM_TAGS.string.map(tag => ([`([@]${tag})(\\s*(?:(?!\\*\\/).)+)`, ['keyword', 'identifier']]))),
         ...(CUSTOM_TAGS.array.map(tag => ([`([@]${tag})(\\s*\\[)`, ['keyword', { token: 'identifier', next: '@jsdocSquareBrackets' }]]))),
         [/@\w+/, 'keyword'],
         [/(\})([^-]+)(?=-)/, ['comment.doc', 'identifier']],
         [/\{/, 'comment.doc', '@jsdocCurlyBrackets'],
-        [/\*\//, 'comment.doc', '@pop'],
         [/./, 'comment.doc']
     ],
     jsdocCurlyBrackets: [


### PR DESCRIPTION
Fixes a tokenizer issue for single line attributes. 

Before: - _Note the closing `*/`_
<img width="229" height="28" alt="image" src="https://github.com/user-attachments/assets/ae31f5d5-582b-4122-81bf-16a8fdaea954" />

After:
<img width="228" height="28" alt="image" src="https://github.com/user-attachments/assets/33d3b1a5-a190-454e-8d29-ef1f35a9f8f6" />

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
