### PR TITLE
feat: expose new engine properties in editor UI (#1754)

### DIFF
--- a/src/editor/attributes/reference/components/light.ts
+++ b/src/editor/attributes/reference/components/light.ts
@@ -238,6 +238,12 @@ export const fields: AttributeReference[]  = [{
     description: 'The size of the penumbra for PCSS (Percentage Closer Soft Shadows). A larger value produces softer shadow edges. Only applies when shadows are enabled.',
     url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#penumbrasize'
 }, {
+    name: 'light:penumbraFalloff',
+    title: 'penumbraFalloff',
+    subTitle: '{Number}',
+    description: 'The falloff rate for shadow penumbra for PCSS (Percentage Closer Soft Shadows). Controls how quickly the shadow edge transitions from hard to soft. Only applies when shadow type is PCSS.',
+    url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#penumbrafalloff'
+}, {
     name: 'light:layers',
     title: 'layers',
     subTitle: '{Number[]}',

--- a/src/editor/entities/entities-migrations.ts
+++ b/src/editor/entities/entities-migrations.ts
@@ -129,6 +129,11 @@ editor.once('load', () => {
                     entity.set('components.light.penumbraSize', 1);
                 }
 
+                // penumbraFalloff
+                if (!entity.has('components.light.penumbraFalloff')) {
+                    entity.set('components.light.penumbraFalloff', 1);
+                }
+
                 // cookieAsset
                 if (!entity.has('components.light.cookieAsset')) {
                     entity.set('components.light.cookieAsset', null);

--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -278,6 +278,8 @@ const ATTRIBUTES: (Attribute | Divider)[] = [{
             v: SHADOW_VSM_16F, t: 'Variance Shadow Map (16bit)'
         }, {
             v: SHADOW_VSM_32F, t: 'Variance Shadow Map (32bit)'
+        }, {
+            v: SHADOW_PCSS_32F, t: 'PCSS (Soft Shadows)'
         }]
     }
 }, {
@@ -341,6 +343,16 @@ const ATTRIBUTES: (Attribute | Divider)[] = [{
     label: 'Penumbra Size',
     path: 'components.light.penumbraSize',
     reference: 'light:penumbraSize',
+    type: 'number',
+    args: {
+        precision: 2,
+        step: 0.1,
+        min: 0
+    }
+}, {
+    label: 'Penumbra Falloff',
+    path: 'components.light.penumbraFalloff',
+    reference: 'light:penumbraFalloff',
     type: 'number',
     args: {
         precision: 2,
@@ -600,7 +612,9 @@ class LightComponentInspector extends ComponentInspector {
             this._field(field).parent.hidden = !castShadows || shadowTypeVsm;
         });
 
-        this._field('penumbraSize').parent.hidden = !castShadows || shadowType !== SHADOW_PCSS_32F;
+        const shadowTypePcss = shadowType === SHADOW_PCSS_32F;
+        this._field('penumbraSize').parent.hidden = !castShadows || !shadowTypePcss;
+        this._field('penumbraFalloff').parent.hidden = !castShadows || !shadowTypePcss;
 
         this._btnUpdateShadow.hidden = this._field('shadowUpdateMode').value !== SHADOWUPDATE_THISFRAME;
     }


### PR DESCRIPTION
### What's Changed
- Exposed `light.penumbraFalloff` as mentioned in #1754

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
