### PR TITLE
[FIX] Removed checkpoint warning from engine switch popup   

### DIFF
--- a/src/editor/pickers/picker-engine.ts
+++ b/src/editor/pickers/picker-engine.ts
@@ -144,11 +144,6 @@ editor.once('load', () => {
         title.textContent = `Switch to Engine V${engineV2 ? '2' : '1'}?`;
         root.appendChild(title);
 
-        const important = document.createElement('div');
-        important.classList.add('important');
-        important.textContent = 'It is recommended to create a checkpoint before switching engines.';
-        root.appendChild(important);
-
         root.appendChild(createHeader('Engine V1'));
 
         const changesV1 = document.createElement('div');


### PR DESCRIPTION
### What's Changed
- Removed checkpoint warning from engine switch popup

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
