### PR TITLE
chore: log console message when using non-default frontend

### DIFF
--- a/src/editor/console/console.ts
+++ b/src/editor/console/console.ts
@@ -177,8 +177,8 @@ editor.on('load', () => {
         editor.call('layout:console:add', Date.now(), 'info', 'Viewing project in read-only mode');
     }
 
-    // log local frontend usage
+    // log frontend usage
     if (!config.url.frontend.startsWith('/editor/scene')) {
-        editor.call('console:log', `Using local frontend: ${config.url.frontend}`);
+        editor.call('console:log', `Using frontend ${config.url.frontend}`);
     }
 });


### PR DESCRIPTION
### What's Changed
- Log a console info message when a custom (non-default) frontend URL is active, so developers using `use_local_frontend` can immediately see where the bundle is served from

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)