### PR TITLE
fix: resolve 'no view yet' warning when focusing documents in Code Editor

### DIFF
--- a/src/code-editor/documents/documents-load.ts
+++ b/src/code-editor/documents/documents-load.ts
@@ -137,7 +137,9 @@ editor.once('load', () => {
 
         // if already loaded just focus it
         if (documentsIndex[id]) {
-            editor.emit('documents:focus', id);
+            if (!documentsIndex[id].isLoading) {
+                editor.emit('documents:focus', id);
+            }
             return;
         }
 

--- a/src/code-editor/urls.ts
+++ b/src/code-editor/urls.ts
@@ -54,7 +54,7 @@ editor.once('load', () => {
     // Select tabs when ready
     const focusedParam = new URLSearchParams(window.location.search).get('focused');
     const focusedAssetId = focusedParam && config.tabs.includes(parseInt(focusedParam, 10)) ?
-        focusedParam :
+        parseInt(focusedParam, 10) :
         config.tabs[config.tabs.length - 1];
 
     config.tabs.forEach(tab => editor.call('integration:selectWhenReady', tab));


### PR DESCRIPTION
## Summary

- Fixes a number/string type mismatch in `urls.ts` where `focusedAssetId` was a string (from `URLSearchParams.get()`) but `config.tabs` contains numbers. This caused the dedup check in `integration:selectWhenReady` to fail (`275082230 === '275082230'` is `false`), resulting in the same asset being queued twice.
- The double-queued asset was processed twice during initial load: the first call starts `loadDocument()`, and the second finds `documentsIndex[id]` already set and emits `documents:focus` before the ShareDB doc has loaded and the Monaco view was created — producing the "Requested to focus document that has no view yet" warning.
- Adds a defensive `isLoading` guard in `documents-load.ts` to prevent `documents:focus` from being emitted while a document is still loading, since the existing `doc.on('load')` callback handles focus once the view is ready.

Fixes #1217

## Test plan

- [x] Open the Code Editor with a `.mjs` script tab focused (URL has `tabs=...&focused=...`)
- [x] Verify the "Requested to focus document that has no view yet" console warning no longer appears
- [x] Verify the `.mjs` file loads and displays correctly in the Monaco editor
- [x] Verify `.js` script files continue to load and focus correctly
- [x] Verify switching between tabs works as expected
