### PR TITLE
Remove dead Assets Panel CSS

### DIFF
--- a/sass/editor/_editor-assets-panel.scss
+++ b/sass/editor/_editor-assets-panel.scss
@@ -17,14 +17,6 @@
 
             > .pcui-panel-header {
                 width: 90px;
-
-                > .assets-controls {
-                    display: none;
-                }
-
-                > .filters {
-                    display: none;
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Removed 310 lines of dead CSS from the assets panel stylesheet
- Legacy styles targeted selectors that no longer exist in the codebase:
  - `#layout-assets:not(.pcui-asset-panel)` (the panel always has `.pcui-asset-panel` class)
  - `.assets-controls`, `.filters`, `.ui-button.store` (old header controls)
  - `.ui-select-field.options`, `.ui-text-field.search` (old filter/search inputs)
  - `.ui-label.no-assets` (old empty state label)
  - `.pcui-container.progress-overlay > .ui-progress` (old progress bar using legacy `LegacyProgress` component)

## Technical Details

The asset panel was previously refactored to use PCUI components. The old CSS remained but was never cleaned up:
- Header controls now use PCUI buttons with `pcui-asset-panel-btn-*` classes
- Search/filter inputs now use PCUI's `SelectInput` and `TextInput`
- Progress bar now uses PCUI's `Progress` component (`pcui-progress` class) inside a `pcui-asset-panel-progress` container

No visual changes - the deleted CSS was unreachable.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
