### PR TITLE
fix: rename external scripts label to clarify count field

### DIFF
--- a/src/editor/inspector/settings-panels/external-scripts.ts
+++ b/src/editor/inspector/settings-panels/external-scripts.ts
@@ -4,7 +4,7 @@ import type { Attribute } from '../attribute.type.d';
 const ATTRIBUTES: Attribute[] = [
     {
         observer: 'projectSettings',
-        label: 'URLs',
+        label: 'Number of URLs',
         type: 'array:select',
         path: 'externalScripts',
         alias: 'project.externalScripts',


### PR DESCRIPTION
## Summary
- Renames the External Scripts settings panel label from **URLs** to **Number of URLs**
- Clarifies that the adjacent numeric field controls how many URL text inputs are displayed, preventing users from trying to paste a URL into the count field

Fixes #1067