### PR TITLE
fix: update Inspector when arrow-keying through folders in Assets panel

### DIFF
--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -2236,6 +2236,10 @@ class AssetPanel extends Panel {
                 } else {
                     item.selected = false;
                     this.currentFolder = item.asset;
+
+                    if (this._foldersView.pressedArrow) {
+                        editor.call('selector:set', 'asset', [item.asset]);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

- Fix arrow key navigation in the Assets panel folder TreeView not updating the Inspector
- When navigating folders with arrow keys, the GridView/Table updated correctly but the Inspector never loaded the folder asset

## Details

The `_onFolderTreeSelect` handler treats mouse clicks and keyboard navigation identically. For mouse clicks, the two-click pattern is intentional (first click navigates into the folder, second click inspects it). But for arrow key navigation, the user expects the Inspector to update as they browse.

This uses the new `pressedArrow` property from PCUI's TreeView (playcanvas/pcui#517) to detect arrow key navigation and call `selector:set` to load the folder into the Inspector.

## Test plan

- [x] Click a folder once — GridView shows folder contents, Inspector does **not** change
- [x] Click the same folder again — Inspector shows the folder asset
- [x] Arrow key to a different folder — GridView updates **and** Inspector shows the new folder
- [x] Ctrl+click / Shift+click folder selection still works as before
