### PR TITLE
[FIX] Fix race condition in asset inspector license update

### DIFF
--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -550,6 +550,11 @@ class AssetInspector extends Container {
             this._licenseTypes = await editor.call('picker:store:licenses');
         }
 
+        // Re-check after async operation since unlink() could have been called
+        if (!this._assets) {
+            return;
+        }
+
         const licenses = this._assets.map((asset) => {
             return asset.get('license') &&  this._buildLicenseHtml(asset.get('license.id'));
         });


### PR DESCRIPTION
Fixes a `TypeError: Cannot read properties of null (reading 'map')` that could occur in the asset inspector when viewing Store-imported assets.

### Problem

The `_updateLicense` method has an async call to fetch license types. If the user navigates away or selects a different item while this request is in flight, `unlink()` is called which sets `this._assets = null`. When the async call completes, the code attempts to call `.map()` on the now-null `_assets` array.

### Solution

Added a null check for `this._assets` after the async `picker:store:licenses` call to safely bail out if the inspector was unlinked during the request.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
