### PR TITLE
[FIX] Normalize error types in RelayServer

### DIFF
--- a/src/code-editor/files-panel/files-panel.ts
+++ b/src/code-editor/files-panel/files-panel.ts
@@ -448,7 +448,7 @@ editor.once('load', () => {
     // deselect tree item
     editor.on('documents:close', (id: string) => {
         const item = idToItem.get(id);
-        if (item) {
+        if (item && !item.destroyed) {
             item.selected = false;
             item.class.remove('dirty');
         }


### PR DESCRIPTION
Fixes Sentry issue: "Relay server: [object Event]"

- Wrap WebSocket error events in `Error` objects with contextual information (state, url, attempts)
- Improve JSON parse error messages to include the actual exception and a data preview
- Add TypeScript type annotation to `_onerror(error: Error)`

Previously, `_onerror` received inconsistent types:
- WebSocket `Event` object from `socket.onerror` (stringified as unhelpful `[object Event]`)
- `Error` object from JSON parse failures

Now all `'error'` events emit `Error` objects with actionable debugging context.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
