### PR TITLE
refactor: compact left toolbar and add responsive overflow

### DIFF
--- a/sass/editor/_editor-layout.scss
+++ b/sass/editor/_editor-layout.scss
@@ -5,7 +5,7 @@
     grid-template:
         'toolbar hierarchy viewport attributes' 1fr
         'toolbar hierarchy assets attributes' auto
-        'toolbar console console console' auto / 45px auto 1fr auto;
+        'toolbar console console console' auto / 40px auto 1fr auto;
 }
 
 // left toolbar

--- a/sass/editor/_editor-left-toolbar.scss
+++ b/sass/editor/_editor-left-toolbar.scss
@@ -9,8 +9,8 @@
         border: none;
         border-radius: 0;
         margin: 0;
-        width: 45px;
-        height: 45px;
+        width: 40px;
+        height: 40px;
         flex-shrink: 0;
 
         &.hidden {
@@ -19,19 +19,19 @@
 
         &.logo {
             background-image: url('https://playcanvas.com/static-assets/images/editor_logo.png');
-            background-size: 92px 46px;
+            background-size: 80px 40px;
             background-repeat: no-repeat;
-            background-position: -1px -1px;
+            background-position: 0 0;
 
             &:hover {
-                background-position: -47px -1px;
+                background-position: -40px 0;
             }
         }
 
         &.icon,
         &.pc-icon {
             color: $text-dark;
-            line-height: 43px;
+            line-height: 38px;
             text-align: center;
             background-color: $bcg-primary;
 
@@ -123,4 +123,20 @@
 
 #layout-toolbar.hide-items > div {
     display: none;
+}
+
+@media (max-height: 760px) {
+    #layout-toolbar > .pcui-button {
+        &.github,
+        &.discord,
+        &.forum,
+        &.help-howdoi,
+        &.help-controls {
+            display: none;
+        }
+
+        &.editor-settings {
+            margin-top: auto;
+        }
+    }
 }

--- a/src/editor/toolbar/toolbar-discord.ts
+++ b/src/editor/toolbar/toolbar-discord.ts
@@ -36,7 +36,7 @@ editor.once('load', () => {
     // Append the discord svg to the button
     const color = '#9ba1a3';
     const hoverColor = '#ffffff';
-    const [icon, path] = discordSvg(color, 'margin-top: 14px');
+    const [icon, path] = discordSvg(color, 'margin-top: 9px');
     button.dom.append(icon);
 
     button.on('click', () => {

--- a/src/editor/toolbar/toolbar-logo.ts
+++ b/src/editor/toolbar/toolbar-logo.ts
@@ -400,7 +400,7 @@ editor.once('load', () => {
             }]
         }]
     });
-    menu.position(45, 0);
+    menu.position(40, 0);
     root.append(menu);
 
     const tooltip = LegacyTooltip.attach({


### PR DESCRIPTION
## Summary

- Reduces left toolbar button size from **45x45px** to **40x40px**, aligning with industry-standard sizing used by Unity, Godot, Figma, and Blender (32-40px range). Icon font sizes remain unchanged at 20px, improving the icon-to-button fill ratio from 44% to 50%.
- Adds a responsive `@media (max-height: 760px)` rule that hides the 5 community/help buttons (GitHub, Discord, Forum, "How do I...?", Controls) on shorter screens. These are all still accessible via the Logo Menu > Help submenu. Settings remains pinned to the bottom via `margin-top: auto`.
- Reclaims **5px of horizontal viewport space** from the narrower toolbar column (45px → 40px).

## Details

The left toolbar currently has 19 buttons at 45px each, requiring 855px of vertical space. On laptops with ~768px viewport height, the bottom buttons overflow and become inaccessible.

This PR addresses the issue in two ways:

1. **Smaller buttons** (45px → 40px): Saves 95px total (19 × 5px), bringing the minimum to 760px.
2. **Responsive hiding**: When even 760px isn't available, the 5 least-critical buttons are hidden, leaving 14 buttons at 560px — comfortable on any modern screen.

### Files changed

| File | Change |
|------|--------|
| `sass/editor/_editor-layout.scss` | Grid column: 45px → 40px |
| `sass/editor/_editor-left-toolbar.scss` | Button size, line-height, logo sprite, responsive media query |
| `src/editor/toolbar/toolbar-logo.ts` | Menu position offset: 45 → 40 |
| `src/editor/toolbar/toolbar-discord.ts` | Discord SVG vertical centering: 14px → 9px |

## Test Plan

- [x] Verify toolbar renders correctly at normal desktop resolution (1080p+)
- [x] Resize browser window to <760px height and confirm the 5 community/help buttons hide
- [x] Confirm Settings button stays pinned to bottom in both states
- [x] Confirm logo menu opens in the correct position (flush with toolbar edge)
- [x] Verify Discord icon is vertically centered in its button
- [x] Confirm all hidden buttons are still accessible via Logo Menu > Help
