### PR TITLE
fix: set Code Editor TypeScript target to ES2020

### DIFF
--- a/src/code-editor/monaco/document.ts
+++ b/src/code-editor/monaco/document.ts
@@ -175,7 +175,7 @@ editor.once('load', () => {
             allowNonTsExtensions: true,
             esModuleInterop: true,
             target: monaco.languages.typescript.ScriptTarget.ES2020,
-            lib: ['es2020', 'dom'],
+            lib: ['es2020', 'dom', 'dom.iterable'],
             paths: {
                 'playcanvas': ['playcanvas.d.ts'],
                 ...monacoImportPaths


### PR DESCRIPTION
## Summary

<img width="1278" height="388" alt="image" src="https://github.com/user-attachments/assets/e27ec77a-9e06-4954-af41-46630210dd8b" />

- `setCompilerOptions` in the Code Editor's Monaco setup was missing `target` and `lib`, causing Monaco's TypeScript language service to fall back to ES5/ES6 defaults. This meant modern APIs like `Array.prototype.includes()` (ES2016) and `Object.entries()` (ES2017) showed type errors.
- Explicitly sets `target` to `ScriptTarget.ES2020` and `lib` to `['es2020', 'dom']` to match the engine's build target.

Fixes #1731

## Test plan

- [x] Open the Code Editor
- [x] Use `Array.prototype.includes()` in a script -- verify no type error
- [x] Use `Object.entries()` in a script -- verify no type error
- [x] Verify general IntelliSense and type checking still works correctly
