### PR TITLE
[FIX] Fix stale asset references in Settings Inspector

### DIFF
--- a/src/editor/inspector/settings-panels/import-map.ts
+++ b/src/editor/inspector/settings-panels/import-map.ts
@@ -86,6 +86,14 @@ class ImportMapSettingsPanel extends BaseSettingsPanel {
                 this._loadLayout();
             }
         });
+
+        // Clear the import map setting when the asset is removed
+        editor.on('assets:remove', (asset) => {
+            const id = this._projectSettings.get('importMap');
+            if (id && asset.get('id').toString() === id.toString()) {
+                this._projectSettings.set('importMap', null);
+            }
+        });
     }
 
     _loadLayout() {

--- a/src/editor/inspector/settings-panels/loading-screen.ts
+++ b/src/editor/inspector/settings-panels/loading-screen.ts
@@ -87,6 +87,14 @@ class LoadingScreenSettingsPanel extends BaseSettingsPanel {
                 this._loadLayout();
             }
         });
+
+        // Clear the loading screen script setting when the asset is removed
+        editor.on('assets:remove', (asset) => {
+            const scriptId = this._projectSettings.get('loadingScreenScript');
+            if (scriptId && asset.get('id').toString() === scriptId.toString()) {
+                this._projectSettings.set('loadingScreenScript', null);
+            }
+        });
     }
 
     _loadLayout() {


### PR DESCRIPTION
Fixes #1564 

https://github.com/user-attachments/assets/ede0a77a-c448-4863-9284-ffe3baa8bc82

When a loading screen script or import map asset was deleted, the reference in project settings was not being cleared. This caused:

* The Settings Inspector UI to still show the deleted asset as assigned
* Launch errors like "Could not load loading screen script: [id]"

Added `assets:remove` listeners to both `LoadingScreenSettingsPanel` and `ImportMapSettingsPanel` that clear the respective setting when the referenced asset is deleted.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
