### PR TITLE
[Fix] Hide frontend URL from console log

### DIFF
--- a/src/editor/console/console.ts
+++ b/src/editor/console/console.ts
@@ -179,6 +179,6 @@ editor.on('load', () => {
 
     // log frontend usage
     if (!config.url.frontend.startsWith('/editor/scene')) {
-        editor.call('console:log', `Using frontend ${config.url.frontend}`);
+        editor.call('console:log', 'Using local frontend');
     }
 });


### PR DESCRIPTION
### What's Changed
- Replace the console log message that previously exposed the full frontend URL (`config.url.frontend`) with a generic "Using local frontend" message to avoid leaking internal URL structure.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)