### PR TITLE
fix: enable undo for keyboard Delete in AnimStateGraph editor

### DIFF
--- a/src/editor/animstategraph/view.ts
+++ b/src/editor/animstategraph/view.ts
@@ -271,15 +271,13 @@ class AnimstategraphView {
     }
 
     _keyboardListener(e: KeyboardEvent) {
-        if (e.keyCode === 27) {
-            // esc
+        if (e.key === 'Escape') {
             if (this._graph.selectedItem) {
                 this._graph.deselectItem();
             } else {
                 this.parent.closeAsset(this._assets[0]);
             }
-        } else if (e.keyCode === 46 && this._graph.selectedItem && document.activeElement.constructor.name !== 'HTMLInputElement') {
-            // del
+        } else if (e.key === 'Delete' && this._graph.selectedItem && !(document.activeElement instanceof HTMLInputElement)) {
             const item = this._graph.selectedItem;
             switch (item.type) {
                 case 'NODE': {
@@ -290,14 +288,22 @@ class AnimstategraphView {
                         ANIM_SCHEMA.NODE.END_STATE,
                         ANIM_SCHEMA.NODE.ANY_STATE
                     ].includes(node.nodeType)) {
-                        this._graph.deleteNode(item.id);
+                        const data = this._assets[0].get('data');
+                        const edges = Object.keys(data.transitions).filter((key) => {
+                            const t = data.transitions[key];
+                            return t.from === item.id || t.to === item.id;
+                        });
+                        this._onDeleteNode({
+                            node: { id: item.id as number, attributes: { name: node.name } },
+                            edges: edges.map(Number)
+                        });
                     }
                     break;
                 }
                 case 'EDGE': {
                     const edge = this._assets[0].get(`data.transitions.${item.edgeId}`);
                     if (!edge.defaultTransition) {
-                        this._graph.deleteEdge(item.edgeId);
+                        this._onDeleteEdge({ edgeId: String(item.edgeId) });
                     }
                     break;
                 }


### PR DESCRIPTION
## Summary

- Fix undo not restoring deleted states/edges when using the keyboard Delete key in the AnimStateGraph editor
- Modernize `_keyboardListener`: replace deprecated `keyCode` with `key`, use `instanceof` instead of `constructor.name` string comparison

## Details

The keyboard Delete handler was calling `this._graph.deleteNode()` / `this._graph.deleteEdge()` directly on the pcui-graph instance. These methods modify pcui-graph's internal state and view but do not update the asset data or record history. Undo therefore had nothing to restore.

The fix routes keyboard Delete through `_onDeleteNode` / `_onDeleteEdge` (the same handlers used by the context menu delete path), which update the asset data via `this._assets[0].set('data', data)`. This records the change in ObserverHistory and triggers `_handleIncomingUpdates` to sync the pcui-graph view. Undo then correctly restores the previous asset data, and the diff-based sync recreates the deleted nodes/edges.

## Test plan

- [x] Open an AnimStateGraph asset in the editor
- [x] Select a state and press Delete -- state disappears
- [x] Press Ctrl+Z -- state reappears with its connected transitions
- [x] Select a transition edge and press Delete -- edge disappears
- [x] Press Ctrl+Z -- edge reappears
- [x] Verify context menu Delete still works the same way
- [x] Verify Escape still deselects / closes the graph editor
