### PR TITLE
[FIX] Fix phantom undo operations in AnimStateGraph Editor

### DIFF
--- a/src/editor/inspector/assets/animstategraph-view.ts
+++ b/src/editor/inspector/assets/animstategraph-view.ts
@@ -786,13 +786,8 @@ class AnimstategraphView {
         });
 
         this._graph.on(GRAPH_ACTIONS.DESELECT_ITEM, ({ prevItem }) => {
-            if (this._suppressGraphDataEvents) {
-                return;
-            }
-            // Only add history entry if there was actually a selected item
-            if (!prevItem) {
-                this._onDeselectItem();
-                this._graph.deselectItem();
+            // Skip if events are suppressed or if nothing was selected
+            if (this._suppressGraphDataEvents || !prevItem) {
                 return;
             }
             const assetId = this._assets[0].get('id');
@@ -814,7 +809,6 @@ class AnimstategraphView {
                     this._suppressGraphEvents(() => {
                         switch (type) {
                             case 'NODE': {
-
                                 const node = this._graph._graphData.get(`data.nodes.${id}`);
                                 this._graph.selectNode(node);
                                 this._onSelectNode({ node });


### PR DESCRIPTION
### Overview

Fixed a bug where pressing CTRL+Z in the AnimStateGraph Editor would sometimes do nothing (phantom undo operation) between undoing state deletions.

### The Bug

When creating multiple states:
1. Create state 1
2. Create state 2
3. CTRL+Z → deletes state 2 ✓
4. CTRL+Z → **nothing happens** (phantom!)
5. CTRL+Z → deletes state 1 ✓

### Root Cause

The `DESELECT_ITEM` event handler had two issues:

1. **Event data mismatch**: The handler expected `{ type, id, edgeId }` directly from the event, but pcui-graph dispatches `{ prevItem: SelectedItem }`. This caused `type`, `id`, `edgeId` to all be `undefined`, making the undo action do nothing.

2. **Missing null check**: When right-clicking on empty canvas to open the context menu, `DESELECT_ITEM` fires with `prevItem: null`. The handler was adding a history entry regardless, creating a phantom undo operation.

### The Fix

- Correctly destructure `{ prevItem }` from the event
- Early return without adding history entry when `prevItem` is null (nothing was selected)
- Extract `type`, `id`, `edgeId` from the `prevItem` SelectedItem object

Fixes #1638

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
