### PR TITLE
fix: default engineV2 to true

### DIFF
--- a/src/common/editor.ts
+++ b/src/common/editor.ts
@@ -29,7 +29,7 @@ class Editor<T extends EditorMethods> extends Caller<T> {
     /**
      * Whether the Editor project is using engine v2.
      */
-    projectEngineV2: boolean = config.project?.settings?.engineV2 ?? false;
+    projectEngineV2: boolean = config.project?.settings?.engineV2 ?? true;
 
     /**
      * Editor API history global


### PR DESCRIPTION
### What's Changed
- Default `projectEngineV2` fallback from `false` to `true` in `editor.ts`, aligning the editor client with all backend defaults

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)