### PR TITLE
[FIX] Fix template preview not working when render assets are missing

### DIFF
--- a/src/common/thumbnail-renderers/template-thumbnail-renderer.ts
+++ b/src/common/thumbnail-renderers/template-thumbnail-renderer.ts
@@ -173,9 +173,15 @@ class TemplatePreviewScene extends Observer {
             console.warn('Asset ID not provided');
             return;
         }
-        this.requiredAssetLoadCount++;
+
         const asset = this.app.assets.get(assetId);
 
+        // If asset doesn't exist (e.g., was deleted), skip loading
+        if (!asset) {
+            return;
+        }
+
+        this.requiredAssetLoadCount++;
         asset.ready(this.handleAssetLoad.bind(this));
         this.app.assets.load(asset);
     }


### PR DESCRIPTION
Fixes #1671

https://github.com/user-attachments/assets/9f6532fd-13cb-4a01-97c9-0c667ae5d8c3

### Overview

The template preview would fail to render entirely if any render component in the template referenced a deleted or missing asset.

### Changes

- Added null check in `queueAssetLoad` to gracefully skip missing assets
- Templates now render with available assets/primitives even when some referenced assets are deleted

### Technical Details

When `this.app.assets.get(assetId)` returns `null` (e.g., asset was deleted), the code previously attempted to call `.ready()` on the null value, causing an error that broke the entire preview. The fix checks if the asset exists before attempting to load it, allowing the preview to proceed with the remaining valid assets.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
