### PR TITLE
fix: default engineV2 migration fallback to true

### DIFF
--- a/src/editor/settings/project-settings.ts
+++ b/src/editor/settings/project-settings.ts
@@ -45,7 +45,7 @@ editor.once('load', () => {
         settings.sync.enabled = editor.call('permissions:write');
 
         if (!config.project.settings.hasOwnProperty('engineV2')) {
-            settings.set('engineV2', false);
+            settings.set('engineV2', true);
         }
 
         if (config.project.settings.hasOwnProperty('useLegacyScripts')) {


### PR DESCRIPTION
## Summary

- Fixes the 'Switching project to Engine V1' overlay appearing on load for newly created projects
- The schema cleanup PR (playcanvas-monorepo#3234) changed the `engineV2` schema `` from `false` to `true`, but the migration fallback in `project-settings.ts` was still hardcoded to `false`
- For projects without an explicit `engineV2` field in the database, the Observer initialized with the schema default (`true`), then the migration set it to `false`, firing a spurious `engineV2:set` event that triggered the switching overlay

## Fix

Update the migration fallback from `false` to `true` to match the schema default.

## Test plan

- [x] Create a new project from the New Project dialog and verify the 'Switching project to Engine V1' overlay no longer appears
- [x] Verify existing Engine V1 projects that have `engineV2: false` explicitly stored still load correctly as V1
- [x] Verify existing Engine V2 projects that have `engineV2: true` explicitly stored still load correctly as V2
