### PR TITLE
fix(editor): update asset attribute type checks to include 'json'

### DIFF
--- a/src/editor/assets/assets-used.ts
+++ b/src/editor/assets/assets-used.ts
@@ -252,11 +252,11 @@ editor.once('load', () => {
                 }
             } else if (!legacyScripts && path.startsWith('components.script.scripts')) {
                 const parts = splitPath(path);
-                if (parts.length === 6 && parts[4] === 'attributes') {
+                if (parts.length >= 6 && parts[4] === 'attributes') {
                     const primaryScript = editor.call('assets:scripts:assetByScript', parts[3]);
                     if (primaryScript) {
                         const type = primaryScript.get(`data.scripts.${parts[3]}.attributes.${parts[5]}.type`);
-                        if (type !== 'asset') {
+                        if (type !== 'asset' && type !== 'json') {
                             return;
                         }
                     } else {
@@ -321,11 +321,11 @@ editor.once('load', () => {
                 }
             } else if (!legacyScripts && path.startsWith('components.script.scripts')) {
                 const parts = splitPath(path);
-                if (parts.length === 6 && parts[4] === 'attributes') {
+                if (parts.length >= 6 && parts[4] === 'attributes') {
                     const primaryScript = editor.call('assets:scripts:assetByScript', parts[3]);
                     if (primaryScript) {
                         const type = primaryScript.get(`data.scripts.${parts[3]}.attributes.${parts[5]}.type`);
-                        if (type !== 'asset') {
+                        if (type !== 'asset' && type !== 'json') {
                             return;
                         }
                     } else {


### PR DESCRIPTION
Ensures that asset reference counts are updated when using asset types in json attributes.

Fixes #681

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
