### PR TITLE
[FIX] Clarify cookie asset types for light components

### DIFF
--- a/src/editor/attributes/reference/components/light.ts
+++ b/src/editor/attributes/reference/components/light.ts
@@ -181,16 +181,10 @@ export const fields: AttributeReference[]  = [{
     description: 'Constant depth offset applied to a shadow map that enables the tuning of shadows in order to eliminate rendering artifacts, namely \'shadow acne\' and \'peter-panning\'',
     url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#vsmbias'
 }, {
-    name: 'light:cookie',
-    title: 'cookie',
-    subTitle: '{pc.Texture}',
-    description: 'Projection texture. Must be 2D for spot and cubemap for point (ignored if incorrect type is used).',
-    url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#cookie'
-}, {
     name: 'light:cookieAsset',
     title: 'cookieAsset',
     subTitle: '{pc.Asset}',
-    description: 'Asset that has texture that will be assigned to cookie internally once asset resource is available.',
+    description: 'Projection texture asset. Spot lights require a texture asset, omni lights require a cubemap asset.',
     url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#cookieasset'
 }, {
     name: 'light:cookieIntensity',

--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -547,6 +547,11 @@ class LightComponentInspector extends ComponentInspector {
         this._field('cookieDivider').hidden = this._field('cookieAsset').hidden;
         this._field('cookieAsset').assetType = (isPoint ? 'cubemap' : 'texture');
 
+        // Update the label to indicate which asset type is needed
+        if (!isDirectional) {
+            this._field('cookieAsset').text = isPoint ? 'Cookie (Cubemap)' : 'Cookie (Texture)';
+        }
+
         this._field('cookieFalloff').parent.hidden = !isSpot || !cookie || isCLustered;
 
         this._field('shadowResolution').parent.hidden = !castShadows || isCLustered;


### PR DESCRIPTION
Fixes #803

https://github.com/user-attachments/assets/4ee174ed-6c44-431d-ae7b-ef0236448fe1

Makes it clearer which asset type is needed for light cookies:

* Omni lights now show "Cookie (Cubemap)"
* Spot lights now show "Cookie (Texture)"
* The tooltip also now clearly states: "Spot lights require a texture asset, omni lights require a cubemap asset."

Changes:

* Dynamic label updates based on light type
* Improved tooltip description
* Removed unused `light:cookie` reference

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
