### PR TITLE
fix: remove extra arguments from element inspector binding constructors

### DIFF
--- a/src/editor/inspector/components/element.ts
+++ b/src/editor/inspector/components/element.ts
@@ -738,18 +738,14 @@ class ElementComponentInspector extends ComponentInspector {
             history: args.history,
             bindingElementToObservers: new ImageAssetElementToObserversBinding(args.assets, {
                 history: args.history
-            },
-            this.entities
-            )
+            })
         });
         // update binding of spriteFrame field
         this._field('spriteFrame').binding = new BindingTwoWay({
             history: args.history,
             bindingElementToObservers: new SpriteFrameElementToObserversBinding(args.assets, {
                 history: args.history
-            },
-            this.entities
-            )
+            })
         });
 
         // reset size button tooltip


### PR DESCRIPTION
## Summary

- Removes extraneous `this.entities` third argument from `ImageAssetElementToObserversBinding` and `SpriteFrameElementToObserversBinding` constructor calls in the element inspector
- Both constructors only accept two parameters `(assets, args)` — the extra argument was silently ignored
- Matches the existing correct pattern used by the `textureAsset` binding just above
