### PR TITLE
fix: replace inline import() type annotations with regular imports in inspector

### DIFF
--- a/src/editor/inspector/assets/font.ts
+++ b/src/editor/inspector/assets/font.ts
@@ -7,6 +7,7 @@ import { Table } from '@/common/pcui/element/element-table';
 import { TableCell } from '@/common/pcui/element/element-table-cell';
 import { TableRow } from '@/common/pcui/element/element-table-row';
 import { tooltip, tooltipRefItem } from '@/common/tooltips';
+import type { History } from '@/editor-api';
 
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -282,7 +283,7 @@ const CHARACTER_PRESETS = {
 
 type FontAssetInspectorArgs = {
     assets?: Observer[];
-    history?: import('@/editor-api').History;
+    history?: History;
 } & Record<string, unknown>;
 
 class FontAssetInspector extends Container {

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -4,6 +4,7 @@ import * as pc from 'playcanvas';
 
 import { CLASS_MULTIPLE_VALUES } from '@/common/pcui/constants';
 import { pathExists } from '@/common/utils';
+import type { History } from '@/editor-api';
 
 import type { Attribute, Divider } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -1270,7 +1271,7 @@ const TextureTransformTypes = {
 };
 
 type MaterialAssetInspectorArgs = {
-    history?: import('@/editor-api').History;
+    history?: History;
 } & Record<string, unknown>;
 
 class MaterialAssetInspector extends Container {

--- a/src/editor/inspector/assets/texture.ts
+++ b/src/editor/inspector/assets/texture.ts
@@ -952,7 +952,7 @@ class TextureAssetInspector extends Container {
 
     }
 
-    _setupImportButton(panel: import('@playcanvas/pcui').Container, moduleStoreName: string, wasmFilename: string) {
+    _setupImportButton(panel: Container, moduleStoreName: string, wasmFilename: string) {
         if (!this._containerImportBasis) {
             this._containerImportBasis = new Container({
                 flex: true,

--- a/src/editor/inspector/components/anim.ts
+++ b/src/editor/inspector/components/anim.ts
@@ -558,7 +558,7 @@ class AnimComponentInspector extends ComponentInspector {
         }
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         this.unlink();
         super.link(entities);
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/animation.ts
+++ b/src/editor/inspector/components/animation.ts
@@ -1,5 +1,5 @@
-import type { ObserverList } from '@playcanvas/observer';
-import { Button } from '@playcanvas/pcui';
+import type { Observer, ObserverList } from '@playcanvas/observer';
+import { Button, type Element as PcuiElement } from '@playcanvas/pcui';
 
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
@@ -61,14 +61,14 @@ class AnimationComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    _refreshPlayButtons(entities: import('@playcanvas/observer').Observer[], assetList: { listItems: { assetId: string; element: import('@playcanvas/pcui').Element }[] }) {
+    _refreshPlayButtons(entities: Observer[], assetList: { listItems: { assetId: string; element: PcuiElement }[] }) {
         const listItems = assetList.listItems;
         listItems.forEach((item) => {
             this._addPlayButtonForAnimation(entities, item.assetId, item.element);
         });
     }
 
-    _addPlayButtonForAnimation(entities: import('@playcanvas/observer').Observer[], assetId: string, listItem: import('@playcanvas/pcui').Element) {
+    _addPlayButtonForAnimation(entities: Observer[], assetId: string, listItem: PcuiElement) {
         // destroy existing button
         const existing = listItem.dom.querySelector(`.${CLASS_BUTTON_PLAY}`);
         if (existing) {
@@ -99,7 +99,7 @@ class AnimationComponentInspector extends ComponentInspector {
         listItem.appendAfter(btn, label);
     }
 
-    _playAnimation(entities: import('@playcanvas/observer').Observer[], assetId: string | number) {
+    _playAnimation(entities: Observer[], assetId: string | number) {
         assetId = parseInt(assetId, 10);
 
         for (let i = 0; i < entities.length; i++) {
@@ -121,7 +121,7 @@ class AnimationComponentInspector extends ComponentInspector {
         }
     }
 
-    _stopAnimation(entities: import('@playcanvas/observer').Observer[]) {
+    _stopAnimation(entities: Observer[]) {
         for (let i = 0; i < entities.length; i++) {
             if (!entities[i].entity || !entities[i].entity.animation) {
                 continue;
@@ -131,7 +131,7 @@ class AnimationComponentInspector extends ComponentInspector {
         }
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/audiolistener.ts
+++ b/src/editor/inspector/components/audiolistener.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -23,7 +25,7 @@ class AudiolistenerComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/components/audiosource.ts
+++ b/src/editor/inspector/components/audiosource.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -123,7 +125,7 @@ class AudiosourceComponentInspector extends ComponentInspector {
         this._field('rollOffFactor').parent.hidden = !is3d;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._skipToggleFields = true;

--- a/src/editor/inspector/components/button.ts
+++ b/src/editor/inspector/components/button.ts
@@ -1,4 +1,4 @@
-import type { EventHandle } from '@playcanvas/observer';
+import type { EventHandle, Observer } from '@playcanvas/observer';
 import { InfoBox } from '@playcanvas/pcui';
 
 import {
@@ -191,7 +191,7 @@ class ButtonComponentInspector extends ComponentInspector {
         });
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/camera.ts
+++ b/src/editor/inspector/components/camera.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { TONEMAPPING } from '@/core/constants';
 
 import { ComponentInspector } from './component';
@@ -194,7 +196,7 @@ class CameraComponentInspector extends ComponentInspector {
         this._field('orthoHeight').parent.hidden = fieldProjection.value !== 1;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/collision.ts
+++ b/src/editor/inspector/components/collision.ts
@@ -1,4 +1,4 @@
-import type { EventHandle } from '@playcanvas/observer';
+import type { EventHandle, Observer } from '@playcanvas/observer';
 import { InfoBox, LabelGroup } from '@playcanvas/pcui';
 import { CollisionComponent } from 'playcanvas';
 
@@ -181,7 +181,7 @@ class CollisionComponentInspector extends ComponentInspector {
         return this._attributesInspector.getField(`components.collision.${name}`);
     }
 
-    _handleTypeChange(fieldType: { value: string; binding: { on: (event: string, callback: (context: { prevHeights?: number[]; observers: import('@playcanvas/observer').Observer[] }) => void) => void } }) {
+    _handleTypeChange(fieldType: { value: string; binding: { on: (event: string, callback: (context: { prevHeights?: number[]; observers: Observer[] }) => void) => void } }) {
         // when the type changes we need to change the height of the collision
         // component to 2 if it's a capsule or 1 if it's a cylinder or cone.
         fieldType.binding.on('history:init', (context) => {
@@ -258,7 +258,7 @@ class CollisionComponentInspector extends ComponentInspector {
         this._field('renderAsset').hidden = fieldType.value !== 'mesh' || !!modelAsset;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/component.ts
+++ b/src/editor/inspector/components/component.ts
@@ -35,7 +35,7 @@ class ComponentInspector extends Panel {
 
     constructor(args: {
         component: string;
-        history: import('@/editor-api').History;
+        history: History;
         templateOverridesInspector?: TemplateOverrideInspector;
     } & Record<string, unknown>) {
         args = Object.assign({}, args);

--- a/src/editor/inspector/components/gsplat.ts
+++ b/src/editor/inspector/components/gsplat.ts
@@ -1,4 +1,4 @@
-import type { ObserverList } from '@playcanvas/observer';
+import type { Observer, ObserverList } from '@playcanvas/observer';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
 import { ComponentInspector } from './component';
@@ -56,7 +56,7 @@ class GSplatComponentInspector extends ComponentInspector {
         return this._attributesInspector.getField(`components.gsplat.${name}`);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/components/layoutchild.ts
+++ b/src/editor/inspector/components/layoutchild.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -57,7 +59,7 @@ class LayoutchildComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/components/layoutgroup.ts
+++ b/src/editor/inspector/components/layoutgroup.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import {
     ORIENTATION_HORIZONTAL,
     ORIENTATION_VERTICAL,
@@ -121,7 +123,7 @@ class LayoutgroupComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -1,4 +1,4 @@
-import type { EventHandle } from '@playcanvas/observer';
+import type { EventHandle, Observer } from '@playcanvas/observer';
 import { Button } from '@playcanvas/pcui';
 import {
     LAYERID_DEPTH,
@@ -624,7 +624,7 @@ class LightComponentInspector extends ComponentInspector {
         this._btnUpdateShadow.hidden = this._field('shadowUpdateMode').value !== SHADOWUPDATE_THISFRAME;
     }
 
-    _updateShadows(entities: import('@playcanvas/observer').Observer[]) {
+    _updateShadows(entities: Observer[]) {
         for (let i = 0; i < entities.length; i++) {
             if (entities[i].entity && entities[i].entity.light && entities[i].entity.light.shadowUpdateMode === SHADOWUPDATE_THISFRAME) {
                 entities[i].entity.light.light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
@@ -637,7 +637,7 @@ class LightComponentInspector extends ComponentInspector {
         this._field('innerConeAngle').max = this._field('outerConeAngle').value;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._skipToggleFields = true;

--- a/src/editor/inspector/components/model.ts
+++ b/src/editor/inspector/components/model.ts
@@ -1,4 +1,4 @@
-import type { ObserverList } from '@playcanvas/observer';
+import type { Observer, ObserverList } from '@playcanvas/observer';
 import { Label, Container, Button, BindingTwoWay, BindingElementToObservers } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
@@ -393,7 +393,7 @@ class ModelComponentInspector extends ComponentInspector {
         return result;
     }
 
-    _getMeshInstanceName(index: number, entities: import('@playcanvas/observer').Observer[]) {
+    _getMeshInstanceName(index: number, entities: Observer[]) {
         // get name of meshinstance from engine
         let meshInstanceName;
         for (let i = 0; i < entities.length; i++) {
@@ -415,7 +415,7 @@ class ModelComponentInspector extends ComponentInspector {
         return meshInstanceName;
     }
 
-    _createMappingInspector(key: string, entities: import('@playcanvas/observer').Observer[]) {
+    _createMappingInspector(key: string, entities: Observer[]) {
         const index = parseInt(key, 10);
 
         if (this._mappingInspectors[key]) {
@@ -515,7 +515,7 @@ class ModelComponentInspector extends ComponentInspector {
         return container;
     }
 
-    _refreshMappings(dirtyMappings?: Record<string, import('@playcanvas/observer').Observer[]>) {
+    _refreshMappings(dirtyMappings?: Record<string, Observer[]>) {
         if (this._timeoutRefreshMappings) {
             cancelAnimationFrame(this._timeoutRefreshMappings);
         }
@@ -729,7 +729,7 @@ class ModelComponentInspector extends ComponentInspector {
         }
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._suppressToggleFields = true;

--- a/src/editor/inspector/components/particlesystem.ts
+++ b/src/editor/inspector/components/particlesystem.ts
@@ -1,3 +1,4 @@
+import type { Observer } from '@playcanvas/observer';
 import { Button, LabelGroup } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
@@ -591,7 +592,7 @@ class ParticlesystemComponentInspector extends ComponentInspector {
         });
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._suppressToggleFields = true;

--- a/src/editor/inspector/components/render.ts
+++ b/src/editor/inspector/components/render.ts
@@ -1,5 +1,5 @@
-import type { ObserverList } from '@playcanvas/observer';
-import { Label } from '@playcanvas/pcui';
+import type { Observer, ObserverList } from '@playcanvas/observer';
+import { Label, type Element as PcuiElement } from '@playcanvas/pcui';
 import { LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_IMMEDIATE } from 'playcanvas';
 
 import { CLASS_ERROR } from '@/common/pcui/constants';
@@ -201,7 +201,7 @@ class RenderComponentInspector extends ComponentInspector {
 
     // when the render type or the render asset change,
     // also change the materialAssets to the correct length
-    _changeMaterialsOnChange(field: import('@playcanvas/pcui').Element) {
+    _changeMaterialsOnChange(field: PcuiElement) {
         const binding = field.binding;
         if (!binding) {
             return;
@@ -460,7 +460,7 @@ class RenderComponentInspector extends ComponentInspector {
         this._toggleFields();
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._suppressToggleFields = true;

--- a/src/editor/inspector/components/rigidbody.ts
+++ b/src/editor/inspector/components/rigidbody.ts
@@ -1,3 +1,4 @@
+import type { Observer } from '@playcanvas/observer';
 import { LabelGroup } from '@playcanvas/pcui';
 
 import { ComponentInspector } from './component';
@@ -168,7 +169,7 @@ class RigidbodyComponentInspector extends ComponentInspector {
         });
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/screen.ts
+++ b/src/editor/inspector/components/screen.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { deepCopy } from '@/common/utils';
 
 import { ComponentInspector } from './component';
@@ -103,7 +105,7 @@ class ScreenComponentInspector extends ComponentInspector {
         this._field('scaleBlend').parent.hidden = scaleMode !== 'blend' || !screenSpace;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/script.ts
+++ b/src/editor/inspector/components/script.ts
@@ -1248,7 +1248,7 @@ class ScriptComponentInspector extends ComponentInspector {
         });
     }
 
-    _parseUnparsedScripts(assets: import('@playcanvas/observer').Observer[]) {
+    _parseUnparsedScripts(assets: Observer[]) {
         assets.forEach(a => editor.call('scripts:parse', a, (err) => {
             a.set('data.lastParsedHash', a.get('file.hash'));
         }));

--- a/src/editor/inspector/components/scrollbar.ts
+++ b/src/editor/inspector/components/scrollbar.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { deepCopy } from '@/common/utils';
 import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from '@/core/constants';
 
@@ -74,7 +76,7 @@ class ScrollbarComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/components/scrollview.ts
+++ b/src/editor/inspector/components/scrollview.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { deepCopy } from '@/common/utils';
 import {
     SCROLL_MODE_BOUNCE,
@@ -183,7 +185,7 @@ class ScrollviewComponentInspector extends ComponentInspector {
         this._field('horizontalScrollbarVisibility').parent.hidden = !horizontalScrollingEnabled;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._suppressToggleFields = true;
         this._attributesInspector.link(entities);

--- a/src/editor/inspector/components/sound.ts
+++ b/src/editor/inspector/components/sound.ts
@@ -218,7 +218,7 @@ class SoundSlotInspector extends Panel {
         }
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         this.unlink();
 
         this._entities = entities;
@@ -331,7 +331,7 @@ class SoundComponentInspector extends ComponentInspector {
         this._field('rollOffFactor').parent.hidden = !positional;
     }
 
-    _onClickAddSlot(entity: import('@playcanvas/observer').Observer) {
+    _onClickAddSlot(entity: Observer) {
         let keyName = 1;
         let count = 0;
         const idx = {};
@@ -362,7 +362,7 @@ class SoundComponentInspector extends ComponentInspector {
         });
     }
 
-    _createSlotInspector(entity: import('@playcanvas/observer').Observer, slotKey: string, slot: Record<string, unknown>) {
+    _createSlotInspector(entity: Observer, slotKey: string, slot: Record<string, unknown>) {
         const inspector = new SoundSlotInspector({
             slotKey: slotKey,
             slot: slot,
@@ -381,7 +381,7 @@ class SoundComponentInspector extends ComponentInspector {
         return inspector;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._suppressToggleFields = true;

--- a/src/editor/inspector/components/sprite.ts
+++ b/src/editor/inspector/components/sprite.ts
@@ -146,7 +146,7 @@ const CLASS_CLIP = 'sprite-component-inspector-clip';
 const REGEX_CLIP = /^components.sprite.clips.\d+$/;
 const REGEX_CLIP_NAME = /^components.sprite.clips.\d+\.name$/;
 
-function getClipsGroupedByName(entities: import('@playcanvas/observer').Observer[]) {
+function getClipsGroupedByName(entities: Observer[]) {
     const result = {};
 
     // first group clips by name
@@ -169,7 +169,7 @@ function getClipsGroupedByName(entities: import('@playcanvas/observer').Observer
     return result;
 }
 
-function getCommonClips(entities: import('@playcanvas/observer').Observer[]) {
+function getCommonClips(entities: Observer[]) {
     const result = getClipsGroupedByName(entities);
 
     // then remove all clips who are not shared across all entities
@@ -315,7 +315,7 @@ class SpriteClipInspector extends Panel {
         redo();
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         this.unlink();
 
         this._entities = entities;
@@ -504,7 +504,7 @@ class SpriteComponentInspector extends ComponentInspector {
         redo();
     }
 
-    _createClipInspector(entities: import('@playcanvas/observer').Observer[], clipName: string, clipKeys: string[], insertBeforeElement?: Element) {
+    _createClipInspector(entities: Observer[], clipName: string, clipKeys: string[], insertBeforeElement?: Element) {
         const inspector = new SpriteClipInspector({
             clipName: clipName,
             clipKeys: clipKeys,
@@ -563,7 +563,7 @@ class SpriteComponentInspector extends ComponentInspector {
         this._updateAutoPlayOptions();
     }
 
-    _onSetClipName(entity: import('@playcanvas/observer').Observer, name: string, oldName: string) {
+    _onSetClipName(entity: Observer, name: string, oldName: string) {
         // update autoPlayClip
         if (entity.get('components.sprite.autoPlayClip') === oldName) {
             const history = entity.history.enabled;
@@ -658,7 +658,7 @@ class SpriteComponentInspector extends ComponentInspector {
         this._field('height').parent.hidden = hideSizeFields;
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
 
         this._suppressToggleFields = true;

--- a/src/editor/inspector/components/zone.ts
+++ b/src/editor/inspector/components/zone.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { ComponentInspector } from './component';
 import type { Attribute } from '../attribute.type.d';
 import { AttributesInspector } from '../attributes-inspector';
@@ -33,7 +35,7 @@ class ZoneComponentInspector extends ComponentInspector {
         this.append(this._attributesInspector);
     }
 
-    link(entities: import('@playcanvas/observer').Observer[]) {
+    link(entities: Observer[]) {
         super.link(entities);
         this._attributesInspector.link(entities);
     }

--- a/src/editor/inspector/entity.ts
+++ b/src/editor/inspector/entity.ts
@@ -1,4 +1,4 @@
-import type { EventHandle, Observer } from '@playcanvas/observer';
+import type { EventHandle, Observer, ObserverList } from '@playcanvas/observer';
 import { Container, Button, Menu, TextInput, VectorInput } from '@playcanvas/pcui';
 
 import { COMPONENT_LOGOS } from '@/core/constants';
@@ -192,10 +192,10 @@ const ATTRIBUTES: Attribute[] = [{
 }];
 
 type EntityInspectorArgs = {
-    history?: import('@/editor-api').History;
+    history?: History;
     projectSettings?: Observer;
-    assets?: import('@playcanvas/observer').ObserverList;
-    entities?: import('@playcanvas/observer').ObserverList;
+    assets?: ObserverList;
+    entities?: ObserverList;
     templateOverridesDiffView?: unknown;
 } & Record<string, unknown>;
 

--- a/src/editor/inspector/settings-panels/localization.ts
+++ b/src/editor/inspector/settings-panels/localization.ts
@@ -1,3 +1,5 @@
+import type { Observer } from '@playcanvas/observer';
+
 import { BaseSettingsPanel } from './base';
 import type { Attribute } from '../attribute.type.d';
 
@@ -51,7 +53,7 @@ class LocalizationSettingsPanel extends BaseSettingsPanel {
         });
     }
 
-    link(observers: import('@playcanvas/observer').Observer[]) {
+    link(observers: Observer[]) {
         super.link(observers);
         if (!this._createAssetTooltip) {
             this._createAssetTooltip = editor.call('attributes:reference:attach', 'settings:localization:createAsset', this._attributesInspector.getField('createAsset'));


### PR DESCRIPTION
## Summary

- Replace all inline `import()` type annotations with regular top-level `import type` statements across 28 files in `src/editor/inspector/`
- No functional changes -- all replaced imports were TypeScript type-position only (erased at compile time)

## Details

Inline type imports like `entities: import('@playcanvas/observer').Observer[]` have been converted to use standard top-level imports (e.g. `import type { Observer } from '@playcanvas/observer'`), improving readability and consistency.

Where the needed type was already imported at the top of the file, it was simply reused. Where it wasn't, it was added to an existing import statement or a new `import type` was introduced.

For `animation.ts` and `render.ts`, PCUI's `Element` is imported as `PcuiElement` to avoid shadowing the global DOM `Element` type.
