### PR TITLE
fix: disable horizontal scroll on entity selection in hierarchy

### DIFF
--- a/src/editor/entities/entities-treeview.ts
+++ b/src/editor/entities/entities-treeview.ts
@@ -232,16 +232,11 @@ class EntitiesTreeView extends TreeView {
         this._suspendSelectionEvents = false;
 
         if (lastItem) {
+            // preserve scrollLeft to prevent horizontal scrolling (#1859)
+            const scrollEl = this._dragScrollElement.dom;
+            const prevScrollLeft = scrollEl.scrollLeft;
             lastItem.content.dom.scrollIntoView({ block: 'nearest' });
-
-            const scrollContainer = this._dragScrollElement.dom;
-            const iconRect = lastItem.iconLabel.dom.getBoundingClientRect();
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const SCROLL_PADDING = 4;
-
-            if (iconRect.left < containerRect.left || iconRect.right > containerRect.right) {
-                scrollContainer.scrollLeft += (iconRect.left - containerRect.left) - SCROLL_PADDING;
-            }
+            scrollEl.scrollLeft = prevScrollLeft;
         }
     };
 


### PR DESCRIPTION
## Summary

- Removes the explicit horizontal scroll logic added in #1863 that scrolled the hierarchy panel horizontally to show entity icons
- Preserves `scrollLeft` before `scrollIntoView({ block: 'nearest' })` and restores it after, preventing any horizontal shift while keeping vertical auto-scroll working

Fixes #1859

## Test plan

- [x] Select an entity deep in the hierarchy (nested/indented) — panel should scroll vertically to reveal it but NOT scroll horizontally
- [x] Select entities via viewport click — same behavior, vertical only
- [x] Use undo/redo to change selection — verify no horizontal scroll jump
- [x] Manually scroll the hierarchy panel horizontally, then select an entity — horizontal position should remain unchanged