### PR TITLE
fix: only disable audiosource fields when engine is v2

### DIFF
--- a/src/editor/inspector/components/audiosource.ts
+++ b/src/editor/inspector/components/audiosource.ts
@@ -102,16 +102,9 @@ class AudiosourceComponentInspector extends ComponentInspector {
 
         this._field('3d').on('change', this._toggleFields.bind(this));
 
-        // disable all fields if engine is v2
-        ATTRIBUTES.forEach((attribute) => {
-            if (!attribute.path) {
-                return;
-            }
-            const field = this._attributesInspector.getField(attribute.path);
-            if (field) {
-                field.parent.enabled = false;
-            }
-        });
+        if (editor.projectEngineV2) {
+            this._attributesInspector.enabled = false;
+        }
     }
 
     _toggleFields() {


### PR DESCRIPTION
## Summary

- Fixes a bug where audiosource inspector fields were unconditionally disabled for all projects, even though the comment indicated this should only apply to engine v2 projects (where the audiosource component was removed)
- Simplifies the per-field disable loop into a single `this._attributesInspector.enabled = false`, since `AttributesInspector` extends `Container` and `enabled` cascades to all children

## Test plan

- [x] Open a v2 engine project with an entity that has an audiosource component -- fields should be disabled
- [x] Open a v1 engine project with an entity that has an audiosource component -- fields should be editable
