### PR TITLE
fix: account for sticky header when scrolling table rows via arrow keys

### DIFF
--- a/src/common/pcui/element/element-table-row.ts
+++ b/src/common/pcui/element/element-table-row.ts
@@ -68,7 +68,7 @@ class TableRow extends Container {
         if (this._header) {
             return;
         }
-        this.dom.focus();
+        this.dom.focus({ preventScroll: true });
     }
 
     blur() {

--- a/src/common/pcui/element/element-table.ts
+++ b/src/common/pcui/element/element-table.ts
@@ -380,6 +380,18 @@ class Table extends Container {
         }
 
         next.selected = true;
+
+        // Manually scroll the focused row into view, accounting for the sticky header
+        const headerRow = this._containerHead.dom.firstElementChild as HTMLElement;
+        const headerHeight = headerRow ? headerRow.offsetHeight : 0;
+        const containerRect = this.dom.getBoundingClientRect();
+        const rowRect = next.dom.getBoundingClientRect();
+
+        if (rowRect.top < containerRect.top + headerHeight) {
+            this.dom.scrollTop -= (containerRect.top + headerHeight - rowRect.top);
+        } else if (rowRect.bottom > containerRect.bottom) {
+            this.dom.scrollTop += (rowRect.bottom - containerRect.bottom);
+        }
     }
 
     // prevent scroll wheel while resizing


### PR DESCRIPTION
## Summary

- Fix arrow-up keyboard navigation in the Assets panel Table view where the selected row was obscured by the sticky table header
- Use `preventScroll` on row focus to bypass the browser's native scroll behavior which doesn't account for sticky-positioned headers
- Manually scroll the focused row into view with header height compensation, handling both up and down directions

## Test plan

- [x] Open the Assets panel in Table/Details view
- [x] Scroll down so the list is longer than the visible area
- [x] Select a row partway down the list
- [x] Press arrow-up repeatedly — the selected row should always be fully visible below the sticky header
- [x] Press arrow-down repeatedly — the selected row should scroll into view at the bottom as before
