### PR TITLE
fix: resolve invalid URL error in texture format conversion

### DIFF
--- a/src/texture-convert/index.ts
+++ b/src/texture-convert/index.ts
@@ -37,9 +37,14 @@ export const convert = async (frontendURL, buffer, sourceFormat, targetFormat): 
     // The URL is unused since we supply a pre-compiled WebAssembly.Module via instantiateWasm,
     // but without locateFile the new URL() call still executes and throws.
     // For the PNG codec (wasm-bindgen), the second argument is harmlessly ignored.
-    const moduleOverrides = { locateFile: (path: string) => path };
-    await initEncode(encodeBinary, moduleOverrides);
-    await initDecode(decodeBinary, moduleOverrides);
+    const encodeOverrides = {
+        locateFile: (path: string) => `${frontendURL}wasm/codecs/${targetFormat}/${path}`,
+    };
+    const decodeOverrides = {
+        locateFile: (path: string) => `${frontendURL}wasm/codecs/${sourceFormat}/${path}`,
+    };
+    await initEncode(encodeBinary, encodeOverrides);
+    await initDecode(decodeBinary, decodeOverrides);
 
     const decoded = await decode(buffer);
     const encoded = await encode(decoded) as any;


### PR DESCRIPTION
Pass locateFile module override to @jsquash codec init calls to prevent Emscripten-generated code from executing new URL(wasm, import.meta.url) which fails in the bundled worker context. The WASM binary URL is unused since a pre-compiled WebAssembly.Module is supplied via instantiateWasm, but the new URL() call still runs and throws without this workaround.

Fixes WebP, AVIF, and JPEG texture conversion. The PNG codec (wasm-bindgen) is unaffected and safely ignores the extra argument.

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
