### PR TITLE
fix: replace cog icon with ellipsis on component context menus

### DIFF
--- a/src/editor/inspector/components/component.ts
+++ b/src/editor/inspector/components/component.ts
@@ -88,15 +88,15 @@ class ComponentInspector extends Panel {
         });
         this.header.append(this._btnHelp);
 
-        // add cog button
-        this._btnCog = new Button({
-            icon: 'E134',
+        // add context menu button
+        this._btnMenu = new Button({
+            icon: 'E235',
             class: 'component-header-btn'
         });
-        this.header.append(this._btnCog);
+        this.header.append(this._btnMenu);
 
         this._localStorage = new LocalStorage();
-        this._contextMenu = this._createContextMenu(this._btnCog);
+        this._contextMenu = this._createContextMenu(this._btnMenu);
 
         this._templateOverridesInspector = args.templateOverridesInspector;
         if (this._templateOverridesInspector) {

--- a/src/editor/inspector/entity.ts
+++ b/src/editor/inspector/entity.ts
@@ -244,15 +244,17 @@ class EntityInspector extends Container {
 
         btnAddComponent.on('click', this._onClickAddComponent.bind(this));
 
-        // cog button
-        const btnCog = new Button({
-            icon: 'E134'
+        // context menu button
+        const btnMenu = new Button({
+            icon: 'E235'
         });
-        btnCog.style.fontSize = '16px';
-        btnCog.style.marginLeft = '0';
-        containerComponentButtons.append(btnCog);
+        btnMenu.style.display = 'inline-flex';
+        btnMenu.style.alignItems = 'center';
+        btnMenu.style.fontSize = '16px';
+        btnMenu.style.marginLeft = '0';
+        containerComponentButtons.append(btnMenu);
 
-        this._menuCog = this._createCogMenu(btnCog);
+        this._menuContext = this._createContextMenu(btnMenu);
 
         // add component inspectors
         this._componentInspectors = {};
@@ -313,7 +315,7 @@ class EntityInspector extends Container {
         this._attributesInspector.getField('name').focus();
     }
 
-    _createCogMenu(target) {
+    _createContextMenu(target) {
         const menu = new Menu({
             items: [{
                 text: 'Paste Component',
@@ -760,7 +762,7 @@ class EntityInspector extends Container {
         }
 
         this._menuAddComponent.destroy();
-        this._menuCog.destroy();
+        this._menuContext.destroy();
         editor.call('hotkey:unregister', 'entities:rename:f2');
 
         super.destroy();


### PR DESCRIPTION
## Summary

<img width="733" height="396" alt="image" src="https://github.com/user-attachments/assets/f4a92da0-92e8-4680-888a-83333b89a273" />

- Replace the cog icon (E134) with a horizontal ellipsis icon (E235) on component inspector and entity inspector context menu buttons, since a cog implies 'settings' while these menus contain actions (Copy, Paste, Delete)
- Rename cog-related variables and methods to context/menu-based naming for clarity (e.g. `_btnCog` -> `_btnMenu`, `_createCogMenu` -> `_createContextMenu`)
- Add inline flex centering on the entity inspector menu button to vertically center the ellipsis glyph

## Test plan

- [x] Open the inspector for an entity with components and verify the ellipsis icon appears in each component header
- [x] Click the ellipsis to confirm the Copy/Paste/Delete menu still opens correctly
- [x] Verify the ellipsis next to the ADD COMPONENT button is vertically centered
- [x] Confirm cog icon still appears on editor settings toolbar button and scene settings context menu