### PR TITLE
fix: entity input empty state not initialized correctly

### DIFF
--- a/src/common/pcui/element/element-entity-input.ts
+++ b/src/common/pcui/element/element-entity-input.ts
@@ -100,7 +100,7 @@ class EntityInput extends Element {
         this._highlightEntityFn = args.highlightEntityFn || this._highlightEntity.bind(this);
 
         this._value = null;
-        this.value = args.value || null;
+        this._updateValue(args.value ?? null);
 
         this.renderChanges = args.renderChanges || false;
 


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/67551211-cd5b-4611-a21e-9fce07a43bc3

- Fixed EntityInput component not properly initializing its empty state when value is null
- Changed constructor to call _updateValue() directly instead of going through the value setter

## Problem

When a script with an entity attribute (with no Entity assigned) is parsed, the entity picker goes from showing 'Select Entity' placeholder to being blank with a visible 'X' button. This makes it appear as if an entity is assigned when none is.

## Root Cause

The constructor set 	his._value = null then called 	his.value = null through the setter. The setter's early-return check if (this._value === value) return would trigger because 
ull === null, so _updateValue() was never called and CLASS_EMPTY was never added.

## Fix

Call _updateValue() directly during initialization to ensure the UI state is properly set up (including adding CLASS_EMPTY for null values).

Fixes #1715