### PR TITLE
[FIX] Make cubemap projection properties always visible in Inspector

### DIFF
--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1483,11 +1483,9 @@ class MaterialAssetInspector extends Container {
         cubeMapField.hidden = !cubeMapField.value && sphereMapField.value;
         sphereMapField.hidden = !sphereMapField.value && cubeMapField.value;
 
-        const cubeMapProjectField = this._envInspector.getField('data.cubeMapProjection');
-        cubeMapProjectField.parent.hidden = !cubeMapField.value;
-        const cubeMapCenterField = this._envInspector.getField('data.cubeMapProjectionBox.center');
-        cubeMapCenterField.parent.hidden = cubeMapProjectField.parent.hidden || cubeMapProjectField.value === 0;
-        this._envInspector.getField('data.cubeMapProjectionBox.halfExtents').parent.hidden = cubeMapCenterField.parent.hidden;
+        const hideBoxProjection = this._envInspector.getField('data.cubeMapProjection').value === 0;
+        this._envInspector.getField('data.cubeMapProjectionBox.center').parent.hidden = hideBoxProjection;
+        this._envInspector.getField('data.cubeMapProjectionBox.halfExtents').parent.hidden = hideBoxProjection;
     }
 
     _getApplyToAllValue() {


### PR DESCRIPTION
### Description

The cubemap projection properties (`cubeMapProjection`, `cubeMapProjectionBox.center`, `cubeMapProjectionBox.halfExtents`) are now always visible in the material inspector, regardless of whether an explicit cubemap is set on the material.

<img width="566" height="555" alt="image" src="https://github.com/user-attachments/assets/950c9bb6-30a1-4c0c-82b9-d3aae018eae1" />

### Changes

- Removed the condition that hid `cubeMapProjection` field when no explicit cubemap was assigned
- Box projection fields (center and halfExtents) are now only hidden based on the projection mode, not the cubemap assignment

### Rationale

When a material doesn't have an explicitly set cubemap, it uses the global scene cubemap. The `cubeMapProjection` property still applies in this case. Previously, if a user set box projection on a material with a cubemap and then removed the cubemap, the projection settings would still affect rendering but the UI would be hidden, preventing users from viewing or modifying these settings.

Fixes #1226

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
