### PR TITLE
refactor: import engine constants instead of duplicating them

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -14,36 +14,10 @@ export const TONEMAPPING = [
     'Neutral'
 ];
 
-// Layout groups
-export const ORIENTATION_HORIZONTAL = 0;
-export const ORIENTATION_VERTICAL = 1;
-export const FITTING_NONE = 0;
-export const FITTING_STRETCH = 1;
-export const FITTING_SHRINK = 2;
-export const FITTING_BOTH = 3;
-
-// Buttons
-export const BUTTON_TRANSITION_MODE_TINT = 0;
-export const BUTTON_TRANSITION_MODE_SPRITE_CHANGE = 1;
-
-// Scroll Views
-export const SCROLL_MODE_CLAMP = 0;
-export const SCROLL_MODE_BOUNCE = 1;
-export const SCROLL_MODE_INFINITE = 2;
-
-export const SCROLLBAR_VISIBILITY_SHOW_ALWAYS = 0;
-export const SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED = 1;
-
-
-// Editor-specific curve types (not in engine)
-export const CURVE_CATMULL = 2;
-export const CURVE_CARDINAL = 3;
-
 // Script Loading Type
 export const LOAD_SCRIPT_AS_ASSET = 0;
 export const LOAD_SCRIPT_BEFORE_ENGINE = 1;
 export const LOAD_SCRIPT_AFTER_ENGINE = 2;
-
 
 // VERSION CONTROL
 export const MERGE_STATUS_AUTO_STARTED = 'merge_auto_started';

--- a/src/editor/components/scrollbar/components-scrollbar-defaults.ts
+++ b/src/editor/components/scrollbar/components-scrollbar-defaults.ts
@@ -1,4 +1,4 @@
-import { ORIENTATION_VERTICAL, ORIENTATION_HORIZONTAL } from '@/core/constants';
+import { ORIENTATION_VERTICAL, ORIENTATION_HORIZONTAL } from 'playcanvas';
 
 editor.once('load', () => {
     const DEFAULT_THICKNESS = 20;

--- a/src/editor/entities/entities-menu.ts
+++ b/src/editor/entities/entities-menu.ts
@@ -1,5 +1,7 @@
+import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from 'playcanvas';
+
 import { formatShortcut } from '@/common/utils';
-import { COMPONENT_LOGOS, ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from '@/core/constants';
+import { COMPONENT_LOGOS } from '@/core/constants';
 
 editor.once('load', () => {
     const applyAdditions = (object, additions?) => {

--- a/src/editor/inspector/components/button.ts
+++ b/src/editor/inspector/components/button.ts
@@ -1,9 +1,9 @@
 import { InfoBox } from '@playcanvas/pcui';
-
 import {
     BUTTON_TRANSITION_MODE_TINT,
     BUTTON_TRANSITION_MODE_SPRITE_CHANGE
-} from '@/core/constants';
+} from 'playcanvas';
+
 import type { EntityObserver } from '@/editor-api';
 
 import { ComponentInspector, type ComponentInspectorArgs } from './component';

--- a/src/editor/inspector/components/layoutgroup.ts
+++ b/src/editor/inspector/components/layoutgroup.ts
@@ -5,7 +5,7 @@ import {
     FITTING_STRETCH,
     FITTING_SHRINK,
     FITTING_BOTH
-} from '@/core/constants';
+} from 'playcanvas';
 
 import { ComponentInspector, type ComponentInspectorArgs } from './component';
 import type { Attribute } from '../attribute.type.d';

--- a/src/editor/inspector/components/scrollbar.ts
+++ b/src/editor/inspector/components/scrollbar.ts
@@ -1,5 +1,6 @@
+import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from 'playcanvas';
+
 import { deepCopy } from '@/common/utils';
-import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from '@/core/constants';
 
 import { ComponentInspector, type ComponentInspectorArgs } from './component';
 import type { Attribute } from '../attribute.type.d';

--- a/src/editor/inspector/components/scrollview.ts
+++ b/src/editor/inspector/components/scrollview.ts
@@ -1,11 +1,12 @@
-import { deepCopy } from '@/common/utils';
 import {
     SCROLL_MODE_BOUNCE,
     SCROLL_MODE_CLAMP,
     SCROLL_MODE_INFINITE,
     SCROLLBAR_VISIBILITY_SHOW_ALWAYS,
     SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED
-} from '@/core/constants';
+} from 'playcanvas';
+
+import { deepCopy } from '@/common/utils';
 import type { EntityObserver } from '@/editor-api';
 
 import { ComponentInspector, type ComponentInspectorArgs } from './component';

--- a/src/editor/viewport/viewport-entities-elements.ts
+++ b/src/editor/viewport/viewport-entities-elements.ts
@@ -1,4 +1,4 @@
-import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from '@/core/constants';
+import { ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL } from 'playcanvas';
 
 editor.once('load', () => {
     const events = [];


### PR DESCRIPTION
## Summary

- Remove 13 duplicated constant definitions from `src/core/constants.ts` that are already exported by the PlayCanvas engine (`ORIENTATION_*`, `FITTING_*`, `BUTTON_TRANSITION_MODE_*`, `SCROLL_MODE_*`, `SCROLLBAR_VISIBILITY_*`)
- Update 7 consumer files to import these constants from `playcanvas` instead of `@/core/constants`
- Remove dead code: `CURVE_CATMULL` and `CURVE_CARDINAL` (unused anywhere in the editor)

## Test plan

- [x] Verify the editor builds without errors
- [x] Verify the layout group, button, scrollbar, and scroll view component inspectors render correctly
