### PR TITLE
fix: allow dashes and underscores in animation state names

### DIFF
--- a/src/editor/inspector/assets/animstategraph-state.ts
+++ b/src/editor/inspector/assets/animstategraph-state.ts
@@ -88,7 +88,7 @@ class AnimstategraphState extends Panel {
     }
 
     static validateStateName(stateId: number, value: string, asset: Observer) {
-        if (!value.match('^[A-Za-z0-9 ]*$')) {
+        if (!value.match('^[A-Za-z0-9 _-]*$')) {
             return false;
         }
         if (value === '') {


### PR DESCRIPTION
## Summary

- Update the `validateStateName` regex to accept dashes (`-`) and underscores (`_`) in animation state names, in addition to the existing alphanumeric characters and spaces
- Previously, only `[A-Za-z0-9 ]` was allowed; now `[A-Za-z0-9 _-]` is accepted

Fixes #1808