### PR TITLE
chore: remove @playcanvas/editor-api npm dep from test-suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test/editor-api/dist
 /test-suite/playwright-report
 /test-suite/blob-report
 /test-suite/playwright/.cache
+/test-suite/.editor-api-types

--- a/src/editor-api/tsconfig.types.json
+++ b/src/editor-api/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "noEmit": false,
+        "rootDir": ".",
+        "outDir": "../../test-suite/.editor-api-types"
+    },
+    "include": ["."]
+}

--- a/test-suite/package-lock.json
+++ b/test-suite/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@playcanvas/editor-api": "^1.1.28",
         "@playcanvas/eslint-config": "2.1.0",
         "@playcanvas/observer": "1.7.1",
         "@playwright/test": "^1.58.2",
@@ -717,16 +716,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@playcanvas/editor-api": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/@playcanvas/editor-api/-/editor-api-1.1.28.tgz",
-      "integrity": "sha512-KJvEBKmJxHmJy2s/9vgD2sFEHfKgmCPjgdZbugCbHmRp4uI4/1MoqDy8F9Z6R1ZGmiebVBusquMHLEZPROXTzQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@playcanvas/eslint-config": {

--- a/test-suite/package.json
+++ b/test-suite/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@playcanvas/editor-api": "^1.1.28",
     "@playcanvas/eslint-config": "2.1.0",
     "@playcanvas/observer": "1.7.1",
     "@playwright/test": "^1.58.2",
@@ -35,7 +34,8 @@
     "test:debug": "playwright test --debug ",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
-    "type:check": "tsc --declaration --emitDeclarationOnly"
+    "build:types": "tsc -p ../src/editor-api/tsconfig.types.json --noCheck",
+    "type:check": "npm run build:types && tsc --declaration --emitDeclarationOnly"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/test-suite/tsconfig.json
+++ b/test-suite/tsconfig.json
@@ -7,7 +7,11 @@
         "allowJs": true,
         "strict": true,
         "skipLibCheck": true,
-        "noEmit": true
+        "noEmit": true,
+        "baseUrl": ".",
+        "paths": {
+            "@playcanvas/editor-api": ["./.editor-api-types"]
+        }
     },
     "include": ["src", "test", "lib", "globals.d.ts"],
     "exclude": ["node_modules", "out"]


### PR DESCRIPTION
## Summary
- Removes the deprecated `@playcanvas/editor-api` npm package from `test-suite/devDependencies`
- Generates `.d.ts` declarations from the local `src/editor-api/` source via a new `build:types` script using `tsc --noCheck`
- Resolves `@playcanvas/editor-api` imports in the test-suite via a `paths` mapping in `tsconfig.json` pointing to the generated declarations

## Test plan
- [x] Run `cd test-suite && npm run build:types` — generates `.editor-api-types/`
- [x] Run `cd test-suite && npx tsc --noEmit` — 0 errors
- [x] Run `cd test-suite && npm run type:check` — passes (generates types then checks)
- [x] Run root `npm run type:check` — no regressions (same pre-existing error count)