### PR TITLE
feat: add Show/Hide options to hierarchy context menu

### DIFF
--- a/sass/editor/_editor-entities-treeview.scss
+++ b/sass/editor/_editor-entities-treeview.scss
@@ -102,6 +102,24 @@
     }
 }
 
+.entities-context-menu-hide {
+    .pcui-menu-item-content > .pcui-label:not(.pcui-menu-item-shortcut)[data-icon] {
+        position: relative;
+
+        &::after {
+            content: '';
+            position: absolute;
+            left: -2px;
+            width: calc(1em + 4px);
+            top: calc(50% - 2px);
+            height: 2px;
+            background: currentcolor;
+            transform: rotate(-45deg);
+            pointer-events: none;
+        }
+    }
+}
+
 .entities-treeview-user-marker-container {
     flex-shrink: 0;
 }

--- a/src/editor/entities/entities-context-menu.ts
+++ b/src/editor/entities/entities-context-menu.ts
@@ -182,6 +182,43 @@ editor.once('load', () => {
         });
 
         menuData.push({
+            text: 'Show',
+            icon: 'E117',
+            onIsVisible: function () {
+                for (let i = 0; i < items.length; i++) {
+                    if (editor.call('entities:visibility:isHidden', items[i].get('resource_id'))) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            onSelect: function () {
+                for (let i = 0; i < items.length; i++) {
+                    editor.call('entities:visibility:set', items[i].get('resource_id'), false);
+                }
+            }
+        });
+
+        menuData.push({
+            text: 'Hide',
+            icon: 'E117',
+            class: 'entities-context-menu-hide',
+            onIsVisible: function () {
+                for (let i = 0; i < items.length; i++) {
+                    if (!editor.call('entities:visibility:isHidden', items[i].get('resource_id'))) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            onSelect: function () {
+                for (let i = 0; i < items.length; i++) {
+                    editor.call('entities:visibility:set', items[i].get('resource_id'), true);
+                }
+            }
+        });
+
+        menuData.push({
             text: 'Copy',
             icon: 'E351',
             shortcut: formatShortcut(`${ctrl}+C`),


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/55a452bb-848a-4a56-a80c-4e65b168bb67

- Adds **Show** and **Hide** options to the hierarchy panel context menu for controlling viewport-only entity visibility
- Mirrors the existing Enable/Disable pattern: Show appears when at least one selected entity is hidden, Hide when at least one is shown, and both for mixed visibility states
- The Hide menu item icon displays the eye (E117) with a diagonal strikethrough, matching the existing visibility column visual

## Test plan

- [x] Right-click a visible entity in the hierarchy -- only **Hide** should appear
- [x] Right-click a hidden entity -- only **Show** should appear
- [x] Select multiple entities with mixed visibility -- both **Show** and **Hide** should appear
- [x] Click Show/Hide and verify the viewport visibility toggles correctly
- [x] Verify the Hide icon strikethrough line is visually centered over the eye icon