### PR TITLE
refactor: standardize asset inspector preview classes

### DIFF
--- a/src/common/thumbnail-renderers/template-thumbnail-renderer.ts
+++ b/src/common/thumbnail-renderers/template-thumbnail-renderer.ts
@@ -253,7 +253,7 @@ export class TemplateThumbnailRenderer extends ThumbnailRenderer {
 
     private readonly handleTemplateAssetChange: (asset: Asset) => void;
 
-    constructor(editorAsset: EditorAsset,
+    constructor(editorAsset: Observer,
                 private canvas: HTMLCanvasElement) {
         super();
         this.app = Application.getApplication();

--- a/src/editor/inspector/assets/asset-preview-base.ts
+++ b/src/editor/inspector/assets/asset-preview-base.ts
@@ -1,3 +1,4 @@
+import type { Observer } from '@playcanvas/observer';
 import { Container, Button, Label } from '@playcanvas/pcui';
 
 const CLASS_ROOT = 'pcui-asset-preview';
@@ -84,7 +85,7 @@ class AssetInspectorPreviewBase extends Container {
         this.class.toggle(CLASS_CONTAINER_LARGE);
     }
 
-    link() {
+    link(_assets?: Observer[]) {
         this.unlink();
 
         this.dom.addEventListener('mousedown', this._domEvtMouseDown);

--- a/src/editor/inspector/assets/cubemap-preview.ts
+++ b/src/editor/inspector/assets/cubemap-preview.ts
@@ -11,11 +11,11 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
-    _previewRenderer: Cubemap3dThumbnailRenderer | null;
+    _previewRenderer: Cubemap3dThumbnailRenderer | null = null;
 
-    _previewRotation: [number, number];
+    private _previewRotation: [number, number] = [0, 0];
 
     private _sx = 0;
 
@@ -25,30 +25,15 @@ class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
 
     private _y = 0;
 
-    private _nx = 0;
-
-    private _ny = 0;
-
     constructor(args: Record<string, unknown>) {
         super(args);
 
         this._preview = new Canvas({
-            canvasWidth: 320,
-            canvasHeight: 144,
-            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP]
+            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP],
+            useDevicePixelRatio: true
         });
-
+        this._preview.resize(320, 144);
         this.append(this._preview);
-
-        this._renderFrame = null;
-        this._previewRenderer = null;
-        this._previewRotation = [0, 0];
-        this._sx = 0;
-        this._sy = 0;
-        this._x = 0;
-        this._y = 0;
-        this._nx = 0;
-        this._ny = 0;
     }
 
     // queue up the rendering to prevent too often renders
@@ -58,7 +43,6 @@ class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
         }
         this._renderFrame = requestAnimationFrame(this._renderPreview.bind(this));
     }
-
 
     _renderPreview() {
         if (this._renderFrame) {
@@ -88,8 +72,6 @@ class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
         super._onMouseMove(evt);
 
         if (this._dragging) {
-            this._nx = this._x - evt.clientX;
-            this._ny = this._y - evt.clientY;
             this._x = evt.clientX;
             this._y = evt.clientY;
 
@@ -100,7 +82,7 @@ class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
     _onMouseUp(evt: MouseEvent) {
         if (this._dragging) {
             if ((Math.abs(this._sx - this._x) + Math.abs(this._sy - this._y)) < 8) {
-                (this._preview.dom as HTMLCanvasElement).height = this.height;
+                this._preview.height = this.height;
             }
 
             this._previewRotation[0] = Math.max(-90, Math.min(90, this._previewRotation[0] + ((this._sy - this._y) * 0.3)));
@@ -123,8 +105,10 @@ class CubemapAssetInspectorPreview extends AssetInspectorPreviewBase {
     }
 
     link(assets: Observer[]) {
-        super.link(assets);
-        this._previewRenderer = new Cubemap3dThumbnailRenderer(assets[0], this._preview.dom);
+        this.unlink();
+        super.link();
+
+        this._previewRenderer = new Cubemap3dThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement);
         this._queueRender();
     }
 

--- a/src/editor/inspector/assets/font-preview.ts
+++ b/src/editor/inspector/assets/font-preview.ts
@@ -11,7 +11,7 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 class FontAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
     _previewRenderer: FontThumbnailRenderer;
 
@@ -23,10 +23,7 @@ class FontAssetInspectorPreview extends AssetInspectorPreviewBase {
             useDevicePixelRatio: true
         });
         this._preview.resize(320, 144);
-
         this.append(this._preview);
-
-        this._renderFrame = null;
     }
 
     // queue up the rendering to prevent too often renders
@@ -59,8 +56,9 @@ class FontAssetInspectorPreview extends AssetInspectorPreviewBase {
     }
 
     link(assets: Observer[]) {
-        super.link(assets);
-        this._previewRenderer = new FontThumbnailRenderer(assets[0], this._preview.dom);
+        this.unlink();
+        super.link();
+        this._previewRenderer = new FontThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement);
         this._queueRender();
     }
 

--- a/src/editor/inspector/assets/material-preview.ts
+++ b/src/editor/inspector/assets/material-preview.ts
@@ -11,13 +11,13 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 class MaterialAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _previewModel: string;
+    _previewModel: 'sphere' | 'box' = 'sphere';
 
-    _previewRenderer: MaterialThumbnailRenderer | null;
+    _previewRenderer: MaterialThumbnailRenderer | null = null;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
-    private _previewRotation: [number, number];
+    private _previewRotation: [number, number] = [-15, 45];
 
     private _sx = 0;
 
@@ -27,29 +27,15 @@ class MaterialAssetInspectorPreview extends AssetInspectorPreviewBase {
 
     private _y = 0;
 
-    private _nx = 0;
-
-    private _ny = 0;
-
     constructor(args: Record<string, unknown>) {
         super(args);
 
-        this._preview = new Canvas();
+        this._preview = new Canvas({
+            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP],
+            useDevicePixelRatio: true
+        });
         this._preview.resize(320, 144);
-        this._preview.class.add(CLASS_CANVAS, CLASS_CANVAS_FLIP);
         this.append(this._preview);
-
-        this._previewModel = 'sphere';
-        this._previewRenderer = null;
-
-        this._renderFrame = null;
-        this._previewRotation = [-15, 45];
-        this._sx = 0;
-        this._sy = 0;
-        this._x = 0;
-        this._y = 0;
-        this._nx = 0;
-        this._ny = 0;
     }
 
     // queue up the rendering to prevent too often renders
@@ -90,8 +76,6 @@ class MaterialAssetInspectorPreview extends AssetInspectorPreviewBase {
         super._onMouseMove(evt);
 
         if (this._dragging) {
-            this._nx = this._x - evt.clientX;
-            this._ny = this._y - evt.clientY;
             this._x = evt.clientX;
             this._y = evt.clientY;
 
@@ -128,7 +112,7 @@ class MaterialAssetInspectorPreview extends AssetInspectorPreviewBase {
         this.unlink();
         super.link();
 
-        this._previewRenderer = new MaterialThumbnailRenderer(assets[0], this._preview.dom);
+        this._previewRenderer = new MaterialThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement);
         this._queueRender();
     }
 

--- a/src/editor/inspector/assets/model-preview.ts
+++ b/src/editor/inspector/assets/model-preview.ts
@@ -11,11 +11,11 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 class ModelAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
     _previewRenderer: ModelThumbnailRenderer;
 
-    private _previewRotation: [number, number];
+    private _previewRotation: [number, number] = [-15, 45];
 
     private _sx = 0;
 
@@ -25,26 +25,15 @@ class ModelAssetInspectorPreview extends AssetInspectorPreviewBase {
 
     private _y = 0;
 
-    private _nx = 0;
-
-    private _ny = 0;
-
     constructor(args: Record<string, unknown>) {
         super(args);
 
-        this._preview = new Canvas({ useDevicePixelRatio: true });
+        this._preview = new Canvas({
+            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP],
+            useDevicePixelRatio: true
+        });
         this._preview.resize(320, 144);
-        this._preview.class.add(CLASS_CANVAS, CLASS_CANVAS_FLIP);
         this.append(this._preview);
-
-        this._renderFrame = null;
-        this._previewRotation = [-15, 45];
-        this._sx = 0;
-        this._sy = 0;
-        this._x = 0;
-        this._y = 0;
-        this._nx = 0;
-        this._ny = 0;
     }
 
     // queue up the rendering to prevent too often renders
@@ -84,8 +73,6 @@ class ModelAssetInspectorPreview extends AssetInspectorPreviewBase {
         super._onMouseMove(evt);
 
         if (this._dragging) {
-            this._nx = this._x - evt.clientX;
-            this._ny = this._y - evt.clientY;
             this._x = evt.clientX;
             this._y = evt.clientY;
 
@@ -122,7 +109,7 @@ class ModelAssetInspectorPreview extends AssetInspectorPreviewBase {
         this.unlink();
         super.link();
 
-        this._previewRenderer = new ModelThumbnailRenderer(assets[0], this._preview.dom);
+        this._previewRenderer = new ModelThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement);
         this._queueRender();
     }
 

--- a/src/editor/inspector/assets/render-preview.ts
+++ b/src/editor/inspector/assets/render-preview.ts
@@ -11,11 +11,11 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 class RenderAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
     _previewRenderer: RenderThumbnailRenderer;
 
-    private _previewRotation: [number, number];
+    private _previewRotation: [number, number] = [-15, 45];
 
     private _sx = 0;
 
@@ -25,26 +25,15 @@ class RenderAssetInspectorPreview extends AssetInspectorPreviewBase {
 
     private _y = 0;
 
-    private _nx = 0;
-
-    private _ny = 0;
-
     constructor(args: Record<string, unknown>) {
         super(args);
 
-        this._preview = new Canvas({ useDevicePixelRatio: true });
+        this._preview = new Canvas({
+            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP],
+            useDevicePixelRatio: true
+        });
         this._preview.resize(320, 144);
-        this._preview.class.add(CLASS_CANVAS, CLASS_CANVAS_FLIP);
         this.append(this._preview);
-
-        this._renderFrame = null;
-        this._previewRotation = [-15, 45];
-        this._sx = 0;
-        this._sy = 0;
-        this._x = 0;
-        this._y = 0;
-        this._nx = 0;
-        this._ny = 0;
     }
 
     // queue up the rendering to prevent too often renders
@@ -84,8 +73,6 @@ class RenderAssetInspectorPreview extends AssetInspectorPreviewBase {
         super._onMouseMove(evt);
 
         if (this._dragging) {
-            this._nx = this._x - evt.clientX;
-            this._ny = this._y - evt.clientY;
             this._x = evt.clientX;
             this._y = evt.clientY;
 
@@ -122,7 +109,7 @@ class RenderAssetInspectorPreview extends AssetInspectorPreviewBase {
         this.unlink();
         super.link();
 
-        this._previewRenderer = new RenderThumbnailRenderer(assets[0], this._preview.dom);
+        this._previewRenderer = new RenderThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement);
         this._queueRender();
     }
 

--- a/src/editor/inspector/assets/sprite-preview.ts
+++ b/src/editor/inspector/assets/sprite-preview.ts
@@ -99,8 +99,9 @@ class SpriteAssetInspectorPreview extends AssetInspectorPreviewBase {
     }
 
     link(assets: Observer[]) {
-        super.link(assets);
-        this._previewRenderer = new SpriteThumbnailRenderer(assets[0], this._preview.dom, editor.call('assets:raw'));
+        this.unlink();
+        super.link();
+        this._previewRenderer = new SpriteThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement, editor.call('assets:raw'));
         this._spriteFrames = assets[0].get('data.frameKeys').length;
         this._queueRender();
     }

--- a/src/editor/inspector/assets/template-preview.ts
+++ b/src/editor/inspector/assets/template-preview.ts
@@ -1,7 +1,7 @@
+import type { Observer } from '@playcanvas/observer';
 import { Canvas } from '@playcanvas/pcui';
 
 import { TemplateThumbnailRenderer } from '@/common/thumbnail-renderers/template-thumbnail-renderer';
-import { Assets } from '@/editor-api';
 
 import { AssetInspectorPreviewBase } from './asset-preview-base';
 
@@ -10,10 +10,10 @@ const CLASS_CANVAS_FLIP = 'pcui-asset-preview-canvas-flip';
 
 const ROTATION_SPEED = 0.5;
 
-export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
+class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
     _preview: Canvas;
 
-    _renderFrame: number | null;
+    _renderFrame: number | null = null;
 
     _previewRenderer?: TemplateThumbnailRenderer;
 
@@ -27,21 +27,18 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
 
     private _y = 0;
 
-    private _nx = 0;
-
-    private _ny = 0;
-
     constructor(args: Record<string, unknown>) {
         super(args);
 
-        this._preview = new Canvas();
-        this._preview.class.add(CLASS_CANVAS, CLASS_CANVAS_FLIP);
+        this._preview = new Canvas({
+            class: [CLASS_CANVAS, CLASS_CANVAS_FLIP],
+            useDevicePixelRatio: true
+        });
+        this._preview.resize(320, 144);
         this.append(this._preview);
-
-        this._renderFrame = null;
     }
 
-    link(assets: Assets) {
+    link(assets: Observer[]) {
         this.unlink();
         super.link();
 
@@ -72,19 +69,19 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
         }
     }
 
-    private _toggleSize() {
+    _toggleSize() {
         super._toggleSize();
         this._queueRender();
     }
 
-    private _queueRender() {
+    _queueRender() {
         if (this._renderFrame || !this._previewRenderer) {
             return;
         }
         this._renderFrame = requestAnimationFrame(this._renderPreview.bind(this));
     }
 
-    private _renderPreview() {
+    _renderPreview() {
         if (this._renderFrame) {
             cancelAnimationFrame(this._renderFrame);
             this._renderFrame = null;
@@ -100,7 +97,7 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
         );
     }
 
-    private _onMouseDown(evt: MouseEvent) {
+    _onMouseDown(evt: MouseEvent) {
         super._onMouseDown(evt);
         if (this._mouseDown) {
             this._sx = this._x = evt.clientX;
@@ -108,11 +105,9 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
         }
     }
 
-    private _onMouseMove(evt: MouseEvent) {
+    _onMouseMove(evt: MouseEvent) {
         super._onMouseMove(evt);
         if (this._dragging) {
-            this._nx = this._x - evt.clientX;
-            this._ny = this._y - evt.clientY;
             this._x = evt.clientX;
             this._y = evt.clientY;
 
@@ -120,7 +115,7 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
         }
     }
 
-    private _onMouseUp(evt: MouseEvent) {
+    _onMouseUp(evt: MouseEvent) {
         if (this._dragging) {
             if ((Math.abs(this._sx - this._x) + Math.abs(this._sy - this._y)) < 8) {
                 this._preview.height = this.height;
@@ -136,3 +131,5 @@ export class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
         super._onMouseUp(evt);
     }
 }
+
+export { TemplateAssetInspectorPreview };


### PR DESCRIPTION
## Summary

- **Standardize Canvas construction** across all 7 preview classes: pass `class` in the constructor, use `useDevicePixelRatio: true`, call `.resize(320, 144)` consistently
- **Remove dead code**: delete unused `_nx`/`_ny` fields and redundant constructor initializations (values now live on field declarations)
- **Fix type errors**: add `as HTMLCanvasElement` casts for `Canvas.dom`, correct `_previewModel` type to `'sphere' | 'box'`, change `TemplateThumbnailRenderer` constructor to accept `Observer` instead of `EditorAsset`
- **Fix `link()` lifecycle**: ensure every preview calls `this.unlink()` then `super.link()` (no arguments) before setup
- **Minor consistency fixes**: make `_previewRotation` private in cubemap-preview, use PCUI `.height` instead of raw DOM in cubemap-preview, align template-preview export style and method visibility with other previews

## Files Changed

- `src/editor/inspector/assets/asset-preview-base.ts` — base class `link()` now accepts optional `Observer[]`
- `src/editor/inspector/assets/material-preview.ts`
- `src/editor/inspector/assets/model-preview.ts`
- `src/editor/inspector/assets/render-preview.ts`
- `src/editor/inspector/assets/cubemap-preview.ts`
- `src/editor/inspector/assets/font-preview.ts`
- `src/editor/inspector/assets/sprite-preview.ts`
- `src/editor/inspector/assets/template-preview.ts`
- `src/common/thumbnail-renderers/template-thumbnail-renderer.ts`

## Test plan

- [x] Open an asset inspector for each preview type (material, model, render, cubemap, font, sprite, template) and verify the preview renders correctly
- [x] Click and drag on previews to rotate — confirm mouse interaction still works
- [x] Click the size toggle on previews — confirm expand/collapse works
- [x] Verify no TypeScript errors with `npm run type:check`
