### PR TITLE
fix: resolve TypeScript property errors in component inspectors

### DIFF
--- a/src/editor/inspector/components/anim.ts
+++ b/src/editor/inspector/components/anim.ts
@@ -1,3 +1,4 @@
+import type { EventHandle, Observer, ObserverList } from '@playcanvas/observer';
 import { InfoBox, Container, TreeView, TreeViewItem, BooleanInput, Menu, Button, Panel, BindingTwoWay } from '@playcanvas/pcui';
 import type { Entity } from 'playcanvas';
 
@@ -67,6 +68,28 @@ const CLASS_MASK_INSPECTOR_ADD_ALL_BUTTON = `${CLASS_MASK_INSPECTOR}-add-all-but
 const CLASS_MASK_INSPECTOR_REMOVE_ALL_BUTTON = `${CLASS_MASK_INSPECTOR}-remove-all-button`;
 
 class AnimComponentInspector extends ComponentInspector {
+    _args: Record<string, unknown>;
+
+    _assets: ObserverList;
+
+    _stateGraphAssetId: number | null = null;
+
+    _stateGraphAsset: Observer | null = null;
+
+    _maskInspector: Panel | null = null;
+
+    _contextMenus: Menu[] = [];
+
+    _evts: EventHandle[] = [];
+
+    _maskEvts: EventHandle[] = [];
+
+    _attributesInspector: AttributesInspector;
+
+    _normalizeWeightsMessage: InfoBox;
+
+    _layersContainer: Container;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'anim';
@@ -76,15 +99,7 @@ class AnimComponentInspector extends ComponentInspector {
         this._args = args;
         this._assets = args.assets;
 
-        this._stateGraphAssetId = null;
-        this._stateGraphAsset = null;
         this._entities = null;
-
-        this._maskInspector = null;
-        this._contextMenus = [];
-
-        this._evts = [];
-        this._maskEvts = [];
 
         this._attributesInspector = new AttributesInspector({
             assets: args.assets,

--- a/src/editor/inspector/components/animation.ts
+++ b/src/editor/inspector/components/animation.ts
@@ -1,3 +1,4 @@
+import type { ObserverList } from '@playcanvas/observer';
 import { Button } from '@playcanvas/pcui';
 
 import { ComponentInspector } from './component';
@@ -39,6 +40,10 @@ const ATTRIBUTES: Attribute[] = [{
 const CLASS_BUTTON_PLAY = 'animation-component-inspector-play';
 
 class AnimationComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'animation';

--- a/src/editor/inspector/components/audiolistener.ts
+++ b/src/editor/inspector/components/audiolistener.ts
@@ -6,6 +6,8 @@ import { AttributesInspector } from '../attributes-inspector';
 const ATTRIBUTES: Attribute[] = [];
 
 class AudiolistenerComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'audiolistener';

--- a/src/editor/inspector/components/audiosource.ts
+++ b/src/editor/inspector/components/audiosource.ts
@@ -80,6 +80,10 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class AudiosourceComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _skipToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'audiosource';
@@ -95,8 +99,6 @@ class AudiosourceComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
 
         this._field('3d').on('change', this._toggleFields.bind(this));
-
-        this._skipToggleFields = false;
 
         // disable all fields if engine is v2
         ATTRIBUTES.forEach((attribute) => {

--- a/src/editor/inspector/components/button.ts
+++ b/src/editor/inspector/components/button.ts
@@ -1,3 +1,4 @@
+import type { EventHandle } from '@playcanvas/observer';
 import { InfoBox } from '@playcanvas/pcui';
 
 import {
@@ -118,6 +119,14 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class ButtonComponentInspector extends ComponentInspector {
+    _inputWarning: InfoBox;
+
+    _evts: EventHandle[] = [];
+
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'button';
@@ -131,8 +140,6 @@ class ButtonComponentInspector extends ComponentInspector {
         });
         this.append(this._inputWarning);
 
-        this._evts = [];
-
         this._attributesInspector = new AttributesInspector({
             assets: args.assets,
             entities: args.entities,
@@ -143,8 +150,6 @@ class ButtonComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
 
         this._field('transitionMode').on('change', this._toggleFields.bind(this));
-
-        this._suppressToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/camera.ts
+++ b/src/editor/inspector/components/camera.ts
@@ -150,6 +150,10 @@ const ATTRIBUTES: (Attribute | Divider)[] = [{
 }];
 
 class CameraComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'camera';
@@ -168,8 +172,6 @@ class CameraComponentInspector extends ComponentInspector {
         ['clearColorBuffer', 'projection'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));
         });
-
-        this._suppressToggleFields = false;
 
         this._attributesInspector.getField('divider:0').hidden = !editor.projectEngineV2;
         this._field('toneMapping').parent.hidden = !editor.projectEngineV2;

--- a/src/editor/inspector/components/collision.ts
+++ b/src/editor/inspector/components/collision.ts
@@ -1,4 +1,5 @@
-import { InfoBox } from '@playcanvas/pcui';
+import type { EventHandle } from '@playcanvas/observer';
+import { InfoBox, LabelGroup } from '@playcanvas/pcui';
 import { CollisionComponent } from 'playcanvas';
 
 import { ComponentInspector } from './component';
@@ -119,6 +120,16 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class CollisionComponentInspector extends ComponentInspector {
+    _variedTransformScalesWarning: InfoBox;
+
+    _evts: EventHandle[] = [];
+
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
+    _importAmmoPanel: LabelGroup;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'collision';
@@ -131,8 +142,6 @@ class CollisionComponentInspector extends ComponentInspector {
             text: 'This entity has a non-uniform scale. Mesh collision will not work as expected.'
         });
         this.append(this._variedTransformScalesWarning);
-
-        this._evts = [];
 
         this._attributesInspector = new AttributesInspector({
             assets: args.assets,
@@ -147,8 +156,6 @@ class CollisionComponentInspector extends ComponentInspector {
         this._field('renderAsset').on('change', this._toggleFields.bind(this));
 
         this._handleTypeChange(this._field('type'));
-
-        this._suppressToggleFields = false;
 
         this._importAmmoPanel = editor.call('attributes:appendImportAmmo', this);
         this._importAmmoPanel.hidden = true;

--- a/src/editor/inspector/components/component.ts
+++ b/src/editor/inspector/components/component.ts
@@ -2,7 +2,7 @@ import type { EventHandle, Observer } from '@playcanvas/observer';
 import { BindingTwoWay, BooleanInput, Button, Container, Label, LabelGroup, Menu, Panel } from '@playcanvas/pcui';
 
 import { tooltip, tooltipRefItem } from '@/common/tooltips';
-import { LocalStorage } from '@/editor-api';
+import { LocalStorage, type History } from '@/editor-api';
 
 import type { TemplateOverrideInspector } from '../../templates/templates-override-inspector.js';
 
@@ -18,6 +18,8 @@ class ComponentInspector extends Panel {
     _entities: Observer[] | null = null;
 
     _entityEvents: EventHandle[] = [];
+
+    protected _history: History;
 
     protected _templateOverridesInspector: TemplateOverrideInspector;
 

--- a/src/editor/inspector/components/element.ts
+++ b/src/editor/inspector/components/element.ts
@@ -412,6 +412,8 @@ function getTextureDimensions(id: number, assets: Assets) {
 // Custom binding from element -> observers for texture and sprite assets which
 // resizes an Image Element when the asset is first assigned
 class ImageAssetElementToObserversBinding extends BindingElementToObservers {
+    _assets: Assets;
+
     constructor(assets: Assets, args: Record<string, unknown>) {
         super(args);
         this._assets = assets;
@@ -672,6 +674,14 @@ class SpriteFrameElementToObserversBinding extends ImageAssetElementToObserversB
 }
 
 class ElementComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressLocalizedEvents = false;
+
+    _suppressPresetEvents = false;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'element';
@@ -756,10 +766,6 @@ class ElementComponentInspector extends ComponentInspector {
         this._field('resetSize').on('click', () => {
             this._onClickResetSize(args.assets);
         });
-
-        this._suppressLocalizedEvents = false;
-        this._suppressPresetEvents = false;
-        this._suppressToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/gsplat.ts
+++ b/src/editor/inspector/components/gsplat.ts
@@ -1,3 +1,4 @@
+import type { ObserverList } from '@playcanvas/observer';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
 import { ComponentInspector } from './component';
@@ -28,6 +29,10 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class GSplatComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'gsplat';

--- a/src/editor/inspector/components/layoutchild.ts
+++ b/src/editor/inspector/components/layoutchild.ts
@@ -41,6 +41,8 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class LayoutchildComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'layoutchild';

--- a/src/editor/inspector/components/layoutgroup.ts
+++ b/src/editor/inspector/components/layoutgroup.ts
@@ -105,6 +105,8 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class LayoutgroupComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'layoutgroup';

--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -1,3 +1,4 @@
+import type { EventHandle } from '@playcanvas/observer';
 import { Button } from '@playcanvas/pcui';
 import {
     LAYERID_DEPTH,
@@ -449,6 +450,14 @@ const ATTRIBUTES: (Attribute | Divider)[] = [{
 }];
 
 class LightComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _btnUpdateShadow: Button;
+
+    _eventUpdateShadow: EventHandle | null = null;
+
+    _skipToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'light';
@@ -486,8 +495,6 @@ class LightComponentInspector extends ComponentInspector {
         });
         this._field('shadowUpdateMode').parent.append(this._btnUpdateShadow);
 
-        this._eventUpdateShadow = null;
-
         const tooltip = LegacyTooltip.attach({
             target: this._btnUpdateShadow.dom,
             text: 'Update Shadows',
@@ -497,8 +504,6 @@ class LightComponentInspector extends ComponentInspector {
         this._btnUpdateShadow.once('destroy', () => {
             tooltip.destroy();
         });
-
-        this._skipToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/model.ts
+++ b/src/editor/inspector/components/model.ts
@@ -1,8 +1,10 @@
+import type { ObserverList } from '@playcanvas/observer';
 import { Label, Container, Button, BindingTwoWay, BindingElementToObservers } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
 import { CLASS_ERROR } from '@/common/pcui/constants';
 import { AssetInput } from '@/common/pcui/element/element-asset-input';
+import type { Assets } from '@/editor-api';
 
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
@@ -132,7 +134,9 @@ const REGEX_MAPPING = /^components.model.mapping.(\d+)$/;
 // Custom binding for asset field so that when we change the asset we
 // reset the model's mapping
 class AssetElementToObserversBinding extends BindingElementToObservers {
-    constructor(assets: import('@/editor-api').Assets, args: Record<string, unknown>) {
+    _assets: Assets;
+
+    constructor(assets: Assets, args: Record<string, unknown>) {
         super(args);
         this._assets = assets;
     }
@@ -250,6 +254,28 @@ class AssetElementToObserversBinding extends BindingElementToObservers {
 }
 
 class ModelComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
+    _labelUv1Missing: Label;
+
+    _containerButtons: Container;
+
+    _containerMappings: Container;
+
+    _mappingInspectors: Record<string, any> = {};
+
+    _suppressToggleFields = false;
+
+    _suppressAssetChange = false;
+
+    _suppressCustomAabb = false;
+
+    _timeoutRefreshMappings: ReturnType<typeof setTimeout> | null;
+
+    _dirtyMappings: boolean;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'model';
@@ -305,12 +331,6 @@ class ModelComponentInspector extends ComponentInspector {
             flex: true
         });
         this.append(this._containerMappings);
-
-        this._mappingInspectors = {};
-
-        this._suppressToggleFields = false;
-        this._suppressAssetChange = false;
-        this._suppressCustomAabb = false;
 
         ['type', 'asset', 'lightmapped', 'lightmapSizeMultiplier', 'customAabb'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));

--- a/src/editor/inspector/components/particlesystem.ts
+++ b/src/editor/inspector/components/particlesystem.ts
@@ -389,6 +389,14 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class ParticlesystemComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
+    _btnPlay: Button;
+
+    _btnPause: Button;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'particlesystem';
@@ -403,8 +411,6 @@ class ParticlesystemComponentInspector extends ComponentInspector {
             templateOverridesInspector: this._templateOverridesInspector
         });
         this.append(this._attributesInspector);
-
-        this._suppressToggleFields = false;
 
         [
             'loop',

--- a/src/editor/inspector/components/render.ts
+++ b/src/editor/inspector/components/render.ts
@@ -1,3 +1,4 @@
+import type { ObserverList } from '@playcanvas/observer';
 import { Label } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
@@ -130,6 +131,18 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class RenderComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
+    _labelUv1Missing: Label;
+
+    _suppressToggleFields = false;
+
+    _suppressAssetChange = false;
+
+    _suppressCustomAabb = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'render';
@@ -154,10 +167,6 @@ class RenderComponentInspector extends ComponentInspector {
         });
         this._labelUv1Missing.style.marginLeft = 'auto';
         this._field('lightmapped').parent.append(this._labelUv1Missing);
-
-        this._suppressToggleFields = false;
-        this._suppressAssetChange = false;
-        this._suppressCustomAabb = false;
 
         ['type', 'asset', 'lightmapped', 'lightmapSizeMultiplier', 'customAabb'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));

--- a/src/editor/inspector/components/rigidbody.ts
+++ b/src/editor/inspector/components/rigidbody.ts
@@ -1,3 +1,5 @@
+import { LabelGroup } from '@playcanvas/pcui';
+
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -110,6 +112,12 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class RigidbodyComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
+    _importAmmoPanel: LabelGroup;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'rigidbody';
@@ -125,8 +133,6 @@ class RigidbodyComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
 
         this._field('type').on('change', this._toggleFields.bind(this));
-
-        this._suppressToggleFields = false;
 
         this._importAmmoPanel = editor.call('attributes:appendImportAmmo', this);
         this._importAmmoPanel.hidden = true;

--- a/src/editor/inspector/components/screen.ts
+++ b/src/editor/inspector/components/screen.ts
@@ -62,7 +62,12 @@ const ATTRIBUTES: Attribute[] = [{
         step: 1
     }
 }];
+
 class ScreenComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'screen';
@@ -78,8 +83,6 @@ class ScreenComponentInspector extends ComponentInspector {
 
         this._field('scaleMode').on('change', this._toggleFields.bind(this));
         this._field('screenSpace').on('change', this._toggleFields.bind(this));
-
-        this._suppressToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/script.ts
+++ b/src/editor/inspector/components/script.ts
@@ -99,6 +99,16 @@ class ScriptInspector extends Panel {
 
     private _scriptName: string;
 
+    _history: History;
+
+    _argsAssets: Observer[];
+
+    _argsEntities: Observer[];
+
+    _templateOverridesInspector: TemplateOverrideInspector;
+
+    _attributes: Record<string, unknown>;
+
     private _asset: AssetObserver;
 
     private _attributeWarnings: Map<string, string[]> = new Map();
@@ -118,7 +128,7 @@ class ScriptInspector extends Panel {
 
     private _labelInvalid: Label;
 
-    private _tooltipInvalid: any;
+    private _tooltipInvalid: Container;
 
     private _fieldEnable: BooleanInput;
 
@@ -945,6 +955,10 @@ class ScriptInspector extends Panel {
 }
 
 class ScriptComponentInspector extends ComponentInspector {
+    _argsAssets: Observer[];
+
+    _argsEntities: Observer[];
+
     private _scriptPanels: Record<string, ScriptInspector> = {};
 
     private _editorEvents: EventHandle[] = [];

--- a/src/editor/inspector/components/scrollbar.ts
+++ b/src/editor/inspector/components/scrollbar.ts
@@ -49,6 +49,8 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class ScrollbarComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'scrollbar';

--- a/src/editor/inspector/components/scrollview.ts
+++ b/src/editor/inspector/components/scrollview.ts
@@ -130,6 +130,10 @@ const ATTRIBUTES: (Attribute | Divider)[] = [{
 }];
 
 class ScrollviewComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'scrollview';
@@ -155,8 +159,6 @@ class ScrollviewComponentInspector extends ComponentInspector {
         ['scrollMode', 'useMouseWheel', 'vertical', 'horizontal'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));
         });
-
-        this._suppressToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/sound.ts
+++ b/src/editor/inspector/components/sound.ts
@@ -1,8 +1,10 @@
+import type { EventHandle, Observer, ObserverList } from '@playcanvas/observer';
 import { Panel, Container, Button } from '@playcanvas/pcui';
 
 import { deepCopy } from '@/common/utils';
 
 import { ComponentInspector } from './component';
+import type { TemplateOverrideInspector } from '../../templates/templates-override-inspector.js';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
 
@@ -154,6 +156,18 @@ const SLOT_ATTRIBUTES: Attribute[] = [{
 const CLASS_SLOT = 'sound-component-inspector-slot';
 
 class SoundSlotInspector extends Panel {
+    _entities: Observer[] | null = null;
+
+    _slotEvents: EventHandle[] = [];
+
+    _templateOverridesInspector: TemplateOverrideInspector;
+
+    _slotKey: string;
+
+    _attrs: Attribute[];
+
+    _inspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({
             headerText: args.slot.name || 'New Slot',
@@ -163,9 +177,6 @@ class SoundSlotInspector extends Panel {
         super(args);
 
         this.class.add(CLASS_SLOT);
-
-        this._entities = null;
-        this._slotEvents = [];
 
         this._templateOverridesInspector = args.templateOverridesInspector;
 
@@ -260,6 +271,18 @@ class SoundSlotInspector extends Panel {
 }
 
 class SoundComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
+    _containerSlots: Container;
+
+    _slotInspectors: Record<string, SoundSlotInspector> = {};
+
+    _btnAddSlot: Button;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'sound';
@@ -281,8 +304,6 @@ class SoundComponentInspector extends ComponentInspector {
         });
         this.append(this._containerSlots);
 
-        this._slotInspectors = {};
-
         this._btnAddSlot = new Button({
             text: 'ADD SLOT',
             icon: 'E120',
@@ -292,8 +313,6 @@ class SoundComponentInspector extends ComponentInspector {
         this.append(this._btnAddSlot);
 
         this._field('positional').on('change', this._toggleFields.bind(this));
-
-        this._suppressToggleFields = false;
     }
 
     _field(name: string) {

--- a/src/editor/inspector/components/sprite.ts
+++ b/src/editor/inspector/components/sprite.ts
@@ -1,9 +1,11 @@
+import type { Observer, ObserverList } from '@playcanvas/observer';
 import { Panel, Container, Button } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
 import { deepCopy } from '@/common/utils';
 
 import { ComponentInspector } from './component';
+import type { TemplateOverrideInspector } from '../../templates/templates-override-inspector.js';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
 
@@ -181,6 +183,18 @@ function getCommonClips(entities: import('@playcanvas/observer').Observer[]) {
 }
 
 class SpriteClipInspector extends Panel {
+    _entities: Observer[] | null = null;
+
+    _spriteInspector: SpriteComponentInspector;
+
+    _templateOverridesInspector: TemplateOverrideInspector;
+
+    _clipKeys: string[];
+
+    _attrs: Attribute[];
+
+    _inspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({
             collapsible: true,
@@ -190,8 +204,6 @@ class SpriteClipInspector extends Panel {
         super(args);
 
         this.class.add(CLASS_CLIP);
-
-        this._entities = null;
 
         this._spriteInspector = args.spriteInspector;
         this._templateOverridesInspector = args.templateOverridesInspector;
@@ -346,6 +358,20 @@ class SpriteClipInspector extends Panel {
 }
 
 class SpriteComponentInspector extends ComponentInspector {
+    _assets: ObserverList;
+
+    _attributesInspector: AttributesInspector;
+
+    _containerClips: Container;
+
+    _clipInspectors: Record<string, SpriteClipInspector> = {};
+
+    _btnAddClip: Button;
+
+    _timeoutAfterClipNameChange: ReturnType<typeof setTimeout> | null = null;
+
+    _suppressToggleFields = false;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'sprite';
@@ -368,8 +394,6 @@ class SpriteComponentInspector extends ComponentInspector {
         });
         this.append(this._containerClips);
 
-        this._clipInspectors = {};
-
         this._btnAddClip = new Button({
             text: 'ADD CLIP',
             icon: 'E120',
@@ -380,10 +404,6 @@ class SpriteComponentInspector extends ComponentInspector {
         this._btnAddClip.on('click', this._onClickAddClip.bind(this));
 
         this.append(this._btnAddClip);
-
-        this._timeoutAfterClipNameChange = null;
-
-        this._suppressToggleFields = false;
 
         ['type', 'spriteAsset'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));

--- a/src/editor/inspector/components/zone.ts
+++ b/src/editor/inspector/components/zone.ts
@@ -16,6 +16,8 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 class ZoneComponentInspector extends ComponentInspector {
+    _attributesInspector: AttributesInspector;
+
     constructor(args: Record<string, unknown>) {
         args = Object.assign({}, args);
         args.component = 'zone';


### PR DESCRIPTION
## Summary

- Add explicit class property declarations to all 24 component inspector files under `src/editor/inspector/components/` to fix ~490 `Property X does not exist on type Y` TypeScript errors
- Replace `any` and `unknown` types with accurate types (`ObserverList`, `LabelGroup`, `Container`, `TemplateOverrideInspector`, `SpriteComponentInspector`, `History`, `Button`, `Label`, `InfoBox`, `Panel`, `EventHandle`, `Observer`, etc.)
- Move trivial field initializations (`null`, `false`, `[]`, `{}`) from constructors to declaration sites
- Combine duplicate imports from the same module (e.g. `@/editor-api`)

## Test plan

- [x] Verify `npm run type:check` passes (or at least no new errors introduced)
- [x] Verify `npm run build` succeeds
- [x] Smoke test the editor: open entity inspector for entities with various components (camera, render, model, sound, sprite, script, anim, collision, rigidbody, etc.) and confirm inspector panels render correctly
