### PR TITLE
[CHORE] Update playcanvas to 2.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.16.1",
+        "playcanvas": "2.16.2",
         "postcss": "8.5.6",
         "rollup": "4.57.1",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8473,9 +8473,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.16.1.tgz",
-      "integrity": "sha512-3Ve1sTJ7drmc5OUNCIITigk/mranENJynN5pd0DXF+AIKg2WNYp5mJyP/FoWG5rLJl7XoxR3ngcIwtyBd4L//A==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.16.2.tgz",
+      "integrity": "sha512-wroCTsDbhooKBAJKC3QkNV2p/wuviRA5zxCNZVoYWGT4A81thlw4knTPPg+8RniaaQjbUmshJfvxzyX2i5TApQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.16.1",
+    "playcanvas": "2.16.2",
     "postcss": "8.5.6",
     "rollup": "4.57.1",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
### What's Changed
- Update `playcanvas` dependency from 2.16.1 to 2.16.2

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)