### PR TITLE
fix: use correct path property for Resolution Height setting

### DIFF
--- a/src/editor/inspector/settings-panels/rendering.ts
+++ b/src/editor/inspector/settings-panels/rendering.ts
@@ -387,7 +387,7 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
     {
         observer: 'projectSettings',
         label: 'Resolution Height',
-        paths: 'height',
+        path: 'height',
         type: 'number',
         args: {
             min: 1


### PR DESCRIPTION
## Summary
- The Resolution Height attribute in Rendering settings incorrectly used `paths` (plural) instead of `path`, causing `_getFieldKey()` to index into the string `'height'` and return `'h'` as the field key instead of `'height'`.
- The field still worked due to PCUI's binding layer accepting `string | string[]`, but the wrong key meant clipboard copy/paste was not registered and any future `getField('height')` call would fail.

## Test plan
- Open the Editor and go to **Settings > Rendering**
- Verify the **Resolution Height** field displays the correct value
- Verify editing it persists correctly
- Right-click the **Resolution Height** field and confirm the clipboard context menu now appears (matching **Resolution Width** behavior)