### PR TITLE
fix: use base class _entityEvents instead of custom _evts array in button and collision inspectors

### DIFF
--- a/src/editor/inspector/components/button.ts
+++ b/src/editor/inspector/components/button.ts
@@ -1,4 +1,3 @@
-import type { EventHandle } from '@playcanvas/observer';
 import { InfoBox } from '@playcanvas/pcui';
 
 import {
@@ -122,9 +121,6 @@ const ATTRIBUTES: Attribute[] = [{
 class ButtonComponentInspector extends ComponentInspector {
     _inputWarning: InfoBox;
 
-    _evts: EventHandle[] = [];
-
-
     _suppressToggleFields = false;
 
     constructor(args: ComponentInspectorArgs) {
@@ -196,15 +192,9 @@ class ButtonComponentInspector extends ComponentInspector {
         const updateInputWarning = () => {
             this._inputWarning.hidden = entities.length !== 1 || entities[0].get('components.element.useInput') || !entities[0].get('components.button.active');
         };
-        this._evts.push(entities[0].on('components.element.useInput:set', updateInputWarning));
-        this._evts.push(entities[0].on('components.button.active:set', updateInputWarning));
+        this._entityEvents.push(entities[0].on('components.element.useInput:set', updateInputWarning));
+        this._entityEvents.push(entities[0].on('components.button.active:set', updateInputWarning));
         updateInputWarning();
-    }
-
-    unlink() {
-        super.unlink();
-        this._evts.forEach(e => e.unbind());
-        this._evts = [];
     }
 }
 

--- a/src/editor/inspector/components/collision.ts
+++ b/src/editor/inspector/components/collision.ts
@@ -1,4 +1,4 @@
-import type { EventHandle, Observer } from '@playcanvas/observer';
+import type { Observer } from '@playcanvas/observer';
 import { InfoBox, LabelGroup } from '@playcanvas/pcui';
 import { CollisionComponent } from 'playcanvas';
 
@@ -123,9 +123,6 @@ const ATTRIBUTES: Attribute[] = [{
 
 class CollisionComponentInspector extends ComponentInspector {
     _variedTransformScalesWarning: InfoBox;
-
-    _evts: EventHandle[] = [];
-
 
     _suppressToggleFields = false;
 
@@ -290,18 +287,12 @@ class CollisionComponentInspector extends ComponentInspector {
             }
             this._variedTransformScalesWarning.hidden = false;
         };
-        this._evts.push(entities[0].on('*:set', (path) => {
+        this._entityEvents.push(entities[0].on('*:set', (path) => {
             if (path === 'components.collision.type' || path.indexOf('scale.') === 0) {
                 updateVariedTransformScalesWarning();
             }
         }));
         updateVariedTransformScalesWarning();
-    }
-
-    unlink() {
-        super.unlink();
-        this._evts.forEach(e => e.unbind());
-        this._evts = [];
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace redundant `_evts` arrays in `ButtonComponentInspector` and `CollisionComponentInspector` with the `_entityEvents` array already provided by the `ComponentInspector` base class
- Remove the now-unnecessary `unlink()` overrides since the base class handles event cleanup
- Follows the same pattern established in #1884 for the anim inspector

## Test plan

- [x] Verify button component inspector shows/hides the input warning correctly when toggling `useInput` and `active`
- [x] Verify collision component inspector shows/hides the non-uniform scale warning correctly when changing collision type or entity scale
- [x] Verify unlinking (selecting a different entity) properly cleans up event listeners
