### PR TITLE
[FIX] Fix asset loading for folders with special characters

### DIFF
--- a/src/launch/assets/assets-sync.ts
+++ b/src/launch/assets/assets-sync.ts
@@ -31,7 +31,7 @@ editor.once('load', () => {
             if (folder) {
                 path += `${encodeURIComponent(folder.get('name'))}/`;
             } else {
-                path += `${assetNames[folders[i]] || 'unknown'}/`;
+                path += `${encodeURIComponent(assetNames[folders[i]] || 'unknown')}/`;
             }
         }
         return `assets/files/${path}${encodeURIComponent(filename)}?id=${id}&branchId=${config.self.branch.id}`;


### PR DESCRIPTION
Fixes #814 

Folder names containing special characters (e.g., #, !) weren't being URL-encoded when using the fallback `assetNames` cache in `getFileUrl`. This caused 401 errors when loading assets from folders with names like S#!T, as the # was interpreted as a URL fragment.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
