### PR TITLE
Light falloff attribute fix

### DIFF
--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -505,7 +505,7 @@ class LightComponentInspector extends ComponentInspector {
         });
 
         // falloff mode is ignored on area lights
-        if (shape !== 0) {
+        if (areaEnabled && shape !== 0) {
             this._field('falloffMode').parent.hidden = true;
         }
 


### PR DESCRIPTION
Currently, if light is using area light shape (non punctual), then falloff property is disabled.
But if you set light shape to non-punctual and then switch off area light for the project, then falloff property will not be visible.

This PR fixes that.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
