### PR TITLE
fix: hide tab progress bar when opening pre-loaded ESM dependency

### DIFF
--- a/src/code-editor/tab-panel/tab-panel.ts
+++ b/src/code-editor/tab-panel/tab-panel.ts
@@ -428,7 +428,9 @@ editor.once('load', () => {
 
         // If the document was already loaded (e.g. as a dependency of another
         // ESM script), documents:load won't fire again. Hide progress immediately.
-        if (isNew && editor.call('documents:get', id) && !editor.call('documents:isLoading', id)) {
+        const doc = editor.call('documents:get', id);
+        const isLoading = editor.call('documents:isLoading', id);
+        if (isNew && doc && !isLoading) {
             toggleProgress(id, false);
         }
     });


### PR DESCRIPTION
## Summary

- Fixes the tab progress bar staying visible forever when opening an ESM script that was previously pre-loaded as a dependency of another ESM script
- Repro: open `b.mjs` (which imports `a.mjs`), close it, then open `a.mjs` -- the progress bar under the tab never hides

## Root Cause

When an ESM script (e.g. `b.mjs`) loads, `documents-load.ts` pre-loads its dependencies (e.g. `a.mjs`) into `documentsIndex` via `loadDocument(a.mjs, false)`. Later, when the user opens `a.mjs` directly, the `select:asset` handler in `documents-load.ts` sees `documentsIndex[a.id]` already exists and takes a fast path -- emitting `documents:focus` instead of calling `loadDocument`. Since `documents:load` never fires again for `a.mjs`, the `tab-panel.ts` listener that hides the progress bar via `toggleProgress(id, false)` never runs.

## Fix

After creating a new tab in `tab-panel.ts`, check whether the document was already loaded (exists in `documentsIndex` and is not currently loading). If so, hide the progress bar immediately since `documents:load` won't fire again.

## Test plan

- [x] Create two ESM scripts where `b.mjs` imports from `a.mjs` (e.g. class inheritance)
- [x] Open `a.mjs` in the Code Editor (progress completes and hides)
- [x] Click `b.mjs` to replace `a.mjs` in the preview tab (progress completes and hides)
- [x] Click `a.mjs` again -- verify the progress bar completes and hides (previously stayed visible)
- [x] Verify non-ESM scripts still work normally
