### PR TITLE
fix: event listener leak on outerConeAngle in light component inspector

### DIFF
--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -487,6 +487,8 @@ class LightComponentInspector extends ComponentInspector {
             this._field(field).on('change', this._toggleFields.bind(this));
         });
 
+        this._field('outerConeAngle').on('change', this._resetInnerConeAngleLimit.bind(this));
+
         // add update shadow button
         this._btnUpdateShadow = new Button({
             size: 'small',
@@ -547,9 +549,7 @@ class LightComponentInspector extends ComponentInspector {
             this._field(field).parent.hidden = !isSpot;
         });
 
-        // Avoid inner cone angle from being larger than outer cone angle
         this._resetInnerConeAngleLimit();
-        this._field('outerConeAngle').on('change', this._resetInnerConeAngleLimit.bind(this));
 
         const bakeEnabled = this._field('bake').value;
         const bakeDirEnabled = this._field('bakeDir').value;


### PR DESCRIPTION
## Summary
- Fix an event listener leak in the light component inspector. The `outerConeAngle` change handler (`_resetInnerConeAngleLimit`) was being registered inside `_toggleFields()`, which runs on every `link()` call and on every change to any of the 10 toggle-driving fields. This caused unbounded listener accumulation over repeated link/unlink cycles. Moved the subscription to the constructor so it is registered exactly once.

## Test plan
- [x] Select an entity with a light component, verify inner/outer cone angle clamping still works (inner cone angle max should track the outer cone angle value).
- [x] Switch between entities with light components multiple times and verify no performance degradation from accumulated listeners.
