### PR TITLE
[FIX] Fix AnimGraph Editor transition deletion with multiple transitions

### DIFF
--- a/src/editor/inspector/assets/animstategraph-view.ts
+++ b/src/editor/inspector/assets/animstategraph-view.ts
@@ -498,11 +498,10 @@ class AnimstategraphView {
                             // Find remaining transitions on the same from-to path in the current layer
                             const layerTransitionIds = new Set(newValue.layers?.[this._selectedLayer]?.transitions || []);
                             const remainingTransitions = Object.entries(newValue.transitions || {})
-                                .filter(([id, t]: [string, { from: number; to: number }]) =>
-                                    layerTransitionIds.has(Number(id)) &&
+                            .filter(([id, t]: [string, { from: number; to: number }]) => layerTransitionIds.has(Number(id)) &&
                                     t.from === deletedTransition.from &&
                                     t.to === deletedTransition.to
-                                );
+                            );
 
                             if (remainingTransitions.length > 0) {
                                 // Re-create remaining edges to force adjustVertices to recalculate positions


### PR DESCRIPTION
Fixes #1033

https://github.com/user-attachments/assets/f0b491e2-f12a-49d6-859e-10e046173e42

### Summary

When multiple transitions exist on the same path (same from-to nodes), deleting one transition via the inspector caused the remaining transitions to become non-selectable.

### Changes

- Only unlink the transitions container when the **last** transition on a path is deleted, preventing premature clearing of `_assets` that blocked re-linking
- After deleting a transition with remaining transitions on the same path, re-create all remaining edges to force `adjustVertices` to recalculate their visual positions and click areas

### Root Cause

Two issues in `_handleIncomingUpdates`:

1. `_transitionsContainer.unlink()` was called whenever any transition on the selected edge path was deleted, which set `_assets = null` and prevented the subsequent `link()` call in the click:remove handler from executing

2. After deleting one of multiple edges on the same path, pcui-graph's `adjustVertices` wasn't recalculating the remaining edge positions, causing click detection to fail on re-selection

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
