### PR TITLE
feat: batch of low-risk editor improvements

### DIFF
--- a/sass/code-editor.scss
+++ b/sass/code-editor.scss
@@ -14,6 +14,7 @@ $muted-yellow: #f4a62a;
 $status-error: $bright-red;
 $status-warning: $bright-yellow;
 $status-log: #ccc;
+$link-color: #63b3ed;
 
 html {
     height: 100%;
@@ -618,6 +619,16 @@ strong {
     }
 }
 
+.dst-branch-label {
+    background: rgba(#0b3b76, 0.8);
+    color: #8dbfff;
+    font-size: 11px;
+    font-style: italic;
+    padding: 1px 6px;
+    border-radius: 2px;
+    margin-right: 8px;
+}
+
 .src-branch {
     background: rgba(#15515e, 0.5);
 
@@ -625,6 +636,16 @@ strong {
         background: #1d6d7f;
         border: 1px solid #20292b;
     }
+}
+
+.src-branch-label {
+    background: rgba(#15515e, 0.8);
+    color: #8dd8e5;
+    font-size: 11px;
+    font-style: italic;
+    padding: 1px 6px;
+    border-radius: 2px;
+    margin-right: 8px;
 }
 
 .diff-overlay-hunk {
@@ -646,6 +667,91 @@ strong {
 
 .pcui-tooltip-desc {
     margin: 0;
+}
+
+.markdown-preview {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 50%;
+    height: 100%;
+    overflow-y: auto;
+    padding: 16px 24px;
+    box-sizing: border-box;
+    background: $bcg-primary;
+    color: $text-primary;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    z-index: 5;
+    border-left: 1px solid $bcg-dark;
+
+    &.invisible {
+        display: none;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        color: $text-primary;
+        margin: 16px 0 8px;
+        font-weight: 600;
+    }
+
+    h1 { font-size: 24px; border-bottom: 1px solid $bcg-dark; padding-bottom: 8px; }
+    h2 { font-size: 20px; border-bottom: 1px solid $bcg-dark; padding-bottom: 6px; }
+    h3 { font-size: 16px; }
+
+    p { margin: 8px 0; }
+
+    code {
+        background: $bcg-dark;
+        padding: 2px 5px;
+        border-radius: 3px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+    }
+
+    pre {
+        background: $bcg-dark;
+        padding: 12px;
+        border-radius: 4px;
+        overflow-x: auto;
+
+        code {
+            padding: 0;
+            background: none;
+        }
+    }
+
+    blockquote {
+        border-left: 3px solid $text-dark;
+        margin: 8px 0;
+        padding: 4px 12px;
+        color: $text-dark;
+    }
+
+    a { color: $link-color; }
+
+    ul, ol { padding-left: 24px; }
+
+    table {
+        border-collapse: collapse;
+        margin: 8px 0;
+
+        th, td {
+            border: 1px solid $bcg-dark;
+            padding: 6px 12px;
+        }
+
+        th { background: $bcg-dark; font-weight: 600; }
+    }
+
+    img { max-width: 100%; }
+
+    hr {
+        border: none;
+        border-top: 1px solid $bcg-dark;
+        margin: 16px 0;
+    }
 }
 
 @import 'common/ui-common';

--- a/sass/editor/_editor-asset-animstategraph-inspector.scss
+++ b/sass/editor/_editor-asset-animstategraph-inspector.scss
@@ -156,3 +156,10 @@
 .asset-animstategraph-inspector-state-view-button.active:hover {
     color: $text-active;
 }
+
+#layout-viewport .pcui-graph {
+    .graph-node-input {
+        position: relative;
+        z-index: 2;
+    }
+}

--- a/sass/editor/_editor-attributes-panel.scss
+++ b/sass/editor/_editor-attributes-panel.scss
@@ -1910,6 +1910,10 @@
     }
 }
 
+#layout-attributes .pcui-select-input.pcui-open {
+    z-index: 2;
+}
+
 .pcui-container.inspector-controls {
     overflow: hidden;
 

--- a/sass/editor/_editor-entities-treeview.scss
+++ b/sass/editor/_editor-entities-treeview.scss
@@ -43,8 +43,34 @@
     }
 }
 
