### PR TITLE
Assets Panel header makeup - tooltips, styling

### DIFF
--- a/sass/editor/_editor-assets-panel.scss
+++ b/sass/editor/_editor-assets-panel.scss
@@ -660,25 +660,23 @@
             flex-direction: row;
             flex-grow: 1;
             align-items: center;
-        }
-
-        .pcui-button {
-            height: 24px;
-            line-height: 24px;
-            border: 1px solid $bcg-darkest;
-            background-color: $bcg-dark;
-            margin: $element-margin;
-            flex-shrink: 0;
+            height: 32px;
+            border-left: 1px solid $bcg-darkest;
         }
 
         .pcui-asset-panel-btn-small {
             padding: 0;
-            width: 24px;
+            margin: 0;
+            border: 0;
+            width: 32px;
+            height: 32px;
+            line-height: 32px;
             font-size: 15px;
-            line-height: 15px;
-            margin-left: 0;
-            margin-top: 4px;
-            margin-bottom: 4px;
+
+            &:hover {
+                z-index: 1;
+                background-color: #20292b;
+            }
         }
 
         .pcui-asset-panel-btn-active {
@@ -687,26 +685,31 @@
         }
 
         .pcui-asset-panel-btn-container {
-            height: 100%;
             align-items: center;
-            margin-left: 2 * $element-margin;
-            padding-left: 3 * $element-margin;
             border-left: 1px solid $bcg-darkest;
-            flex-shrink: 0;
-            margin-right: 2 * $element-margin;
-            padding-right: 2 * $element-margin;
             border-right: 1px solid $bcg-darkest;
         }
 
         .pcui-select-input {
-            width: 230px;
+            width: 180px;
+            margin: 0;
 
             &.pcui-open {
                 z-index: 2;
             }
 
-            .pcui-label {
-                font-weight: bold;
+            &.asset-filter-specific > .pcui-container > .pcui-select-input-value {
+                background-color: #20292b;
+            }
+
+            .pcui-select-input-value {
+                height: 32px;
+                line-height: 32px;
+                font-size: 14px;
+            }
+
+            .pcui-select-input-icon {
+                line-height: 32px;
             }
 
             .pcui-select-input-list {
@@ -716,38 +719,70 @@
 
         .pcui-input-element {
             width: 230px;
-            font-weight: bold;
-            line-height: 24px;
+            height: 32px;
+            line-height: 32px;
+            margin: 0;
+            border: 0;
+            border-left: 1px solid $bcg-darkest;
+            border-right: 1px solid $bcg-darkest;
 
             > input {
                 max-width: calc(100% - 24px);
                 text-overflow: ellipsis;
+                background-color: transparent;
             }
 
             .pcui-button {
                 position: absolute;
                 right: 0;
-                background: transparent;
+                background-color: transparent;
                 margin: 0;
                 border: 0;
                 box-shadow: none;
+                height: 32px;
+                line-height: 32px;
 
                 &:hover {
                     color: $error;
                 }
             }
 
-            // placeholder left
+            &:hover,
+            &:not([placeholder]) {
+                background-color: #20292b;
+            }
+
+            // placeholder text
             &::after {
-                left: 0;
+                left: 24px;
                 right: initial;
-                font-size: 12px;
+                font-size: 14px;
+                font-weight: normal;
+                line-height: 32px;
+                background-color: transparent;
+            }
+
+            // magnifying glass
+            &[placeholder]::before {
+                @extend .font-icon;
+
+                content: '\E129';
+                font-size: 18px;
+                font-weight: normal;
+                text-align: center;
+                position: absolute;
+                width: 32px;
+                z-index: 1;
             }
         }
 
         .pcui-asset-panel-btn-store {
             margin-left: auto;
             color: white;
+        }
+
+        &:hover {
+            z-index: 2;
         }
     }
 }

--- a/src/common/ui/tooltip.ts
+++ b/src/common/ui/tooltip.ts
@@ -284,6 +284,10 @@ class LegacyTooltip extends LegacyContainer {
         };
 
         this._removeTarget = remove;
+
+        if (target.matches(':hover')) {
+            evtHover();
+        }
     }
 
     detach() {

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -26,7 +26,7 @@ import { TableCell } from '../../common/pcui/element/element-table-cell.ts';
 import { TableRow } from '../../common/pcui/element/element-table-row.ts';
 import { Table } from '../../common/pcui/element/element-table.ts';
 import { type Tooltip } from '../../common/pcui/element/element-tooltip.ts';
-import { tooltip, tooltipSimpleItem } from '../../common/tooltips.ts';
+import { LegacyTooltip } from '../../common/ui/tooltip.ts';
 import { bytesToHuman, naturalCompare } from '../../common/utils.ts';
 
 const CLASS_ROOT = 'pcui-asset-panel';
@@ -449,6 +449,14 @@ class AssetPanel extends Panel {
 
         // header controls
 
+        const tooltip = LegacyTooltip.create({
+            text: 'Add Asset',
+            align: 'bottom',
+            class: 'pcui-tooltip-clipboard',
+            root: editor.call('layout.root')
+        });
+        tooltip.hidden = true;
+
         // button to create new asset
         this._btnNew = new Button({
             icon: 'E120',
@@ -456,9 +464,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
         this._btnNew.on('click', this._onClickNew.bind(this));
+        this._btnNew.on('hover', () => {
+            tooltip.attach(this._btnNew.dom);
+            tooltip.text = 'Add Asset';
+            tooltip.class.toggle('inactive', !this._btnNew.enabled);
+        });
         this._containerControls.append(this._btnNew);
-
-        this._createTooltip('Add Asset', this._btnNew);
 
         // button to delete asset
         this._btnDelete = new Button({
@@ -467,9 +478,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
         this._btnDelete.on('click', this._onClickDelete.bind(this));
+        this._btnDelete.on('hover', () => {
+            tooltip.attach(this._btnDelete.dom);
+            tooltip.text = 'Delete Asset';
+            tooltip.class.toggle('inactive', !this._btnDelete.enabled);
+        });
         this._containerControls.append(this._btnDelete);
-
-        this._createTooltip('Delete Asset', this._btnDelete);
 
         // button to go up on folder
         this._btnBack = new Button({
@@ -477,10 +491,16 @@ class AssetPanel extends Panel {
             enabled: false,
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
-        this._btnBack.on('click', this._onClickBack.bind(this));
+        this._btnBack.on('click', () => {
+            this.navigateBack();
+            tooltip.class.toggle('inactive', !this._btnBack.enabled);
+        });
+        this._btnBack.on('hover', () => {
+            tooltip.attach(this._btnBack.dom);
+            tooltip.text = 'Go one folder up';
+            tooltip.class.toggle('inactive', !this._btnBack.enabled);
+        });
         this._containerControls.append(this._btnBack);
-
-        this._createTooltip('Go one folder up', this._btnBack);
 
         // contains view mode buttons
         const containerBtn = new Container({
@@ -496,9 +516,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
         this._btnLargeGrid.on('click', this._onClickLargeGrid.bind(this));
+        this._btnLargeGrid.on('hover', () => {
+            tooltip.attach(this._btnLargeGrid.dom);
+            tooltip.text = 'Large Icons';
+            tooltip.class.remove('inactive');
+        });
         containerBtn.append(this._btnLargeGrid);
-
-        this._createTooltip('Large Icons', this._btnLargeGrid);
 
         // show small grid view mode
         this._btnSmallGrid = new Button({
@@ -506,9 +529,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
         this._btnSmallGrid.on('click', this._onClickSmallGrid.bind(this));
+        this._btnSmallGrid.on('hover', () => {
+            tooltip.attach(this._btnSmallGrid.dom);
+            tooltip.text = 'Small Icons';
+            tooltip.class.remove('inactive');
+        });
         containerBtn.append(this._btnSmallGrid);
-
-        this._createTooltip('Small Icons', this._btnSmallGrid);
 
         // show details view mode
         this._btnDetailsView = new Button({
@@ -516,9 +542,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_SMALL, CLASS_HIDE_ON_COLLAPSE]
         });
         this._btnDetailsView.on('click', this._onClickDetailsView.bind(this));
+        this._btnDetailsView.on('hover', () => {
+            tooltip.attach(this._btnDetailsView.dom);
+            tooltip.text = 'Details';
+            tooltip.class.remove('inactive');
+        });
         containerBtn.append(this._btnDetailsView);
-
-        this._createTooltip('Details', this._btnDetailsView);
 
         // asset type dropdown filter
         const dropdownTypeOptions = Object.keys(TYPES)
@@ -540,6 +569,12 @@ class AssetPanel extends Panel {
 
         this._containerControls.append(this._dropdownType);
         this._dropdownType.on('change', this._onDropDownTypeChange.bind(this));
+
+        this._dropdownType.on('hover', () => {
+            tooltip.attach(this._dropdownType.dom);
+            tooltip.text = 'Filter by Type';
+            tooltip.class.remove('inactive');
+        });
 
         // search input filter
         this._searchInput = new TextInput({
@@ -569,9 +604,12 @@ class AssetPanel extends Panel {
             class: [CLASS_BTN_STORE, CLASS_HIDE_ON_COLLAPSE]
         });
         btnStore.on('click', this._onClickStore.bind(this));
+        btnStore.on('hover', () => {
+            tooltip.attach(btnStore.dom);
+            tooltip.text = 'Open Store';
+            tooltip.class.remove('inactive');
+        });
         this._containerControls.append(btnStore);
-
-        this._createTooltip('Open Store', btnStore);
 
         // resizable container for a scrollable folders container
         this._containerLeft = new Container({
@@ -782,18 +820,6 @@ class AssetPanel extends Panel {
         });
     }
 
-    _createTooltip(text, target) {
-        const item = tooltipSimpleItem({
-            text: text
-        });
-        tooltip().attach({
-            container: item,
-            target: target,
-            align: 'bottom'
-        });
-        this._tooltips.push(item);
-    }
-
     _onCopyAssets() {
         if (this._currentFolder === LEGACY_SCRIPTS_FOLDER_ASSET) {
             return;
@@ -912,11 +938,6 @@ class AssetPanel extends Panel {
         }
     }
 
-    // Goes up on folder
-    _onClickBack() {
-        this.navigateBack();
-    }
-
     // Sets view mode to large grid
     _onClickLargeGrid() {
         this.viewMode = AssetPanel.VIEW_LARGE_GRID;
@@ -937,7 +958,10 @@ class AssetPanel extends Panel {
         if (this._suspendFiltering) {
             return;
         }
+
         this.filter();
+
+        this._dropdownType.class.toggle('asset-filter-specific', this._dropdownType.value !== 'all');
     }
 
     // Convert string in form "tag1, tag2" to an array


### PR DESCRIPTION
Partially Fixes #74 

Before:  
<img width="819" height="109" alt="image" src="https://github.com/user-attachments/assets/8accfa6d-7236-4719-a930-ad3e8a997668" />

After:  
<img width="705" height="99" alt="image" src="https://github.com/user-attachments/assets/0f9a524e-f412-4459-b86a-ee42f40490be" />

Tooltips when hovering:

Before:  
<img width="114" height="98" alt="image" src="https://github.com/user-attachments/assets/63a6385a-6bc2-40e0-9bcc-1765e603a9b3" />

After:  
<img width="130" height="102" alt="image" src="https://github.com/user-attachments/assets/d2add281-330c-4cf1-ae48-ca4a87b4fa6b" />

### This PR addresses a few things with Assets Panel header:

1. Styling for buttons to make them more like a left toolbar - simple, minimal, straight to the point.
2. Select field and Search field - are now also more minimal, and don't use "bold" font uniquely, and looks closer like other searches across the Editor.
3. Type filter as well as search bar will stay dark and apparent when not empty, so you won't be wandering "where are all my assets?" only to realize you've left something in these filters.
4. Tooltips, make them quick, fast, and clear.
5. Tooltips now respect if a button is disabled, like on the left toolbar, and have label dimmed.

@kpal81xd I've re-used one legacy tooltip for a whole header based on your recent PR, so it does not create thousands of them. 🙏

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
