### PR TITLE
[TEST] Enable parallel Playwright workers in CI

### DIFF
--- a/test-suite/playwright.config.mjs
+++ b/test-suite/playwright.config.mjs
@@ -15,10 +15,10 @@ const CHROME_ARGS = [
 export default defineConfig({
     timeout: 2 * 60 * 1000,
     testDir: './test',
-    fullyParallel: false, // FIXME: Enable once account per worker is implemented
+    fullyParallel: false,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: 1, // FIXME: Enable once account per worker is implemented
+    workers: process.env.CI ? 2 : undefined,
     reporter: process.env.CI ? 'list' : 'html',
     use: {
         trace: 'on-first-retry'


### PR DESCRIPTION
### What's Changed
- Set Playwright workers to 2 in CI (was hardcoded to 1), defaulting to Playwright's auto-detection locally
- Removed stale FIXME comments about account-per-worker

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)