### PR TITLE
refactor: move legacy/removed title logic to component inspector subclasses

### DIFF
--- a/src/editor/inspector/components/anim.ts
+++ b/src/editor/inspector/components/anim.ts
@@ -83,7 +83,6 @@ class AnimComponentInspector extends ComponentInspector {
 
     _maskEvts: EventHandle[] = [];
 
-
     _normalizeWeightsMessage: InfoBox;
 
     _layersContainer: Container;

--- a/src/editor/inspector/components/animation.ts
+++ b/src/editor/inspector/components/animation.ts
@@ -44,12 +44,13 @@ const CLASS_BUTTON_PLAY = 'animation-component-inspector-play';
 class AnimationComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     constructor(args: ComponentInspectorArgs) {
         args = Object.assign({}, args);
         args.component = 'animation';
 
         super(args);
+
+        this.headerText += ' (LEGACY)';
 
         this._assets = args.assets;
 

--- a/src/editor/inspector/components/audiosource.ts
+++ b/src/editor/inspector/components/audiosource.ts
@@ -90,6 +90,8 @@ class AudiosourceComponentInspector extends ComponentInspector {
 
         super(args);
 
+        this.headerText += editor.projectEngineV2 ? ' (REMOVED)' : ' (LEGACY)';
+
         this._attributesInspector = new AttributesInspector({
             assets: args.assets,
             history: args.history,

--- a/src/editor/inspector/components/component.ts
+++ b/src/editor/inspector/components/component.ts
@@ -62,15 +62,7 @@ class ComponentInspector extends Panel {
         });
         this.header.prepend(iconLabel);
 
-        let title = args.component.toUpperCase();
-        if (args.component === 'animation' ||
-            args.component === 'model') {
-            title += ' (LEGACY)';
-        }
-        if (args.component === 'audiosource') {
-            title += editor.projectEngineV2 ? ' (REMOVED)' : ' (LEGACY)';
-        }
-        this.headerText = title;
+        this.headerText = args.component.toUpperCase();
 
         this._history = args.history;
 

--- a/src/editor/inspector/components/gsplat.ts
+++ b/src/editor/inspector/components/gsplat.ts
@@ -31,7 +31,6 @@ const ATTRIBUTES: Attribute[] = [{
 class GSplatComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     constructor(args: ComponentInspectorArgs) {
         args = Object.assign({}, args);
         args.component = 'gsplat';

--- a/src/editor/inspector/components/model.ts
+++ b/src/editor/inspector/components/model.ts
@@ -255,7 +255,6 @@ class AssetElementToObserversBinding extends BindingElementToObservers {
 class ModelComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     _labelUv1Missing: Label;
 
     _containerButtons: Container;
@@ -279,6 +278,8 @@ class ModelComponentInspector extends ComponentInspector {
         args.component = 'model';
 
         super(args);
+
+        this.headerText += ' (LEGACY)';
 
         this._assets = args.assets;
 

--- a/src/editor/inspector/components/render.ts
+++ b/src/editor/inspector/components/render.ts
@@ -134,7 +134,6 @@ const ATTRIBUTES: Attribute[] = [{
 class RenderComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     _labelUv1Missing: Label;
 
     _suppressToggleFields = false;

--- a/src/editor/inspector/components/sound.ts
+++ b/src/editor/inspector/components/sound.ts
@@ -274,7 +274,6 @@ class SoundSlotInspector extends Panel {
 class SoundComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     _containerSlots: Container;
 
     _slotInspectors: Record<string, SoundSlotInspector> = {};

--- a/src/editor/inspector/components/sprite.ts
+++ b/src/editor/inspector/components/sprite.ts
@@ -361,7 +361,6 @@ class SpriteClipInspector extends Panel {
 class SpriteComponentInspector extends ComponentInspector {
     _assets: ObserverList;
 
-
     _containerClips: Container;
 
     _clipInspectors: Record<string, SpriteClipInspector> = {};


### PR DESCRIPTION
## Summary

- Moves legacy/removed title suffix logic out of the base `ComponentInspector` and into the `AnimationComponentInspector`, `ModelComponentInspector`, and `AudiosourceComponentInspector` subclasses where it belongs.
- Removes extra blank lines between class field declarations across 7 component inspector files.

## Details

The base `ComponentInspector` constructor had special-case knowledge of which components are legacy or removed (`animation`, `model`, `audiosource`). This is now handled by each subclass appending to `this.headerText` after `super()`, keeping the base class generic.
