### PR TITLE
Asset panel header small ui fixes

### DIFF
--- a/sass/editor/_editor-assets-panel.scss
+++ b/sass/editor/_editor-assets-panel.scss
@@ -672,6 +672,7 @@
             height: 32px;
             line-height: 32px;
             font-size: 15px;
+            flex-shrink: 0;
 
             &:hover {
                 z-index: 1;
@@ -686,11 +687,13 @@
 
         .pcui-asset-panel-btn-container {
             align-items: center;
+            flex-shrink: 0;
             border-left: 1px solid $bcg-darkest;
             border-right: 1px solid $bcg-darkest;
         }
 
         .pcui-select-input {
+            min-width: 100px;
             width: 180px;
             margin: 0;
 
@@ -772,7 +775,6 @@
                 text-align: center;
                 position: absolute;
                 width: 32px;
-                z-index: 1;
             }
         }
 

--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -570,8 +570,9 @@ class AssetPanel extends Panel {
         this._containerControls.append(this._dropdownType);
         this._dropdownType.on('change', this._onDropDownTypeChange.bind(this));
 
-        this._dropdownType.on('hover', () => {
-            tooltip.attach(this._dropdownType.dom);
+
+        this._dropdownType._labelValue.on('hover', () => {
+            tooltip.attach(this._dropdownType._labelValue.dom);
             tooltip.text = 'Filter by Type';
             tooltip.class.remove('inactive');
         });


### PR DESCRIPTION
* Type filter should show tooltip only when hovering it's label, and not element values.
* Buttons and elements should not shrink when not enough space.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
