### PR TITLE
refactor: adopt PCUI 5.6 TreeView API improvements

### DIFF
--- a/src/editor/entities/entities-control.ts
+++ b/src/editor/entities/entities-control.ts
@@ -106,31 +106,19 @@ editor.once('load', () => {
         root: root
     });
 
-    // TODO: replace _treeItemIndex/_rootItem access with TreeView.expandAll()/collapseAll()
-    // once that API is added to PCUI
-    const treeView = editor.call('entities:hierarchy') as any;
+    const treeView = editor.call('entities:hierarchy');
     const menuMore = new Menu({
         items: [{
             text: 'Expand All',
             icon: 'E386',
             onSelect: () => {
-                for (const id in treeView._treeItemIndex) {
-                    const item = treeView._treeItemIndex[id];
-                    if (item && !item.destroyed) {
-                        item.open = true;
-                    }
-                }
+                treeView.expandAll();
             }
         }, {
             text: 'Collapse All',
             icon: 'E385',
             onSelect: () => {
-                for (const id in treeView._treeItemIndex) {
-                    const item = treeView._treeItemIndex[id];
-                    if (item && !item.destroyed && item !== treeView._rootItem) {
-                        item.open = false;
-                    }
-                }
+                treeView.collapseAll();
             }
         }, {
             text: 'Show All',

--- a/src/editor/entities/entities-panel.ts
+++ b/src/editor/entities/entities-panel.ts
@@ -116,7 +116,7 @@ editor.once('load', () => {
                 updates.push({ button, top: 0, visible: false });
                 return;
             }
-            const contentsEl = (treeItem as TreeViewItem & { _containerContents: Container })._containerContents.dom;
+            const contentsEl = treeItem.content.dom;
             const rect = contentsEl.getBoundingClientRect();
             const visible = !!contentsEl.offsetParent;
             updates.push({ button, top: rect.top - columnRect.top, visible });
@@ -176,7 +176,7 @@ editor.once('load', () => {
         const item = origOnAddEntity(entity);
         const resourceId = entity.get('resource_id');
         if (!eyeEntries.has(resourceId)) {
-            const contentsRow = (item as TreeViewItem & { _containerContents: Container })._containerContents.dom;
+            const contentsRow = item.content.dom;
             const entry = createEyeIcon(resourceId, contentsRow);
 
             if (editor.call('entities:visibility:isHidden', resourceId)) {


### PR DESCRIPTION
## Summary

- Replace unsafe `_containerContents` type assertions with the new public `TreeViewItem.content` getter (PCUI 5.6)
- Replace manual expand/collapse loops over `_treeItemIndex` with the new `TreeView.expandAll()` / `collapseAll()` API (resolves the existing TODO comment)

## Details

PCUI 5.6 added several new public APIs to `TreeView` and `TreeViewItem`. This PR adopts two of them in the editor:

**`TreeViewItem.content`** (entities-panel.ts)

Before:
```typescript
const el = (treeItem as TreeViewItem & { _containerContents: Container })._containerContents.dom;
```

After:
```typescript
const el = treeItem.content.dom;
```

**`TreeView.expandAll()` / `collapseAll()`** (entities-control.ts)

Before:
```typescript
// TODO: replace _treeItemIndex/_rootItem access with TreeView.expandAll()/collapseAll()
const treeView = editor.call('entities:hierarchy') as any;
for (const id in treeView._treeItemIndex) {
    const item = treeView._treeItemIndex[id];
    if (item && !item.destroyed) item.open = true;
}
```

After:
```typescript
const treeView = editor.call('entities:hierarchy');
treeView.expandAll();
```

## Test plan

- [x] Production build passes (`npm run build`)
- [x] No new type errors (`npm run type:check` -- all errors are pre-existing)
- [x] Manual: Verify Expand All / Collapse All in hierarchy panel More Options menu
- [x] Manual: Verify entity visibility eye icons position correctly
