### PR TITLE
fix: scroll hierarchy to newly selected entity

### DIFF
--- a/src/editor/entities/entities-treeview.ts
+++ b/src/editor/entities/entities-treeview.ts
@@ -214,7 +214,7 @@ class EntitiesTreeView extends TreeView {
         this._suspendSelectionEvents = false;
 
         if (lastItem) {
-            (lastItem as TreeViewItem).content.dom.scrollIntoView({ block: 'nearest' });
+            lastItem.content.dom.scrollIntoView({ block: 'nearest' });
         }
     }
 


### PR DESCRIPTION
## Summary

- After PCUI 6.0.0 decoupled DOM focus from selection (`TreeViewItem.selected = true` no longer calls `focus()`), the hierarchy panel stopped scrolling to entities that are selected programmatically (e.g. on creation, undo/redo, viewport selection).
- Add an explicit `scrollIntoView({ block: 'nearest' })` call in `_onSelectorChange` so the last selected entity is revealed if off-screen, without stealing keyboard focus from other panels.

Fixes #1842

## Test plan

- [x] Narrow the editor window so the hierarchy panel is short
- [x] Create entities until they extend beyond the visible area — the hierarchy should auto-scroll to each new entity
- [x] Select an off-screen entity in the viewport — the hierarchy should scroll to reveal it
- [x] Undo/redo entity creation — the hierarchy should scroll to the restored selection
- [x] Click an entity already visible in the hierarchy — no unexpected scrolling should occur
- [x] Verify keyboard focus stays in the viewport/toolbar after entity creation (not stolen by the hierarchy)
