### PR TITLE
Gizmo left button fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "monaco-themes": "^0.4.2",
         "nodemon": "3.1.7",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "^2.13.4",
+        "playcanvas": "^2.13.5",
         "postcss": "8.4.48",
         "rollup": "4.25.0",
         "rollup-plugin-copy": "3.5.0",
@@ -6110,9 +6110,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.13.4.tgz",
-      "integrity": "sha512-GkXH7nVYsvTgTQQX2GlOneg1c+gyXOekf6EBBnXB7fDkBWFInxzedAwB1GA4rYNDlJRewSHIgszv5SYE0RmbYQ==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.13.5.tgz",
+      "integrity": "sha512-twe4B4fGAu7aUTOCYTo8O8CjKtNnec2wco10CigkNzVzBc0BM2QZPPUbEmlfLkAQxqp4vZ39Rdbothipm1Bnhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "monaco-themes": "^0.4.2",
     "nodemon": "3.1.7",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "^2.13.4",
+    "playcanvas": "^2.13.5",
     "postcss": "8.4.48",
     "rollup": "4.25.0",
     "rollup-plugin-copy": "3.5.0",

--- a/src/editor/viewport/gizmo/gizmo-transform.ts
+++ b/src/editor/viewport/gizmo/gizmo-transform.ts
@@ -179,6 +179,11 @@ const initGizmo = <T extends TransformGizmo>(gizmo: T) => {
     // disable pointer event prevent default to allow viewport tap handling
     gizmo.preventDefault = false;
 
+    // only allow left mouse button interaction
+    gizmo.mouseButtons[0] = true; // left
+    gizmo.mouseButtons[1] = false; // middle
+    gizmo.mouseButtons[2] = false; // right
+
     // enable orbit rotation for rotate gizmo
     if (gizmo instanceof pc.RotateGizmo) {
         gizmo.rotationMode = 'orbit';


### PR DESCRIPTION
Fixes #1509

### What's changed
- Updated engine to latest patch
- Restricts gizmo interaction to only initiate on left mouse button

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
