### PR TITLE
[FIX] Fix crash when deleting folder with open script

### DIFF
--- a/src/code-editor/files-panel/files-panel.ts
+++ b/src/code-editor/files-panel/files-panel.ts
@@ -448,7 +448,7 @@ editor.once('load', () => {
     // deselect tree item
     editor.on('documents:close', (id: string) => {
         const item = idToItem.get(id);
-        if (item) {
+        if (item && !item.destroyed) {
             item.selected = false;
             item.class.remove('dirty');
         }


### PR DESCRIPTION
Fixes a crash that occurred when deleting a folder containing a script that was open in the Code Editor.

### The Bug

When a folder was deleted from the main Editor while the Code Editor had a script from that folder open, the following error would occur:

```
TypeError: Cannot read properties of null (reading 'classList')
```

### Root Cause

A race condition in the event handling:

1. `assets:remove` fires and destroys the tree item (nulling its DOM)
2. `documents:close` fires and tries to deselect the already-destroyed item
3. Setting `item.selected = false` internally accesses `this.dom.classList`, which crashes

### The Fix

Added a `!item.destroyed` check before attempting to modify the tree item in the `documents:close` handler.

### Testing

1. Create a folder with a script inside
2. Open the script in the Code Editor
3. Delete the parent folder from the main Editor
4. ✅ No error in console (previously crashed)

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
