### PR TITLE
[FIX] Restore collision gizmo render style

### DIFF
--- a/src/editor/viewport/gizmo/gizmo-collision.ts
+++ b/src/editor/viewport/gizmo/gizmo-collision.ts
@@ -928,7 +928,6 @@ void main(void)
             meshInstanceBehind.setParameter('offset', 0);
             meshInstanceBehind.__editor = true;
             meshInstanceBehind.pick = false;
-            meshInstanceBehind.castShadow = false;
             meshInstanceBehind.receiveShadow = false;
             meshInstanceBehind.__useFrontLayer = true;
 
@@ -937,7 +936,6 @@ void main(void)
             meshInstanceOccluder.setParameter('offset', 0);
             meshInstanceOccluder.__editor = true;
             meshInstanceOccluder.pick = false;
-            meshInstanceOccluder.castShadow = false;
             meshInstanceOccluder.receiveShadow = false;
 
             meshesExtra.push(meshInstanceBehind, meshInstanceOccluder);


### PR DESCRIPTION
Fixes #1651

Avoid overwriting the 'behind' alpha value.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/34d35099-6fb5-44cf-8184-0bbe834cb123" />

Also, strip some redundant property sets (`MeshInstance#castShadow` defaults to `false` and `MeshInstance#drawToDepth` doesn't exist).

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
