### PR TITLE
[FIX] Fix Root Bone property visibility with multi-select

### DIFF
--- a/src/editor/inspector/components/render.ts
+++ b/src/editor/inspector/components/render.ts
@@ -337,13 +337,13 @@ class RenderComponentInspector extends ComponentInspector {
         this._field('asset').hidden = this._field('type').value !== 'asset';
 
         // Show Root Bone only if all selected entities have a skinned render asset
-        const showRootBone = this._entities?.every((e) => {
+        const showRootBone = (this._entities?.length > 0 && this._entities.every((e) => {
             if (e.get('components.render.type') !== 'asset') {
                 return false;
             }
             const assetId = e.get('components.render.asset');
             return assetId && this._assets.get(assetId)?.get('meta.skinned');
-        }) ?? false;
+        })) ?? false;
         this._field('rootBone').parent.hidden = !showRootBone;
 
         const customAabb = this._field('customAabb').value;


### PR DESCRIPTION
The Root Bone property in the Render component inspector was hidden when multi-selecting entities with skinned render assets.

https://github.com/user-attachments/assets/c44ccfbc-560e-4d02-847f-13ee616d7cc5

**Changes:**
- Root Bone is now visible when all selected entities have type 'asset' with a skinned render asset assigned
- Uses `every()` to iterate over all selected entities instead of checking a single field value

Fixes #731

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
