### PR TITLE
Fix requestAnimationFrame field naming, type, and handle lifecycle

### DIFF
--- a/src/editor/inspector/components/model.ts
+++ b/src/editor/inspector/components/model.ts
@@ -271,7 +271,7 @@ class ModelComponentInspector extends ComponentInspector {
 
     _suppressCustomAabb = false;
 
-    _timeoutRefreshMappings: number | null = null;
+    _rafRefreshMappings: number | null = null;
 
     _dirtyMappings = new Set<string>();
 
@@ -512,12 +512,12 @@ class ModelComponentInspector extends ComponentInspector {
     }
 
     _refreshMappings(dirtyKeys?: Set<string>) {
-        if (this._timeoutRefreshMappings) {
-            cancelAnimationFrame(this._timeoutRefreshMappings);
+        if (this._rafRefreshMappings) {
+            cancelAnimationFrame(this._rafRefreshMappings);
         }
 
-        this._timeoutRefreshMappings = requestAnimationFrame(() => {
-            this._timeoutRefreshMappings = null;
+        this._rafRefreshMappings = requestAnimationFrame(() => {
+            this._rafRefreshMappings = null;
 
             const mappings = this._groupMappingsByKey();
             const keys = dirtyKeys ?? new Set(Object.keys(mappings));
@@ -795,9 +795,9 @@ class ModelComponentInspector extends ComponentInspector {
         this._containerMappings.clear();
         this._mappingInspectors = {};
 
-        if (this._timeoutRefreshMappings) {
-            cancelAnimationFrame(this._timeoutRefreshMappings);
-            this._timeoutRefreshMappings = null;
+        if (this._rafRefreshMappings) {
+            cancelAnimationFrame(this._rafRefreshMappings);
+            this._rafRefreshMappings = null;
         }
         this._dirtyMappings.clear();
     }

--- a/src/editor/inspector/components/script.ts
+++ b/src/editor/inspector/components/script.ts
@@ -968,7 +968,7 @@ class ScriptComponentInspector extends ComponentInspector {
 
     private _dirtyScripts: Set<string> = new Set();
 
-    private _dirtyScriptsTimeout: number | null = null;
+    private _rafDirtyScripts: number | null = null;
 
     private _updateScriptsTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -1146,19 +1146,19 @@ class ScriptComponentInspector extends ComponentInspector {
     }
 
     _deferUpdateDirtyScripts() {
-        if (this._dirtyScriptsTimeout) {
-            cancelAnimationFrame(this._dirtyScriptsTimeout);
+        if (this._rafDirtyScripts) {
+            cancelAnimationFrame(this._rafDirtyScripts);
         }
 
-        this._dirtyScriptsTimeout = requestAnimationFrame(this._updateDirtyScripts.bind(this));
+        this._rafDirtyScripts = requestAnimationFrame(this._updateDirtyScripts.bind(this));
     }
 
     _updateDirtyScripts() {
-        if (this._dirtyScriptsTimeout) {
-            cancelAnimationFrame(this._dirtyScriptsTimeout);
+        if (this._rafDirtyScripts) {
+            cancelAnimationFrame(this._rafDirtyScripts);
         }
 
-        this._dirtyScriptsTimeout = null;
+        this._rafDirtyScripts = null;
 
         if (this._dirtyScripts.size) {
             this._updateScripts(this._dirtyScripts);
@@ -1556,8 +1556,9 @@ class ScriptComponentInspector extends ComponentInspector {
         this._scriptPanels = {};
         this._dirtyScripts = new Set();
 
-        if (this._dirtyScriptsTimeout) {
-            cancelAnimationFrame(this._dirtyScriptsTimeout);
+        if (this._rafDirtyScripts) {
+            cancelAnimationFrame(this._rafDirtyScripts);
+            this._rafDirtyScripts = null;
         }
 
         if (this._updateScriptsTimeout) {

--- a/src/editor/inspector/components/sprite.ts
+++ b/src/editor/inspector/components/sprite.ts
@@ -369,7 +369,7 @@ class SpriteComponentInspector extends ComponentInspector {
 
     _btnAddClip: Button;
 
-    _timeoutAfterClipNameChange: ReturnType<typeof setTimeout> | null = null;
+    _rafClipNameChange: number | null = null;
 
     _suppressToggleFields = false;
 
@@ -573,14 +573,16 @@ class SpriteComponentInspector extends ComponentInspector {
             entity.history.enabled = history;
         }
 
-        if (this._timeoutAfterClipNameChange) {
-            cancelAnimationFrame(this._timeoutAfterClipNameChange);
+        if (this._rafClipNameChange) {
+            cancelAnimationFrame(this._rafClipNameChange);
         }
 
-        this._timeoutAfterClipNameChange = requestAnimationFrame(this._onAfterClipNameChange.bind(this));
+        this._rafClipNameChange = requestAnimationFrame(this._onAfterClipNameChange.bind(this));
     }
 
     _onAfterClipNameChange() {
+        this._rafClipNameChange = null;
+
         if (!this._entities) {
             return;
         }
@@ -707,6 +709,11 @@ class SpriteComponentInspector extends ComponentInspector {
     unlink() {
         super.unlink();
         this._attributesInspector.unlink();
+
+        if (this._rafClipNameChange) {
+            cancelAnimationFrame(this._rafClipNameChange);
+            this._rafClipNameChange = null;
+        }
 
         for (const key in this._clipInspectors) {
             this._clipInspectors[key].destroy();


### PR DESCRIPTION
## Summary

- Renames `requestAnimationFrame` handle fields that were misleadingly named with "timeout" to use a `_raf` prefix, accurately reflecting their use of `requestAnimationFrame`/`cancelAnimationFrame` rather than `setTimeout`/`clearTimeout`
- Fixes incorrect type `ReturnType<typeof setTimeout>` to `number` for `_rafClipNameChange` in `sprite.ts`
- Fixes RAF handle lifecycle: ensures handles are nulled after firing and properly cancelled+nulled in `unlink()` to prevent stale state and post-unlink work

### Renames

| File | Old Name | New Name |
|---|---|---|
| `sprite.ts` | `_timeoutAfterClipNameChange` | `_rafClipNameChange` |
| `script.ts` | `_dirtyScriptsTimeout` | `_rafDirtyScripts` |
| `model.ts` | `_timeoutRefreshMappings` | `_rafRefreshMappings` |

### Lifecycle fixes

- **`sprite.ts`**: `_onAfterClipNameChange` now nulls `_rafClipNameChange` on entry (the RAF has already fired); `unlink()` now cancels+nulls the pending RAF
- **`script.ts`**: `unlink()` now nulls `_rafDirtyScripts` after cancelling it (was cancel-only)
- **`model.ts`**: Already had correct lifecycle handling (no changes)
