### PR TITLE
[FIX] Fix loss of template override highlighting after script parse

### DIFF
--- a/src/editor/templates/templates-override-inspector.ts
+++ b/src/editor/templates/templates-override-inspector.ts
@@ -160,14 +160,34 @@ class TemplateOverrideInspector {
             element,
             tooltipGroup
         };
+
+        // If we have an entity, check if there's already an override for this path
+        // and apply the CSS class immediately to avoid a visual blip when elements
+        // are recreated (e.g., during script parsing). Schedule a full refresh to
+        // properly set up tooltips.
+        if (this._entity) {
+            for (const key in this._overrides) {
+                if (key.endsWith(path)) {
+                    element.class.add(CLASS_OVERRIDE);
+                    break;
+                }
+            }
+            this._deferRefreshOverrides();
+        }
     }
 
     /**
      * Unregister the specified override path.
      *
      * @param {string} path - The override path.
+     * @param {Element} [element] - Optional element to match. If provided, only unregisters
+     * if the currently registered element matches. This prevents a destroyed inspector from
+     * unregistering elements that a new inspector just registered for the same path.
      */
-    unregisterElementForPath(path) {
+    unregisterElementForPath(path, element?) {
+        if (element && this._registeredElements[path]?.element !== element) {
+            return;
+        }
         delete this._registeredElements[path];
     }
 


### PR DESCRIPTION
When parsing a script on an entity that's part of a template instance, the cyan override highlighting would disappear until the page was refreshed.

### The Bug

The issue occurred because `ScriptInspector._initializeScriptAttributes()` creates a new `AttributesInspector` before destroying the old one (to prevent scroll jumps). This caused:

1. New inspector registers elements for paths
2. Old inspector is destroyed
3. Old inspector's `destroy()` unregisters the **same paths**, removing the new elements
4. No refresh is triggered (no entity data changed)
5. Override highlighting is lost

### The Fix

**`TemplateOverrideInspector`**:
- `unregisterElementForPath()` now accepts an optional `element` parameter - only unregisters if the element matches what's currently registered
- `registerElementForPath()` now immediately applies the override CSS class if an override already exists for that path, avoiding visual blip

**`AttributesInspector`**:
- `destroy()` now passes the element reference when unregistering, so it won't accidentally unregister elements from a newly created inspector

### Demonstration of Fix

https://github.com/user-attachments/assets/b86f4438-0572-44ad-a799-c2a03f3fab79

### Public API Changes

None. The `element` parameter added to `unregisterElementForPath()` is optional for backwards compatibility.

Fixes #1450 

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
