### PR TITLE
[FIX] Fix unreferenced indicator for loading screen scripts

### DIFF
--- a/src/editor/assets/assets-used.ts
+++ b/src/editor/assets/assets-used.ts
@@ -697,6 +697,16 @@ editor.once('load', () => {
         updateAsset('sceneSettings', 'editorSettings', valueOld, value);
     });
 
+    // project settings
+    const projectSettings = editor.call('settings:project');
+    const loadingScreenScript = projectSettings.get('loadingScreenScript');
+    if (loadingScreenScript) {
+        updateAsset('projectSettings', 'editorSettings', null, parseInt(loadingScreenScript, 10));
+    }
+    projectSettings.on('loadingScreenScript:set', (value, valueOld) => {
+        updateAsset('projectSettings', 'editorSettings', valueOld ? parseInt(valueOld, 10) : null, value ? parseInt(value, 10) : null);
+    });
+
     editor.method('assets:used:index', () => {
         return index;
     });


### PR DESCRIPTION
Fix unreferenced indicator for loading screen scripts

The unreferenced asset indicator (dot) was incorrectly showing for scripts assigned as the project's loading screen, even though they are referenced by the project settings.

### Changes
- Added tracking for the `loadingScreenScript` project setting in the asset usage system
- The loading screen script asset is now correctly marked as "referenced" when assigned in project settings

### Technical Details
The `assets-used.ts` module tracks asset references from various sources (entities, materials, scene settings, etc.) to determine if an asset is used. This change adds similar tracking for the `loadingScreenScript` project setting, following the same pattern used for the scene settings skybox.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
