### PR TITLE
fix: resolve type errors in animstategraph inspectors

### DIFF
--- a/src/editor/animstategraph/parameters.ts
+++ b/src/editor/animstategraph/parameters.ts
@@ -34,7 +34,7 @@ class AnimstategraphParameters extends Panel {
         this.header.append(this._addNewParameterButton);
     }
 
-    _createParamAttributesInspector(paramId: string, param: { name: string; type: number; value: number | boolean }) {
+    _createParamAttributesInspector(paramId: string, param: { name: string; type: string; value: number | boolean }) {
         let valueType;
         switch (param.type) {
             case ANIM_PARAMETER_BOOLEAN:

--- a/src/editor/animstategraph/state.ts
+++ b/src/editor/animstategraph/state.ts
@@ -2,7 +2,9 @@ import type { Observer, EventHandle } from '@playcanvas/observer';
 import { Panel, Label, Button, BindingTwoWay } from '@playcanvas/pcui';
 
 import { AssetInput } from '@/common/pcui/element/element-asset-input';
+import type { EntityObserver } from '@/editor-api';
 
+import type { AnimstategraphView } from './view';
 import type { Attribute } from '../inspector/attribute.type.d';
 import { AttributesInspector } from '../inspector/attributes-inspector';
 
@@ -15,7 +17,7 @@ const CLASS_ANIMSTATEGRAPH_STATE_TRANSITION = `${CLASS_ANIMSTATEGRAPH_STATE}-tra
 class AnimstategraphState extends Panel {
     _args!: Record<string, unknown>;
 
-    _view: { ANIM_SCHEMA: { NODE: { START_STATE: number; ANY_STATE: number; END_STATE: number } }; _parent: { _animViewer: { loadView: (anim: unknown, entity: import('playcanvas').Entity) => void; displayMessage: (msg: string) => void; hidden: boolean } }; selectEdgeEvent: (transition: unknown, id: number) => void; parent: { readOnly: boolean; history: { add: (action: unknown) => void } }; _selectedEntity: Observer | null; _selectedEntityViewButton: Button | null };
+    _view: AnimstategraphView;
 
     _assets: Observer[] | null = null;
 
@@ -47,7 +49,7 @@ class AnimstategraphState extends Panel {
 
     _enabled = false;
 
-    constructor(args: Record<string, unknown>, view: { ANIM_SCHEMA: { NODE: { START_STATE: number; ANY_STATE: number; END_STATE: number } }; _parent: { _animViewer: { loadView: (anim: unknown, entity: import('playcanvas').Entity) => void; displayMessage: (msg: string) => void; hidden: boolean } }; selectEdgeEvent: (transition: unknown, id: number) => void; parent: { readOnly: boolean; history: { add: (action: unknown) => void } }; _selectedEntity: Observer | null; _selectedEntityViewButton: Button | null }) {
+    constructor(args: Record<string, unknown>, view: AnimstategraphView) {
         args.headerText = 'STATE';
         super(args);
         this._args = args;
@@ -61,13 +63,12 @@ class AnimstategraphState extends Panel {
 
         this._linkedEntitiesPanel = new Panel({
             headerText: 'LINKED ENTITIES',
-            collapsible: true,
-            history: ''
+            collapsible: true
         });
         this.append(this._linkedEntitiesPanel);
     }
 
-    _previewEntity(entityObserver: Observer) {
+    _previewEntity(entityObserver: EntityObserver) {
         const animationAssetId = entityObserver.get(`components.anim.animationAssets.${this._layerName}:${this._stateName}.asset`);
         if (animationAssetId) {
             const app = editor.call('viewport:app');

--- a/src/editor/animstategraph/transitions.ts
+++ b/src/editor/animstategraph/transitions.ts
@@ -144,7 +144,7 @@ class AnimstategraphTransitions extends Container {
         this._assets[0].set(`data.transitions.${transitionId}.conditions`, conditions);
     }
 
-    link(assets: import('@playcanvas/observer').Observer[], layer: number, edge: { from: number; to: number }) {
+    link(assets: Observer[], layer: number, edge: { from: number; to: number }) {
         this.unlink();
         this._assets = assets;
         this._selectedLayer = layer;
@@ -373,7 +373,7 @@ class AnimstategraphTransitions extends Container {
                         lastExitTimeValue = exitTime;
                     }
                 } else if (!path || path.includes('parameters') || path.includes(`transitions.${transitionId}`) && transition.conditions) {
-                    addConditions(path);
+                    addConditions();
                     conditionNote.hidden = hideConditionNote();
                 }
             });

--- a/src/editor/inspector/attributes-inspector.ts
+++ b/src/editor/inspector/attributes-inspector.ts
@@ -50,7 +50,7 @@ class AttributesInspector extends Container {
 
     private _sessionSettings: Observer | undefined;
 
-    private _fields: Record<string, Element & IBindable>;
+    protected _fields: Record<string, Element & IBindable>;
 
     private _fieldAttributes: Record<string, Attribute>;
 


### PR DESCRIPTION
## Summary

- Fix `param.type` typed as `number` instead of `string` in `AnimstategraphParameters`, resolving 5 type errors against the engine's string-valued `ANIM_PARAMETER_*` constants
- Replace inline `import('playcanvas').Entity` types with a proper top-level import in `AnimstategraphState`
- Add `EntityObserver` import and use it for `_previewEntity` parameter (fixes `Property 'entity' does not exist on type 'Observer'`)
- Remove spurious `history: ''` property from `Panel` constructor in `AnimstategraphState`
- Replace redundant inline `import('@playcanvas/observer').Observer` with the existing top-level `Observer` import in `AnimstategraphTransitions`
- Remove unused argument passed to `addConditions()` in `AnimstategraphTransitions`
- Change `_fields` from `private` to `protected` in `AttributesInspector` so the `TransitionInspector` subclass can access it

## Test plan

- [x] Verify anim state graph inspector loads and functions correctly
- [x] Verify parameter creation, renaming, type changes, and deletion work
- [x] Verify transition editing and condition management work
- [x] Verify state inspector with linked entities works
