### PR TITLE
[FIX] Tweak Inspector label vs control widths

### DIFF
--- a/sass/pcui/_pcui-inspector.scss
+++ b/sass/pcui/_pcui-inspector.scss
@@ -5,7 +5,7 @@
 
         > .pcui-label:first-child {
             font-size: 12px;
-            width: 30%;
+            width: 35%;
         }
 
         > .pcui-label:not(:first-child) {

--- a/src/editor/layout/layout.ts
+++ b/src/editor/layout/layout.ts
@@ -81,7 +81,7 @@ const createAttributesPanel = () => {
         scrollable: true,
         resizable: 'left',
         resizeMin: 256,
-        resizeMax: 512
+        resizeMax: 600
     });
 
     attributesPanel.on('resize', () => {


### PR DESCRIPTION
### Changes

- Increased inspector panel maximum resize width from 512px to 600px
- Adjusted label/control width ratio from 30%/70% to 35%/65%

Before:

<img width="611" height="436" alt="image" src="https://github.com/user-attachments/assets/d1ed28c0-f368-45a6-9291-37e452625243" />

After:

<img width="611" height="434" alt="image" src="https://github.com/user-attachments/assets/709d2bb4-576d-45ae-91ec-0e8177c93a81" />

### Rationale

The previous 30%/70% split resulted in excessively wide input fields when the inspector panel was expanded, wasting horizontal space. The new 35%/65% ratio improves label readability while keeping controls at a reasonable width. Increasing the maximum panel width to 600px gives users more flexibility to resize the inspector to their preference.

Fixes #1288 

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
