### PR TITLE
Material migration cleanup

### DIFF
--- a/src/editor/assets/assets-migrate.ts
+++ b/src/editor/assets/assets-migrate.ts
@@ -133,10 +133,9 @@ editor.once('load', () => {
         });
 
         if (asset.has('data.useGamma')) {
-            const tonemap = asset.get('data.useGamma') ?? true;
-            tonemap.write = true;
+            const tonemap: boolean = asset.get('data.useGamma') ?? true;
             asset.unset('data.useGamma');
-            asset.set('data.useTonemap', tonemap.value);
+            asset.set('data.useTonemap', tonemap);
             const msg = [
                 `The ${f.path('data.useGamma')} properties of material ${f.asset(asset)} is`,
                 `no longer supported by the Editor and this has been switched to ${f.path('data.useTonemap')}`


### PR DESCRIPTION
Closes #1710

### What's Changed
- Removes `useGamma` migration and updates binding of `useTonemap` to `useGammaTonemap`
- Updates setting of `shader` to always set to `blinn` if not already (compatibility with engine V1) 

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
