### PR TITLE
fix: prevent 'Go one folder up' from changing editor selection

### DIFF
--- a/src/editor/assets/asset-panel.ts
+++ b/src/editor/assets/asset-panel.ts
@@ -2493,7 +2493,11 @@ class AssetPanel extends Panel {
         }
 
         const view = this._viewMode === AssetPanel.VIEW_DETAILS ? this._detailsView : this._gridView;
-        view.once('filter:end', () => this._focusAssetItem(prevFolderId));
+        view.once('filter:end', () => {
+            this._suspendSelectEvents = true;
+            this._focusAssetItem(prevFolderId);
+            this._suspendSelectEvents = false;
+        });
 
         this.currentFolder = folder;
     }


### PR DESCRIPTION
## Summary

- Fix the "Go one folder up" button in the Assets panel so it only moves the active/current folder highlight to the parent folder without changing the editor's asset selection.

## Details

`navigateBack()` calls `_focusAssetItem()` after filtering completes to scroll the previous folder into view. However, `_focusAssetItem` also sets `selected = true` on the grid/table item, which triggers `_onSelectAssetElement` → `editor.call('selector:add', ...)`, modifying the editor's selection as a side effect.

The fix wraps the `_focusAssetItem` call with `_suspendSelectEvents = true` so the item is still focused and scrolled into view, but the selector is not modified.