-.entities-treeview-user-marker-container {
+.entities-treeview-visibility-toggle {
     margin-left: auto;
+    width: 20px;
+    height: 20px;
+    min-width: 20px;
+    border: none;
+    background: transparent;
+    font-size: 12px;
+    color: $text-dark;
+    opacity: 0;
+    cursor: pointer;
+    flex-shrink: 0;
+
+    &:hover {
+        color: $text-primary;
+    }
+}
+
+.pcui-treeview-item:hover > .pcui-treeview-item-contents .entities-treeview-visibility-toggle {
+    opacity: 1;
+}
+
+.pcui-treeview-item.pcui-disabled > .pcui-treeview-item-contents .entities-treeview-visibility-toggle {
+    opacity: 0.5;
+}
+
+.entities-treeview-user-marker-container {
+    margin-left: 0;
 }
 
 .entities-treeview-user-marker {

--- a/src/code-editor/index.ts
+++ b/src/code-editor/index.ts
@@ -87,6 +87,7 @@ import './monaco/actions';
 import './monaco/search';
 import './monaco/merge';
 import './monaco/diff';
+import './monaco/markdown-preview';
 
 // tab panel
 import './tab-panel/tab-context-menu';
@@ -121,6 +122,7 @@ import './menu-panel/edit/undo-redo';
 import './menu-panel/edit/find-replace';
 import './menu-panel/edit/comment';
 import './menu-panel/edit/preferences';
+import './menu-panel/edit/theme-switch';
 import './menu-panel/selection/menu';
 import './menu-panel/selection/selectAll';
 import './menu-panel/selection/expand-shrink';

--- a/src/code-editor/menu-panel/edit/theme-switch.ts
+++ b/src/code-editor/menu-panel/edit/theme-switch.ts
@@ -1,0 +1,24 @@
+import { MenuItem } from '@playcanvas/pcui';
+
+import { THEMES } from '@/core/constants';
+
+editor.once('load', () => {
+    const menu = editor.call('menu:edit');
+    const settings = editor.call('editor:settings');
+
+    const themeGroup = new MenuItem({
+        text: 'Theme',
+        hasChildren: true
+    });
+    menu.append(themeGroup);
+
+    for (const key of Object.keys(THEMES)) {
+        const themeItem = new MenuItem({
+            text: THEMES[key],
+            onSelect: () => {
+                settings.set('ide.theme', key);
+            }
+        });
+        themeGroup.append(themeItem);
+    }
+});

--- a/src/code-editor/monaco/document.ts
+++ b/src/code-editor/monaco/document.ts
@@ -117,8 +117,11 @@ editor.once('load', () => {
 
         let mode;
         const type = asset.get('type');
+        const filename = asset.get('file.filename') || '';
         if (modes[type]) {
             mode = modes[type];
+        } else if (filename.endsWith('.md')) {
+            mode = 'markdown';
         } else {
             mode = null;
         }

--- a/src/code-editor/monaco/markdown-preview.ts
+++ b/src/code-editor/monaco/markdown-preview.ts
@@ -1,0 +1,63 @@
+import MarkdownIt from 'markdown-it';
+
+interface MonacoModel {
+    getValue(): string;
+}
+
+editor.once('load', () => {
+    const md = new MarkdownIt({ html: true, linkify: true, typographer: true });
+    const panel = editor.call('layout.code');
+
+    const previewContainer = document.createElement('div');
+    previewContainer.id = 'markdown-preview';
+    previewContainer.classList.add('markdown-preview', 'invisible');
+    panel.dom.appendChild(previewContainer);
+
+    let currentAssetId: string | null = null;
+
+    const updatePreview = (content: string) => {
+        previewContainer.innerHTML = md.render(content);
+    };
+
+    editor.on('documents:focus', (id: string) => {
+        const asset = editor.call('assets:get', id);
+        if (!asset) {
+            previewContainer.classList.add('invisible');
+            currentAssetId = null;
+            return;
+        }
+
+        const filename = asset.get('file.filename') || '';
+        if (filename.endsWith('.md')) {
+            currentAssetId = id;
+            previewContainer.classList.remove('invisible');
+        } else {
+            currentAssetId = null;
+            previewContainer.classList.add('invisible');
+        }
+    });
+
+    editor.on('views:change', (id: string, model: MonacoModel) => {
+        if (id === currentAssetId) {
+            updatePreview(model.getValue());
+        }
+    });
+
+    editor.on('views:new', (id: string, model: MonacoModel) => {
+        const asset = editor.call('assets:get', id);
+        if (asset) {
+            const filename = asset.get('file.filename') || '';
+            if (filename.endsWith('.md')) {
+                updatePreview(model.getValue());
+            }
+        }
+    });
+
+    editor.on('documents:close', (id: string) => {
+        if (id === currentAssetId) {
+            currentAssetId = null;
+            previewContainer.classList.add('invisible');
+            previewContainer.innerHTML = '';
+        }
+    });
+});

--- a/src/code-editor/monaco/merge.ts
+++ b/src/code-editor/monaco/merge.ts
@@ -63,7 +63,11 @@ editor.once('load', () => {
                 options: {
                     isWholeLine: true,
                     className: className,
-                    inlineClassName: className
+                    inlineClassName: className,
+                    before: {
+                        content: ` ${branchName} `,
+                        inlineClassName: `${className}-label`
+                    }
                 }
             };
         }

--- a/src/editor/assets/assets-context-menu.ts
+++ b/src/editor/assets/assets-context-menu.ts
@@ -593,6 +593,19 @@ editor.once('load', () => {
         menu.append(menuItemDelete);
     }
 
+    // set as default primitive material
+    const menuItemSetDefaultMaterial = new MenuItem({
+        text: 'Set as Default Primitive Material',
+        icon: 'E315',
+        onSelect: () => {
+            if (currentAsset && currentAsset.get('type') === 'material') {
+                editor.call('localStorage:set', 'editor:defaultPrimitiveMaterialId', currentAsset.get('id'));
+                editor.call('status:text', 'Default primitive material set');
+            }
+        }
+    });
+    menu.append(menuItemSetDefaultMaterial);
+
     // move-to-store
     const menuItemMoveToStore = new MenuItem({
         text: 'Move To Store',
@@ -696,6 +709,9 @@ editor.once('load', () => {
             } else {
                 menuItemDuplicate.hidden = true;
             }
+
+            // default primitive material
+            menuItemSetDefaultMaterial.hidden = currentAsset.get('type') !== 'material';
 
             // edit
             if (!currentAsset.get('source') && ['html', 'css', 'json', 'text', 'script', 'shader'].indexOf(currentAsset.get('type')) !== -1) {
@@ -877,6 +893,7 @@ editor.once('load', () => {
             menuItemCreateSlicedSprite.hidden = true;
             menuItemMoveToStore.hidden = true;
             menuItemOpenInViewer.hidden = true;
+            menuItemSetDefaultMaterial.hidden = true;
         }
     });
 

--- a/src/editor/assets/assets-textures-compress.ts
+++ b/src/editor/assets/assets-textures-compress.ts
@@ -32,12 +32,6 @@ class TextureCompressor {
             return false;
         }
 
-        // FIXME: for some reason we disallow rgbm to be compressed
-        const rgbm = asset.get('data.rgbm');
-        if (rgbm) {
-            return false;
-        }
-
         return true;
     }
 

--- a/src/editor/entities/entities-menu.ts
+++ b/src/editor/entities/entities-menu.ts
@@ -121,7 +121,9 @@ editor.once('load', () => {
         const component = 'render';
         data.components[component] = editor.call('components:getDefault', component);
         data.components[component].type = type;
-        data.components.render.materialAssets = [null];
+        const defaultMaterialId = editor.call('localStorage:get', 'editor:defaultPrimitiveMaterialId');
+        const materialExists = defaultMaterialId && editor.call('assets:get', defaultMaterialId);
+        data.components.render.materialAssets = [materialExists ? parseInt(defaultMaterialId, 10) : null];
 
         applyAdditions(data, additions);
 

--- a/src/editor/entities/entities-treeview.ts
+++ b/src/editor/entities/entities-treeview.ts
@@ -1,5 +1,5 @@
 import type { Observer, ObserverList } from '@playcanvas/observer';
-import { Element, TreeView, TreeViewItem, Container } from '@playcanvas/pcui';
+import { Button, Element, TreeView, TreeViewItem, Container } from '@playcanvas/pcui';
 
 import type { DropTarget } from '@/common/pcui/element/element-drop-target';
 
@@ -12,6 +12,7 @@ const CLASS_TEMPLATE_INSTANCE_CHILD = `${CLASS_TEMPLATE_INSTANCE}-child`;
 const CLASS_HIGHLIGHT = `${CLASS_ROOT}-highlight`;
 const CLASS_USER_SELECTION_MARKER = `${CLASS_ROOT}-user-marker`;
 const CLASS_USER_SELECTION_MARKER_CONTAINER = `${CLASS_USER_SELECTION_MARKER}-container`;
+const CLASS_VISIBILITY_TOGGLE = `${CLASS_ROOT}-visibility-toggle`;
 const CLASS_FILTERING = 'pcui-treeview-filtering';
 const CLASS_FILTER_RESULT = `${CLASS_FILTERING}-result`;
 
@@ -812,6 +813,22 @@ class EntitiesTreeView extends TreeView {
                 }
             }
         });
+
+        // visibility toggle
+        const visibilityBtn = new Button({
+            class: CLASS_VISIBILITY_TOGGLE,
+            icon: entity.get('enabled') ? 'E133' : 'E132'
+        });
+        visibilityBtn.dom.addEventListener('click', (evt) => {
+            evt.stopPropagation();
+            if (!editor.call('permissions:write')) return;
+            const newEnabled = !entity.get('enabled');
+            entity.set('enabled', newEnabled);
+        });
+        events.push(entity.on('enabled:set', (value) => {
+            visibilityBtn.icon = value ? 'E133' : 'E132';
+        }));
+        treeViewItem._containerContents.append(visibilityBtn);
 
         // container for user selection markers
         treeViewItem._containerUsers = new Container({

--- a/src/editor/inspector/assets/animstategraph-layers.ts
+++ b/src/editor/inspector/assets/animstategraph-layers.ts
@@ -90,6 +90,18 @@ class AnimstategraphLayers extends Panel {
         });
     }
 
+    _getUniqueLayerName(baseName: string): string {
+        const layers = this._assets[0].get('data.layers');
+        const existingNames = new Set(Object.values(layers).map((l: Record<string, unknown>) => l.name));
+        let candidate = baseName;
+        let suffix = 0;
+        while (existingNames.has(candidate)) {
+            suffix++;
+            candidate = `${baseName} ${suffix}`;
+        }
+        return candidate;
+    }
+
     _addNewLayer(name?: string) {
 
         const data = this._assets[0].get('data');
@@ -153,7 +165,7 @@ class AnimstategraphLayers extends Panel {
         const maxKey = Math.max(...Object.keys(layers));
         const key = Number.isFinite(maxKey) ? maxKey + 1 : 0;
         layers[key] = {
-            name: name || 'New Layer',
+            name: name || this._getUniqueLayerName('New Layer'),
             states: [startStateId, anyStateId, endStateId, stateId],
             transitions: [transitionId],
             blendType: 'OVERWRITE',
@@ -379,6 +391,19 @@ class AnimstategraphLayers extends Panel {
             });
 
             attributesInspector.getField(`data.layers.${layerKey}.name`).enabled = i > 0;
+
+            if (i > 0) {
+                const nameField = attributesInspector.getField(`data.layers.${layerKey}.name`);
+                nameField.onValidate = (value: string) => {
+                    const layers = this._assets[0].get('data.layers');
+                    for (const otherKey of Object.keys(layers)) {
+                        if (otherKey !== String(layerKey) && layers[otherKey].name === value) {
+                            return false;
+                        }
+                    }
+                    return true;
+                };
+            }
 
             this._assetEvents = [];
             this._assetEvents.push(

--- a/src/editor/inspector/assets/cubemap.ts
+++ b/src/editor/inspector/assets/cubemap.ts
@@ -187,6 +187,7 @@ class CubemapAssetInspector extends Container {
 
         let width = 0;
         let height = 0;
+        let format: string | null = null;
 
         for (let i = 0; i < 6; i++) {
             const asset = editor.call('assets:get', faces[i]);
@@ -212,9 +213,15 @@ class CubemapAssetInspector extends Container {
             if (i === 0) {
                 width = w;
                 height = h;
+                format = asset.get('meta.type') || null;
             } else {
                 if (width !== w || height !== h) {
                     return 'face textures should have same resolution';
+                }
+
+                const faceFormat = asset.get('meta.type') || null;
+                if (format && faceFormat && format !== faceFormat) {
+                    return 'face textures should have the same pixel format';
                 }
             }
         }

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1241,7 +1241,7 @@ const BULK_SLOTS = {
     'iridescence': ['ir', 'iridescence'],
     'iridescenceThickness': ['irth', 'iridescenceThickness'],
     'metalness': ['m', 'met', 'metal', 'metalness', 'gma', 'gmat', 'gmao', 'gmaa', 'rma', 'rmat', 'rmao', 'rmaa'],
-    'gloss': ['g', 'gloss', 'glossiness', 'gma', 'gmat', 'gmao', 'gmaa', 'rma', 'rmat', 'rmao', 'rmaa'],
+    'gloss': ['g', 'gloss', 'glossiness', 'rough', 'roughness', 'gma', 'gmat', 'gmao', 'gmaa', 'rma', 'rmat', 'rmao', 'rmaa'],
     'clearCoat': ['cc', 'clearcoat'],
     'clearCoatGloss': ['ccg', 'clearcoatgloss'],
     'clearCoatNormal': ['ccn', 'clearcoatnormal'],

--- a/src/editor/inspector/attributes-inspector.ts
+++ b/src/editor/inspector/attributes-inspector.ts
@@ -371,6 +371,8 @@ class AttributesInspector extends Container {
                         labelAlignTop: attr.type === 'assets' || attr.type.startsWith('array') || attr.type === 'layers' || attr.type === 'json'
                     });
 
+                    labelGroup.label.dom.title = attr.label;
+
                     // If the attribute is a boolean named 'enabled' it will be added as as toggle field to the header, so we ignore it here
                     if (!isEnabledAttribute(attr)) {
                         this.append(labelGroup);
@@ -382,6 +384,11 @@ class AttributesInspector extends Container {
                     let tooltipData;
                     if (attr.reference) {
                         tooltipData = editor.call('attributes:reference:get', attr.reference);
+                        if (tooltipData && attr.label && tooltipData.title !== attr.label) {
+                            tooltipData = Object.assign({}, tooltipData, {
+                                subTitle: tooltipData.subTitle ? `${attr.label} — ${tooltipData.subTitle}` : attr.label
+                            });
+                        }
                     } else if (attr.tooltip) {
                         tooltipData = attr.tooltip;
                     }

--- a/src/editor/inspector/components/element.ts
+++ b/src/editor/inspector/components/element.ts
@@ -802,6 +802,9 @@ class ElementComponentInspector extends ComponentInspector {
         });
 
         this._field('fontAsset').hidden = !isText;
+        if (!isText && this._field('fontAsset').value) {
+            this._field('fontAsset').value = null;
+        }
         this._field('maxLines').parent.hidden = !isText || !this._field('wrapLines').value;
         this._field('localized').parent.hidden = !isText;
         this._field('text').parent.hidden = !isText || this._field('localized').value || this._field('localized').class.contains(CLASS_MULTIPLE_VALUES);

--- a/src/editor/inspector/components/script.ts
+++ b/src/editor/inspector/components/script.ts
@@ -275,6 +275,14 @@ class ScriptInspector extends Panel {
         this._editorEvents.push(editor.on(`assets:scripts[${this._scriptName}]:attribute:move`, this._onMoveAttribute.bind(this)));
         this._editorEvents.push(editor.on(`assets:scripts[${this._scriptName}]:primary:set`, this._onPrimaryScriptSet.bind(this)));
         this._editorEvents.push(editor.on(`assets:scripts[${this._scriptName}]:primary:unset`, this._onPrimaryScriptUnset.bind(this)));
+
+        if (this._asset) {
+            this._editorEvents.push(this._asset.on('name:set', (name: string) => {
+                if (name && this._labelTitle) {
+                    this._labelTitle.text = name;
+                }
+            }));
+        }
     }
 
     _initializeScriptAttributes() {

--- a/src/editor/inspector/components/sprite.ts
+++ b/src/editor/inspector/components/sprite.ts
@@ -220,6 +220,18 @@ class SpriteClipInspector extends Panel {
 
         const fieldName = this._inspector.getField(this._getPathTo('name'));
         fieldName.on('change', this._onClipNameChange.bind(this));
+
+        const fieldSpriteAsset = this._inspector.getField(this._getPathTo('spriteAsset'));
+        if (fieldSpriteAsset) {
+            fieldSpriteAsset.on('change', (value: number) => {
+                if (value && !fieldName.value) {
+                    const asset = editor.call('assets:get', value);
+                    if (asset) {
+                        fieldName.value = asset.get('name');
+                    }
+                }
+            });
+        }
     }
 
     _getPathTo(field: string) {

--- a/src/editor/pickers/picker-curve.ts
+++ b/src/editor/pickers/picker-curve.ts
@@ -690,6 +690,12 @@ editor.once('load', () => {
             const x = gridLeft() + gridWidth() * i / 10;
             drawLine([x, gridTop()], [x, gridBottom()], colors.gridLines);
         }
+
+        // draw zero reference line when visible
+        if (verticalTopValue > 0 && verticalBottomValue < 0) {
+            const zeroY = gridTop() + gridHeight() * (0 - verticalTopValue) / (verticalBottomValue - verticalTopValue);
+            drawLine([gridLeft(), zeroY], [gridRight(), zeroY], colors.highlightedLine);
+        }
     }
 
     function gridWidth() {

--- a/src/editor/pickers/project-management/picker-modal-new-project.ts
+++ b/src/editor/pickers/project-management/picker-modal-new-project.ts
@@ -554,6 +554,13 @@ editor.once('load', () => {
         formInputs.legacy = currentUser.flags.hasLegacyScripts ? false : null;
         buildSidebar();
         overlay.hidden = false;
+        const nameInput = formContent.dom.querySelector('input[type="text"]') as HTMLInputElement;
+        if (nameInput) {
+            setTimeout(() => {
+                nameInput.focus();
+                nameInput.select();
+            }, 0);
+        }
     });
 
 });

--- a/src/editor/pickers/version-control/picker-version-control-merge-branches.ts
+++ b/src/editor/pickers/version-control/picker-version-control-merge-branches.ts
@@ -41,7 +41,7 @@ editor.once('load', () => {
         }
     });
     panel.createTargetCheckpoint = true;
-    panel.createSourceCheckpoint = false;
+    panel.createSourceCheckpoint = true;
     panel.class.add('merge-branches');
 
     boxFrom.on('createSourceCheckpoint', (value) => {

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -734,6 +734,19 @@ editor.once('load', () => {
         }
     });
 
+    // copy branch id
+    const menuBranchesCopyId = new MenuItem({
+        text: 'Copy Branch ID'
+    });
+    menuBranches.append(menuBranchesCopyId);
+
+    menuBranchesCopyId.on('select', () => {
+        if (contextBranch) {
+            navigator.clipboard.writeText(contextBranch.id);
+            editor.call('status:text', 'Branch ID copied to clipboard');
+        }
+    });
+
     // vc graph
     const menuVcGraph = new MenuItem({
         text: 'Version Control Graph'

--- a/src/editor/pickers/version-control/ui/version-control-side-panel-box.ts
+++ b/src/editor/pickers/version-control/ui/version-control-side-panel-box.ts
@@ -74,6 +74,7 @@ class VersionControlSidePanelBox extends Events {
                 'Create checkpoint first?',
                 args.sourceCheckpointHelp
             );
+            this.checkboxSourceCheckpoint.value = true;
 
             this.checkboxSourceCheckpoint.on('change', (value) => {
                 this.emit('createSourceCheckpoint', value);
@@ -200,7 +201,7 @@ class VersionControlSidePanelBox extends Events {
         }
         if (this.panelSourceCheckpoint) {
             panel.remove(this.panelSourceCheckpoint);
-            this.checkboxSourceCheckpoint.value = false;
+            this.checkboxSourceCheckpoint.value = true;
         }
         if (this.panelSourceClose) {
             panel.remove(this.panelSourceClose);

--- a/src/editor/toolbar/toolbar-launch.ts
+++ b/src/editor/toolbar/toolbar-launch.ts
@@ -255,6 +255,25 @@ editor.once('load', () => {
         tooltipBundles.class.add('launch-tooltip');
     }
 
+    // SharedArrayBuffer
+    const projectSettings = editor.call('settings:project');
+    const optionSAB = createOption('sab', 'SharedArrayBuffer');
+    optionSAB.value = !!projectSettings.get('enableSharedArrayBuffer');
+    projectSettings.on('enableSharedArrayBuffer:set', (value: boolean) => {
+        if (value !== optionSAB.value) {
+            optionSAB.value = value;
+        }
+    });
+    optionSAB.on('change', (value: boolean) => {
+        projectSettings.set('enableSharedArrayBuffer', value);
+    });
+    LegacyTooltip.attach({
+        target: optionSAB.parent.element,
+        text: 'Enable SharedArrayBuffer for the launched application.',
+        align: 'right',
+        root: root
+    }).class.add('launch-tooltip');
+
     // mini-stats
     const optionMiniStats = createOption('ministats', 'Mini stats');
     optionMiniStats.value = settings.get('editor.launchMinistats');

--- a/src/editor/toolbar/toolbar-render.ts
+++ b/src/editor/toolbar/toolbar-render.ts
@@ -1,5 +1,7 @@
 import { BooleanInput, Button, Container, Label, RadioButton } from '@playcanvas/pcui';
 import {
+    CULLFACE_BACK,
+    CULLFACE_NONE,
     RENDERSTYLE_SOLID,
     RENDERSTYLE_WIREFRAME,
     SHADERPASS_ALBEDO,
@@ -115,6 +117,25 @@ editor.once('viewport:load', (app) => {
             for (let j = 0; j < layer.meshInstances.length; j++) {
                 const meshInstance = layer.meshInstances[j];
                 meshInstance.renderStyle = renderStyle;
+            }
+        }
+        editor.call('viewport:render');
+    });
+
+    // Backface Culling
+    let cullBackfaces = true;
+    createCheckbox('Cull Backfaces', (state) => {
+        cullBackfaces = !state;
+        const cull = cullBackfaces ? CULLFACE_BACK : CULLFACE_NONE;
+        const sceneLayers = app.scene.layers.layerList;
+        const gizmoLayers = editor.call('gizmo:layers:list');
+        for (let i = 0; i < sceneLayers.length; i++) {
+            const layer = sceneLayers[i];
+            if (gizmoLayers.some(gizmoLayer => gizmoLayer.id === layer.id)) {
+                continue;
+            }
+            for (let j = 0; j < layer.meshInstances.length; j++) {
+                layer.meshInstances[j].material.cull = cull;
             }
         }
         editor.call('viewport:render');

--- a/src/editor/viewport/camera/camera-preview.ts
+++ b/src/editor/viewport/camera/camera-preview.ts
@@ -120,9 +120,13 @@ editor.once('load', () => {
         if (pinnedCamera) {
             pinnedCamera = null;
             btnPin.class.remove('active');
+            editor.call('localStorage:set', 'editor:camera:pinnedEntity', null);
         } else {
             pinnedCamera = selectedEntity;
             btnPin.class.add('active');
+            if (selectedEntity) {
+                editor.call('localStorage:set', 'editor:camera:pinnedEntity', selectedEntity.get('resource_id'));
+            }
         }
 
         updateCameraState();
@@ -141,6 +145,17 @@ editor.once('load', () => {
 
     editor.once('viewport:load', (application: import('playcanvas').Application) => {
         app = application;
+
+        // restore pinned camera from previous session
+        const pinnedEntityId = editor.call('localStorage:get', 'editor:camera:pinnedEntity');
+        if (pinnedEntityId) {
+            const entity = editor.call('entities:get', pinnedEntityId);
+            if (entity && entity.has('components.camera')) {
+                pinnedCamera = entity;
+                btnPin.class.add('active');
+                updateCameraState();
+            }
+        }
     });
 
     editor.on('permissions:writeState', (state: boolean) => {

--- a/src/editor/viewport/camera/camera.ts
+++ b/src/editor/viewport/camera/camera.ts
@@ -295,6 +295,19 @@ editor.once('load', () => {
             }
         }
 
+        // restore persisted camera mode
+        const storedMode = editor.call('localStorage:get', 'editor:camera:mode');
+        if (storedMode && editorCameras[storedMode]) {
+            editor.call('camera:set', editorCameras[storedMode]);
+        }
+
+        // persist camera mode on change
+        editor.on('camera:change', (camera: import('playcanvas').Entity) => {
+            if (camera?.__editorCamera && camera.__editorName) {
+                editor.call('localStorage:set', 'editor:camera:mode', camera.__editorName);
+            }
+        });
+
         // when layers change make sure that our Editor cameras have them
         projectSettings.on('layerOrder:insert', (value: import('@playcanvas/observer').Observer) => {
             const id = parseInt(value.get('layer'), 10);

--- a/src/editor/viewport/gizmo/gizmo-light.ts
+++ b/src/editor/viewport/gizmo/gizmo-light.ts
@@ -96,8 +96,9 @@ editor.once('load', () => {
                 type += 'close';
             }
 
-            // area lights
-            if (light.shape !== LIGHTSHAPE_PUNCTUAL) {
+            // area lights (only show shape gizmo when area lights are enabled in project settings)
+            const areaLightsEnabled = editor.call('sceneSettings')?.get('render.lightingAreaLightsEnabled');
+            if (areaLightsEnabled && light.shape !== LIGHTSHAPE_PUNCTUAL) {
                 switch (light.shape) {
                     case LIGHTSHAPE_RECT:
                         type = 'rectangle';

--- a/src/editor/viewport/viewport-drop-model.ts
+++ b/src/editor/viewport/viewport-drop-model.ts
@@ -14,6 +14,13 @@ editor.once('load', () => {
         return;
     } // webgl not available
 
+    let lastSelectedEntity: InstanceType<typeof Entity> | null = null;
+    editor.on('selector:change', (type: string, items: unknown[]) => {
+        if (type === 'entity' && items.length) {
+            lastSelectedEntity = items[0] as InstanceType<typeof Entity>;
+        }
+    });
+
     const aabb = new BoundingBox();
     const vecA = new Vec3();
     const vecB = new Vec3();
@@ -78,10 +85,12 @@ editor.once('load', () => {
                 return;
             }
 
-            // parent
+            // parent: use current entity selection, or fall back to last selected entity
             let parent = null;
             if (editor.api.globals.selection.items[0] instanceof Entity) {
                 parent = editor.api.globals.selection.items[0];
+            } else if (lastSelectedEntity) {
+                parent = lastSelectedEntity;
             } else {
                 parent = editor.api.globals.entities.root;
             }

--- a/src/editor/viewport/viewport-drop-template.ts
+++ b/src/editor/viewport/viewport-drop-template.ts
@@ -13,6 +13,13 @@ editor.once('load', () => {
         return;
     } // webgl not available
 
+    let lastSelectedEntityObs = null;
+    editor.on('selector:change', (type: string, items: unknown[]) => {
+        if (type === 'entity' && items.length) {
+            lastSelectedEntityObs = items[0];
+        }
+    });
+
     editor.call('drop:target', {
         ref: canvas,
         filter: (type: string, data: { id: string | number } | { ids: string[] }): boolean => {
@@ -66,10 +73,12 @@ editor.once('load', () => {
                 return;
             }
 
-            // parent
+            // parent: use current entity selection, or fall back to last selected entity
             let parent = null;
             if (editor.call('selector:type') === 'entity') {
                 parent = editor.call('selector:items')[0];
+            } else if (lastSelectedEntityObs) {
+                parent = lastSelectedEntityObs;
             }
 
             if (!parent) {

--- a/src/editor/viewport/viewport-focus.ts
+++ b/src/editor/viewport/viewport-focus.ts
@@ -71,6 +71,23 @@ editor.once('load', () => {
             return;
         }
 
+        // expand collapsed parents in hierarchy so focused entities are visible
+        const items = editor.call('selector:items');
+        if (items) {
+            const list = items instanceof Array ? items : [items];
+            for (const item of list) {
+                let parentId = item.get?.('parent');
+                while (parentId) {
+                    const treeItem = editor.call('entities:panel:get', parentId);
+                    if (treeItem && !treeItem.open) {
+                        treeItem.open = true;
+                    }
+                    const parentEntity = editor.call('entities:get', parentId);
+                    parentId = parentEntity?.get('parent');
+                }
+            }
+        }
+
         const camera = editor.call('camera:current');
 
         // aabb


### PR DESCRIPTION
Fixes #931, #879, #919, #807, #1020, #1060, #1291, #1275, #1156, #1330, #1009, #1043, #1207, #1014, #864, #1057, #1127, #1496, #257, #828, #1102, #920, #990, #964, #1093, #1152

## Summary

Batch of ~25 low-risk, frontend-only improvements:

- **Version control**: default checkpoint on merge, copy branch ID, branch names in diff view
- **UI**: auto-focus project name, comma-to-dot number parsing, relative math ops on number fields, z-index fixes
- **Inspector**: attribute label tooltips, font cleanup on element type change, cubemap format validation, sprite clip auto-naming, script name propagation, roughness texture auto-assign
- **Viewport**: persist camera mode and pinned camera, focus expands hierarchy, area light gizmo toggle, drag-drop parents to selected entity, curve zero line, SAB launch option
- **Assets**: remove RGBM compression restriction, default primitive material preference
- **Animation**: unique anim layer names with duplicate validation
- **Code editor**: theme switcher menu, markdown preview for .md files