### PR TITLE
[FIX] Fix clipped Attributes display in Model/Render META section

### DIFF
--- a/sass/editor/_editor-asset-model-inspector.scss
+++ b/sass/editor/_editor-asset-model-inspector.scss
@@ -31,6 +31,19 @@
     }
 }
 
+// Multi-line attributes display for model/render META section
+.asset-model-inspector-meta-attributes {
+    align-items: flex-start;
+
+    > .pcui-label:first-child {
+        margin-top: 4px;
+    }
+
+    > .pcui-label:not(:first-child) {
+        white-space: normal;
+    }
+}
+
 .asset-model-inspector-mesh-instances-picker-mode {
     .pcui-asset-input {
         margin: 0;

--- a/sass/pcui/_pcui-inspector.scss
+++ b/sass/pcui/_pcui-inspector.scss
@@ -10,6 +10,8 @@
 
         > .pcui-label:not(:first-child) {
             @extend .fixedFont;
+
+            min-width: 0;
         }
     }
 

--- a/src/editor/inspector/assets/model.ts
+++ b/src/editor/inspector/assets/model.ts
@@ -8,6 +8,7 @@ import { AttributesInspector } from '../attributes-inspector';
 const CLASS_ROOT = 'asset-model-inspector';
 const CLASS_AUTO_UNWRAP_PROGRESS = `${CLASS_ROOT}-auto-unwrap-progress`;
 const CLASS_AUTO_UNWRAP_PADDING = `${CLASS_ROOT}-auto-unwrap-padding`;
+const CLASS_META_ATTRIBUTES = `${CLASS_ROOT}-meta-attributes`;
 
 const META_ATTRIBUTES: Attribute[] = [
     {
@@ -241,6 +242,7 @@ class ModelAssetInspector extends Container {
         const text = Object.keys(metaAttributes).join(', ');
         const field = this._metaAttributesInspector.getField('meta.attributes');
         field.values = this._assets.map(asset => text);
+        field.parent.class.add(CLASS_META_ATTRIBUTES);
     }
 
     _formatMetaAttributeMeshCompression() {

--- a/src/editor/inspector/assets/render.ts
+++ b/src/editor/inspector/assets/render.ts
@@ -3,6 +3,7 @@ import { Panel, Container } from '@playcanvas/pcui';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
 
+const CLASS_META_ATTRIBUTES = 'asset-model-inspector-meta-attributes';
 
 const META_ATTRIBUTES: Attribute[] = [{
     label: 'Vertices',
@@ -120,6 +121,7 @@ class RenderAssetInspector extends Container {
         const text = Object.keys(metaAttributes).join(', ');
         const field = this._metaAttributesInspector.getField('meta.attributes');
         field.values = assets.map(asset => text);
+        field.parent.class.add(CLASS_META_ATTRIBUTES);
     }
 
     _formatMetaMeshCompression(assets) {


### PR DESCRIPTION
Fixes #542

Before:

https://github.com/user-attachments/assets/181d2fa0-09d6-41a7-b670-32cfab518f9e

After:

https://github.com/user-attachments/assets/fb4d87b8-db93-4d0e-997f-248b66da2a92

The Attributes field in the `META` section was clipping long attribute lists (e.g., `"NORMAL, POSITION, TEXCOORD_0, 
TEXCOORD_1..."`) with no way to view all values.

This PR allows the Attributes field to wrap to multiple lines so all vertex attributes are visible.

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
