### PR TITLE
fix: support undo/redo for hierarchy viewport visibility toggle

### DIFF
--- a/src/editor/entities/entities-context-menu.ts
+++ b/src/editor/entities/entities-context-menu.ts
@@ -193,9 +193,7 @@ editor.once('load', () => {
                 return false;
             },
             onSelect: function () {
-                for (let i = 0; i < items.length; i++) {
-                    editor.call('entities:visibility:set', items[i].get('resource_id'), false);
-                }
+                editor.call('entities:visibility:set', items.map((item: any) => item.get('resource_id')), false);
             }
         });
 
@@ -212,9 +210,7 @@ editor.once('load', () => {
                 return false;
             },
             onSelect: function () {
-                for (let i = 0; i < items.length; i++) {
-                    editor.call('entities:visibility:set', items[i].get('resource_id'), true);
-                }
+                editor.call('entities:visibility:set', items.map((item: any) => item.get('resource_id')), true);
             }
         });
 

--- a/src/editor/entities/entities-viewport-visibility.ts
+++ b/src/editor/entities/entities-viewport-visibility.ts
@@ -10,12 +10,7 @@ editor.once('load', () => {
         return hiddenEntities.has(resourceId);
     });
 
-    editor.method('entities:visibility:set', (resourceId: string, hidden: boolean) => {
-        const wasHidden = hiddenEntities.has(resourceId);
-        if (wasHidden === hidden) {
-            return;
-        }
-
+    const applyOne = (resourceId: string, hidden: boolean) => {
         if (hidden) {
             hiddenEntities.add(resourceId);
         } else {
@@ -33,6 +28,42 @@ editor.once('load', () => {
         }
 
         editor.emit('entities:visibility:changed', resourceId, hidden);
+    };
+
+    editor.method('entities:visibility:set', (resourceIds: string | string[], hidden: boolean, history: boolean = true) => {
+        const ids = Array.isArray(resourceIds) ? resourceIds : [resourceIds];
+        const changed: string[] = [];
+        for (const id of ids) {
+            if (hiddenEntities.has(id) !== hidden) {
+                changed.push(id);
+            }
+        }
+        if (!changed.length) {
+            return;
+        }
+
+        if (history) {
+            editor.api.globals.history.add({
+                name: 'entities.visibility',
+                combine: false,
+                undo: () => {
+                    for (const id of changed) {
+                        applyOne(id, !hidden);
+                    }
+                    editor.call('viewport:render');
+                },
+                redo: () => {
+                    for (const id of changed) {
+                        applyOne(id, hidden);
+                    }
+                    editor.call('viewport:render');
+                }
+            });
+        }
+
+        for (const id of changed) {
+            applyOne(id, hidden);
+        }
         editor.call('viewport:render');
     });
 


### PR DESCRIPTION
## Summary

- The Show/Hide (eye icon) in the Hierarchy panel did not integrate with the editor's undo/redo history. Toggling viewport visibility — via the eye icon or the context menu — can now be undone and redone.
- Batch operations from the context menu (Show/Hide on multiple selected entities) produce a single undo step.
- Redundant per-entity viewport renders during batch operations are eliminated — only one render call is issued.

## Changes

### `entities-viewport-visibility.ts`

- Extracted per-entity mutation into a local `applyOne` helper (updates the `hiddenEntities` set, syncs the viewport entity, emits the change event — but does not trigger a render).
- Generalized `entities:visibility:set` to accept `string | string[]`. It filters to entities whose state actually changes, optionally records a single history action, applies all mutations, and issues one `viewport:render` call.
- Removed the separate `entities:visibility:setBatch` method — `set` now handles both single and batch cases.

### `entities-context-menu.ts`

- Show and Hide `onSelect` handlers now pass an array of resource IDs directly to `entities:visibility:set`, replacing the manual loop.

## Test plan

- [x] Select an entity, click the eye icon to hide it, press Ctrl+Z — entity reappears
- [x] Press Ctrl+Y — entity is hidden again
- [x] Select multiple entities, right-click > Hide, press Ctrl+Z — all entities reappear in one step
- [x] Right-click > Show on hidden entities, Ctrl+Z — all re-hidden in one step
