### PR TITLE
fix: unset shader field in material migration instead of setting it

### DIFF
--- a/src/editor/assets/assets-migrate.ts
+++ b/src/editor/assets/assets-migrate.ts
@@ -288,11 +288,11 @@ editor.once('load', () => {
         // remove shader since physical material is now the default
         if (asset.has('data.shader')) {
             const shader = asset.get('data.shader');
-            asset.set('data.shader', 'blinn');
+            asset.unset('data.shader');
             if (shader !== 'blinn') {
                 const msg = [
                     `The ${f.path('data.shader')} property of material ${f.asset(asset)} is no`,
-                    'longer supported by the Editor, and this has been switched to Physical'
+                    'longer supported by the Editor, and has been removed'
                 ].join(' ');
                 editor.call('console:log:asset', asset, msg);
             }


### PR DESCRIPTION
## Summary

- Fix material migration to unset the `shader` field instead of setting it to `'blinn'`
- Update log message to reflect that the property is removed, not switched

## Problem

The migration code comment says "remove shader" but it was actually setting the field to `'blinn'`. This caused a C3 validation error in the collab-server because the `shader` field is not defined in the material data schema.

## Solution

Changed `asset.set('data.shader', 'blinn')` to `asset.unset('data.shader')` to be consistent with how `fresnelModel` is handled in the same migration.

Fixes #1709
