### PR TITLE
fix: use editor layout API instead of document.querySelector in anim inspector

### DIFF
--- a/src/editor/inspector/components/anim.ts
+++ b/src/editor/inspector/components/anim.ts
@@ -452,7 +452,7 @@ class AnimComponentInspector extends ComponentInspector {
         }
         this._contextMenus.length = 0;
 
-        document.querySelector('#layout-attributes').ui.headerText = 'ENTITY';
+        editor.call('layout.attributes').headerText = 'ENTITY';
         this._maskEvts.forEach(e => e.unbind());
         this._maskEvts.length = 0;
     }


### PR DESCRIPTION
## Summary

- Replace `document.querySelector('#layout-attributes').ui.headerText` with `editor.call('layout.attributes').headerText` in the anim inspector's `_clearMaskInspector` method
- This matches the pattern already used elsewhere in the same file (line 148) and across the codebase
