### PR TITLE
[FIX] Use EngineV2 existence for flag configuration

### DIFF
--- a/src/editor/inspector/settings-panels/engine.ts
+++ b/src/editor/inspector/settings-panels/engine.ts
@@ -63,6 +63,11 @@ class EngineSettingsPanel extends BaseSettingsPanel {
                 return;
             }
 
+            // check if value is changing
+            if (value === oldValue) {
+                return;
+            }
+
             // disable switch button if hidden
             if (switchEngine.hidden) {
                 return;

--- a/src/editor/settings/project-settings.ts
+++ b/src/editor/settings/project-settings.ts
@@ -45,7 +45,7 @@ editor.once('load', () => {
         settings.sync.enabled = editor.call('permissions:write');
 
         if (!config.project.settings.hasOwnProperty('engineV2')) {
-            settings.set('engineV2', false);
+            settings.set('engineV2', false, undefined, undefined, true);
         }
 
         if (config.project.settings.hasOwnProperty('useLegacyScripts')) {


### PR DESCRIPTION
### What's Changed
- Uses presence of engineV2 flag to set value explicitly

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
