### PR TITLE
fix: remove redundant unlink calls before super.link in inspectors

### DIFF
--- a/src/editor/inspector/assets/sprite-preview.ts
+++ b/src/editor/inspector/assets/sprite-preview.ts
@@ -99,7 +99,6 @@ class SpriteAssetInspectorPreview extends AssetInspectorPreviewBase {
     }
 
     link(assets: Observer[]) {
-        this.unlink();
         super.link();
         this._previewRenderer = new SpriteThumbnailRenderer(assets[0], this._preview.dom as HTMLCanvasElement, editor.call('assets:raw'));
         this._spriteFrames = assets[0].get('data.frameKeys').length;

--- a/src/editor/inspector/assets/template-preview.ts
+++ b/src/editor/inspector/assets/template-preview.ts
@@ -39,7 +39,6 @@ class TemplateAssetInspectorPreview extends AssetInspectorPreviewBase {
     }
 
     link(assets: Observer[]) {
-        this.unlink();
         super.link();
 
         this._previewRenderer = new TemplateThumbnailRenderer(

--- a/src/editor/inspector/components/anim.ts
+++ b/src/editor/inspector/components/anim.ts
@@ -559,7 +559,6 @@ class AnimComponentInspector extends ComponentInspector {
     }
 
     link(entities: Observer[]) {
-        this.unlink();
         super.link(entities);
         this._attributesInspector.link(entities);
 


### PR DESCRIPTION
## Summary

- Remove redundant `this.unlink()` calls in `AnimComponentInspector`, `TemplateAssetInspectorPreview` and `SpriteAssetInspectorPreview`
- In all three cases, `super.link()` already calls `this.unlink()` as its first action (dispatching polymorphically to the subclass override), so the explicit call beforehand caused `unlink()` to run twice for no benefit
