### PR TITLE
Refactor viewport icons

### DIFF
--- a/src/editor/entities/entities-icons.ts
+++ b/src/editor/entities/entities-icons.ts
@@ -253,12 +253,15 @@ editor.once('load', () => {
             }
 
             this.events.forEach(evt => evt.unbind());
+            this.eventsLocal.forEach(evt => evt.unbind());
 
             if (this.entity) {
                 this.entityDelete();
             }
 
             this.events = [];
+            this.eventsLocal = [];
+            this.local = '';
             this._link = null;
 
             const ind = icons.indexOf(this);


### PR DESCRIPTION
### What's Changed
* Migrate `Icon` to be a true ES6 class and rename to `ViewportIcon`
* Migrate from `model` to `render` component
* Use `StandardMaterial` instead of `ShaderMaterial`

Bonus: fixes the broken "click-to-select-entity" icon functionality:

https://github.com/user-attachments/assets/a331c3c0-51fe-401d-a75e-2969fec8bdbd


- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
