### PR TITLE
[FIX] Fix sprite frame resize when crossing texture boundaries

### DIFF
--- a/src/editor/pickers/sprite-editor/sprite-editor-frames-attributes-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-frames-attributes-panel.ts
@@ -337,9 +337,8 @@ editor.once('load', () => {
 
                         // Check if the new size would exceed the boundary
                         // and adjust position if necessary
-                        let newPos = currentPos;
                         if (currentPos + clampedValue > dimension) {
-                            newPos = Math.max(0, dimension - clampedValue);
+                            const newPos = Math.max(0, dimension - clampedValue);
                             asset.set(`data.frames.${frames[i]}.rect.${posIdx}`, newPos);
                         }
 


### PR DESCRIPTION
Fixes #723

https://github.com/user-attachments/assets/5fe28c9f-97a1-4b24-b0e7-29d405b75bf9

When resizing a sprite frame in the Sprite Editor, if the new size would cross the texture boundary (e.g., frame at edge/corner), the resize is now applied by automatically moving the frame inward to accommodate the new size.

### Changes

- Modified size input constraints to allow sizes up to the full texture dimension
- When increasing frame size would exceed texture boundaries, the frame position is automatically adjusted to fit
- Undo/redo correctly restores both position and size

### Before

Resizing a frame at the edge of a texture was silently blocked if the new size would exceed the boundary.

### After

The frame is moved inward to accommodate the new size. For example, a frame at X=450 on a 512px texture can now be resized to 100px wide - the X position is automatically adjusted to 412 (512 - 100).

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
