### PR TITLE
[FIX] Prevent text selection drags from activating drop targets

### DIFF
--- a/src/common/pcui/element/element-drop-manager.ts
+++ b/src/common/pcui/element/element-drop-manager.ts
@@ -194,48 +194,45 @@ class DropManager extends Container {
         this.emit('deactivate');
     }
 
-    _onDragEnter(evt) {
+    /**
+     * Returns true if the drag event contains valid drop data.
+     * Text selection drags have types like 'text/plain' but not 'Files'.
+     *
+     * @param evt - The drag event to validate.
+     * @returns True if the drag contains valid data for the current dropType.
+     */
+    _isValidDrag(evt: DragEvent) {
+        if (this._dropType === 'files') {
+            const types = evt.dataTransfer?.types;
+            return types && Array.from(types).includes('Files');
+        }
+        return true;
+    }
+
+    _onDragEnter(evt: DragEvent) {
         if (!this.enabled) {
             return;
         }
 
         evt.preventDefault();
 
-        if (this.readOnly) {
+        if (this.readOnly || !this._isValidDrag(evt)) {
             return;
-        }
-
-        // Only activate for file drags when dropType is 'files'
-        // Text selection drags have types like 'text/plain' but not 'Files'
-        if (this._dropType === 'files') {
-            const types = evt.dataTransfer?.types;
-            if (!types || !Array.from(types).includes('Files')) {
-                return;
-            }
         }
 
         this._dragEventCounter++;
         this.active = true;
     }
 
-    _onDragOver(evt) {
+    _onDragOver(evt: DragEvent) {
         if (!this.enabled) {
             return;
         }
 
         evt.preventDefault();
 
-        if (this.readOnly) {
+        if (this.readOnly || !this._isValidDrag(evt)) {
             return;
-        }
-
-        // Only activate for file drags when dropType is 'files'
-        // Text selection drags have types like 'text/plain' but not 'Files'
-        if (this._dropType === 'files') {
-            const types = evt.dataTransfer?.types;
-            if (!types || !Array.from(types).includes('Files')) {
-                return;
-            }
         }
 
         evt.dataTransfer.dropEffect = 'move';
@@ -243,7 +240,7 @@ class DropManager extends Container {
         this.active = true;
     }
 
-    _onDragLeave(evt) {
+    _onDragLeave(evt: DragEvent) {
         if (!this.enabled) {
             return;
         }
@@ -262,7 +259,7 @@ class DropManager extends Container {
         }
     }
 
-    _onMouseUp(evt) {
+    _onMouseUp(evt: MouseEvent) {
         if (!this.enabled) {
             return;
         }
@@ -273,7 +270,7 @@ class DropManager extends Container {
         this.active = false;
     }
 
-    _onDrop(evt) {
+    _onDrop(evt: DragEvent) {
         if (!this.enabled) {
             return;
         }


### PR DESCRIPTION
## Summary

- Fixes the assets panel incorrectly highlighting when dragging selected text from input fields
- Adds validation in `DropManager` to check that drag events contain actual files before activating drop targets

## Technical Details

When `dropType` is `'files'` (the default), the `_onDragEnter` and `_onDragOver` handlers now verify that `dataTransfer.types` includes `"Files"` before activating the drop manager. Text selection drags only have types like `"text/plain"` and are filtered out.

Fixes #466

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
