### PR TITLE
refactor: rename Animstategraph to AnimStateGraph

### DIFF
--- a/src/editor-api/assets.ts
+++ b/src/editor-api/assets.ts
@@ -625,7 +625,7 @@ class Assets extends Events {
      *
      * @param options.name - The asset name
      * @param options.preload - Whether to preload the asset. Defaults to true.
-     * @param options.data - The asset data. See {@link Asset} for Animstategraph data.
+     * @param options.data - The asset data. See {@link Asset} for AnimStateGraph data.
      * @param options.folder - The parent folder asset
      * @param options.onProgress - Function to report progress
      * @returns The new asset

--- a/src/editor-api/external-types/asset.d.ts
+++ b/src/editor-api/external-types/asset.d.ts
@@ -109,7 +109,7 @@ export type AssetProps = {
  * Represents the data for an Asset.
  */
 export type AssetData = AnimationAssetData
-    | AnimstategraphAssetData
+    | AnimStateGraphAssetData
     | BundleAssetData
     | CubemapAssetData
     | FontAssetData
@@ -157,7 +157,7 @@ type AnimationAssetData = {
 /**
  * Represents the data for an AnimStateGraph asset.
  */
-type AnimstategraphAssetData = {
+type AnimStateGraphAssetData = {
     /**
      * A set of AnimStateGraph layers.
      */

--- a/src/editor/animstategraph/anim-component.ts
+++ b/src/editor/animstategraph/anim-component.ts
@@ -1,13 +1,13 @@
 import type { Observer, ObserverList, EventHandle } from '@playcanvas/observer';
 
-import type { AnimstategraphView } from './view';
+import type { AnimStateGraphView } from './view';
 
-interface AnimstategraphAnimComponentArgs {
+interface AnimStateGraphAnimComponentArgs {
     entities?: ObserverList;
 }
 
-class AnimstategraphAnimComponent {
-    _view: AnimstategraphView;
+class AnimStateGraphAnimComponent {
+    _view: AnimStateGraphView;
 
     _entities: ObserverList | null;
 
@@ -15,7 +15,7 @@ class AnimstategraphAnimComponent {
 
     _onSetStateNameEvent: EventHandle | null = null;
 
-    constructor(args: AnimstategraphAnimComponentArgs, view: AnimstategraphView) {
+    constructor(args: AnimStateGraphAnimComponentArgs, view: AnimStateGraphView) {
         this._view = view;
         this._entities = args.entities ?? null;
     }
@@ -52,4 +52,4 @@ class AnimstategraphAnimComponent {
     }
 }
 
-export { AnimstategraphAnimComponent };
+export { AnimStateGraphAnimComponent };

--- a/src/editor/animstategraph/condition.ts
+++ b/src/editor/animstategraph/condition.ts
@@ -15,15 +15,15 @@ import {
 
 const CLASS_ROOT = 'pcui-animstategraph-condition';
 
-interface AnimstategraphConditionArgs extends ContainerArgs {
+interface AnimStateGraphConditionArgs extends ContainerArgs {
     parameters: string[];
     onDelete: () => void;
 }
 
-class AnimstategraphCondition extends Container {
-    _args!: AnimstategraphConditionArgs;
+class AnimStateGraphCondition extends Container {
+    _args!: AnimStateGraphConditionArgs;
 
-    constructor(args: AnimstategraphConditionArgs) {
+    constructor(args: AnimStateGraphConditionArgs) {
         args = Object.assign({
             class: CLASS_ROOT
         }, args);
@@ -148,4 +148,4 @@ class AnimstategraphCondition extends Container {
     }
 }
 
-export { AnimstategraphCondition };
+export { AnimStateGraphCondition };

--- a/src/editor/animstategraph/layers.ts
+++ b/src/editor/animstategraph/layers.ts
@@ -26,13 +26,13 @@ const ANIM_SCHEMA = {
     }
 };
 
-interface AnimstategraphLayersArgs extends PanelArgs {
+interface AnimStateGraphLayersArgs extends PanelArgs {
     assets?: ObserverList;
     history?: History;
 }
 
-class AnimstategraphLayers extends Panel {
-    _args!: AnimstategraphLayersArgs;
+class AnimStateGraphLayers extends Panel {
+    _args!: AnimStateGraphLayersArgs;
 
     _assets: Observer[] | null = null;
 
@@ -52,7 +52,7 @@ class AnimstategraphLayers extends Panel {
 
     _layerPanels: Panel[] = [];
 
-    constructor(parent: Panel, args: AnimstategraphLayersArgs) {
+    constructor(parent: Panel, args: AnimStateGraphLayersArgs) {
         args = Object.assign({ enabled: !parent.readOnly }, args);
         super(args);
         this._parent = parent;
@@ -478,4 +478,4 @@ class AnimstategraphLayers extends Panel {
     }
 }
 
-export { AnimstategraphLayers };
+export { AnimStateGraphLayers };

--- a/src/editor/animstategraph/parameters.ts
+++ b/src/editor/animstategraph/parameters.ts
@@ -11,13 +11,13 @@ import { AttributesInspector } from '../inspector/attributes-inspector';
 const CLASS_ANIMSTATEGRAPH = 'asset-animstategraph-inspector';
 const CLASS_ANIMSTATEGRAPH_PARAMETER = `${CLASS_ANIMSTATEGRAPH}-parameter`;
 
-interface AnimstategraphParametersArgs extends PanelArgs {
+interface AnimStateGraphParametersArgs extends PanelArgs {
     assets?: ObserverList;
     history?: History;
 }
 
-class AnimstategraphParameters extends Panel {
-    _args!: AnimstategraphParametersArgs;
+class AnimStateGraphParameters extends Panel {
+    _args!: AnimStateGraphParametersArgs;
 
     _assets: Observer[] | null = null;
 
@@ -29,7 +29,7 @@ class AnimstategraphParameters extends Panel {
 
     _assetEvents: EventHandle[] = [];
 
-    constructor(args: AnimstategraphParametersArgs) {
+    constructor(args: AnimStateGraphParametersArgs) {
         args = Object.assign({}, args);
         super(args);
         this._args = args;
@@ -427,4 +427,4 @@ class AnimstategraphParameters extends Panel {
     }
 }
 
-export { AnimstategraphParameters };
+export { AnimStateGraphParameters };

--- a/src/editor/animstategraph/state.ts
+++ b/src/editor/animstategraph/state.ts
@@ -4,7 +4,7 @@ import { Panel, Label, Button, BindingTwoWay, type PanelArgs } from '@playcanvas
 import { AssetInput } from '@/common/pcui/element/element-asset-input';
 import type { EntityObserver, History } from '@/editor-api';
 
-import type { AnimstategraphView } from './view';
+import type { AnimStateGraphView } from './view';
 import type { Attribute } from '../inspector/attribute.type.d';
 import { AttributesInspector } from '../inspector/attributes-inspector';
 
@@ -14,16 +14,16 @@ const CLASS_ANIMSTATEGRAPH_STATE = `${CLASS_ANIMSTATEGRAPH}-state`;
 const CLASS_ANIMSTATEGRAPH_STATE_VIEW_BUTTON = `${CLASS_ANIMSTATEGRAPH_STATE}-view-button`;
 const CLASS_ANIMSTATEGRAPH_STATE_TRANSITION = `${CLASS_ANIMSTATEGRAPH_STATE}-transition`;
 
-interface AnimstategraphStateArgs extends PanelArgs {
+interface AnimStateGraphStateArgs extends PanelArgs {
     assets?: ObserverList;
     history?: History;
     entities?: ObserverList;
 }
 
-class AnimstategraphState extends Panel {
-    _args!: AnimstategraphStateArgs;
+class AnimStateGraphState extends Panel {
+    _args!: AnimStateGraphStateArgs;
 
-    _view: AnimstategraphView;
+    _view: AnimStateGraphView;
 
     _assets: Observer[] | null = null;
 
@@ -55,7 +55,7 @@ class AnimstategraphState extends Panel {
 
     _enabled = false;
 
-    constructor(args: AnimstategraphStateArgs, view: AnimstategraphView) {
+    constructor(args: AnimStateGraphStateArgs, view: AnimStateGraphView) {
         args.headerText = 'STATE';
         super(args);
         this._args = args;
@@ -152,7 +152,7 @@ class AnimstategraphState extends Panel {
     }
 
     static updateAnimationAssetName(observer: Observer, layerName: string, prevState: string, newState: string) {
-        AnimstategraphState.createAnimationAsset(observer, layerName, prevState);
+        AnimStateGraphState.createAnimationAsset(observer, layerName, prevState);
         const historyEnabled = observer.history.enabled;
         observer.history.enabled = false;
         const prevAsset = observer.get(`components.anim.animationAssets.${layerName}:${prevState}`);
@@ -228,7 +228,7 @@ class AnimstategraphState extends Panel {
         this._stateInspector.link(this._assets);
 
         this._stateInspector.getField(`${path}.name`).onValidate = (value) => {
-            return AnimstategraphState.validateStateName(state.id, value, this._assets[0]);
+            return AnimStateGraphState.validateStateName(state.id, value, this._assets[0]);
         };
 
         this._loadTransitions();
@@ -304,7 +304,7 @@ class AnimstategraphState extends Panel {
                 entityAnimationAsset.link([entityObserver], `components.anim.animationAssets.${layerName}:${state.name}.asset`);
                 entityPanel.content.append(entityAnimationAsset);
 
-                AnimstategraphState.createAnimationAsset(entityObserver, layerName, state.name);
+                AnimStateGraphState.createAnimationAsset(entityObserver, layerName, state.name);
 
                 this._linkedEntities.push(entityObserver);
                 this._linkedEntityAssets.push(entityAnimationAsset);
@@ -348,7 +348,7 @@ class AnimstategraphState extends Panel {
             const action = {
                 redo: () => {
                     this._linkedEntities.forEach((entityObserver) => {
-                        AnimstategraphState.updateAnimationAssetName(entityObserver, this._layerName, prevName, newName);
+                        AnimStateGraphState.updateAnimationAssetName(entityObserver, this._layerName, prevName, newName);
                     });
                     const historyEnabled = this._assets[0].history.enabled;
                     this._assets[0].history.enabled = false;
@@ -358,7 +358,7 @@ class AnimstategraphState extends Panel {
                 },
                 undo: () => {
                     this._linkedEntities.forEach((entityObserver) => {
-                        AnimstategraphState.updateAnimationAssetName(entityObserver, this._layerName, newName, prevName);
+                        AnimStateGraphState.updateAnimationAssetName(entityObserver, this._layerName, newName, prevName);
                     });
                     const historyEnabled = this._assets[0].history.enabled;
                     this._assets[0].history.enabled = false;
@@ -411,4 +411,4 @@ class AnimstategraphState extends Panel {
     }
 }
 
-export { AnimstategraphState };
+export { AnimStateGraphState };

--- a/src/editor/animstategraph/transitions.ts
+++ b/src/editor/animstategraph/transitions.ts
@@ -11,8 +11,8 @@ import {
 
 import type { History } from '@/editor-api';
 
-import { AnimstategraphCondition } from './condition';
-import type { AnimstategraphView } from './view';
+import { AnimStateGraphCondition } from './condition';
+import type { AnimStateGraphView } from './view';
 import type { Attribute, Divider } from '../inspector/attribute.type.d';
 import { AttributesInspector } from '../inspector/attributes-inspector';
 
@@ -23,7 +23,7 @@ const CLASS_ANIMSTATEGRAPH_TRANSITIONS = `${CLASS_ANIMSTATEGRAPH}-transitions`;
 const CLASS_ANIMSTATEGRAPH_TRANSITION_CONDITIONS_NOTE = `${CLASS_ANIMSTATEGRAPH_TRANSITION}-conditions-note`;
 
 // This helper function moves the the position of an item in the given array from the supplied old_index position to the new_index position.
-// Used by the AnimstategraphTransitions class to update the transitions order when the _onDragEnd event is fired.
+// Used by the AnimStateGraphTransitions class to update the transitions order when the _onDragEnd event is fired.
 function arrayMove<T>(arr: T[], old_index: number, new_index: number): T[] {
     if (new_index >= arr.length) {
         let k = new_index - arr.length + 1;
@@ -44,15 +44,15 @@ class TransitionInspector extends AttributesInspector {
     }
 }
 
-interface AnimstategraphTransitionsArgs extends ContainerArgs {
+interface AnimStateGraphTransitionsArgs extends ContainerArgs {
     assets?: ObserverList;
     history?: History;
 }
 
-class AnimstategraphTransitions extends Container {
-    _view: AnimstategraphView;
+class AnimStateGraphTransitions extends Container {
+    _view: AnimStateGraphView;
 
-    _args: AnimstategraphTransitionsArgs;
+    _args: AnimStateGraphTransitionsArgs;
 
     _assets: Observer[] | null = null;
 
@@ -72,7 +72,7 @@ class AnimstategraphTransitions extends Container {
 
     _onParamDeleteEvent: EventHandle | null = null;
 
-    constructor(args: AnimstategraphTransitionsArgs, view: AnimstategraphView) {
+    constructor(args: AnimStateGraphTransitionsArgs, view: AnimStateGraphView) {
         super({
             class: CLASS_ANIMSTATEGRAPH_TRANSITIONS,
             enabled: !view.parent.readOnly
@@ -303,7 +303,7 @@ class AnimstategraphTransitions extends Container {
 
             transitionPanel.conditions = new Container();
             Object.keys(transition.conditions).forEach((conditionId) => {
-                const condition = new AnimstategraphCondition({
+                const condition = new AnimStateGraphCondition({
                     parameters: parameters,
                     onDelete: () => {
                         this._deleteCondition(transitionId, conditionId);
@@ -331,7 +331,7 @@ class AnimstategraphTransitions extends Container {
                 }
                 transitionPanel.conditions = new Container();
                 Object.keys(transition.conditions).forEach((conditionId) => {
-                    const condition = new AnimstategraphCondition({
+                    const condition = new AnimStateGraphCondition({
                         parameters: parameters,
                         onDelete: () => {
                             this._deleteCondition(transitionId, conditionId);
@@ -421,4 +421,4 @@ class AnimstategraphTransitions extends Container {
     }
 }
 
-export { AnimstategraphTransitions };
+export { AnimStateGraphTransitions };

--- a/src/editor/animstategraph/view.ts
+++ b/src/editor/animstategraph/view.ts
@@ -5,7 +5,7 @@ import { ANIM_INTERRUPTION_NONE } from 'playcanvas';
 
 import { diff } from '@/common/diff';
 
-import { AnimstategraphState } from './state';
+import { AnimStateGraphState } from './state';
 
 const GRAPH_ACTIONS = {
     ADD_NODE: 'EVENT_ADD_NODE',
@@ -37,7 +37,7 @@ const ANIM_SCHEMA = {
 };
 
 const updateNodeHeaderText = (attributes: Record<string, unknown>, nodeId: number, asset: Observer) => {
-    if (AnimstategraphState.validateStateName(nodeId, attributes.name, asset)) {
+    if (AnimStateGraphState.validateStateName(nodeId, attributes.name, asset)) {
         return attributes.name;
     }
     return null;
@@ -200,7 +200,7 @@ const animContextMenuItems = [
     }
 ];
 
-class AnimstategraphView {
+class AnimStateGraphView {
     _parent: { closeAsset: (asset: Observer) => void; readOnly?: boolean; _stateContainer?: { _stateName?: string; unlink: () => void; hidden?: boolean; link?: (...args: unknown[]) => void }; _transitionsContainer?: { _edge?: string; unlink: () => void; hidden?: boolean; link?: (...args: unknown[]) => void } };
 
     _args: Record<string, unknown>;
@@ -242,7 +242,6 @@ class AnimstategraphView {
             display: none;
         `);
         document.getElementById('layout-viewport').prepend(this._graphElement);
-
     }
 
     get parent() {
@@ -654,7 +653,7 @@ class AnimstategraphView {
     _onUpdateNodeAttribute({ node, attribute }: { node: Record<string, unknown>; attribute: string }) {
         const state = this._assets[0].get(`data.states.${node.id}`);
         if (attribute === 'name') {
-            if (!AnimstategraphState.validateStateName(node.id, node.attributes.name, this._assets[0])) {
+            if (!AnimStateGraphState.validateStateName(node.id, node.attributes.name, this._assets[0])) {
                 this._graph.setNodeAttributeErrorState(node.id, attribute, true);
                 return;
             }
@@ -665,7 +664,7 @@ class AnimstategraphView {
                     const layerName = this._assets[0].get(`data.layers.${this._selectedLayer}.name`);
                     this._args.entities.forEach((entityObserver) => {
                         if (entityObserver.get('components.anim.stateGraphAsset') === this._assets[0].get('id')) {
-                            AnimstategraphState.updateAnimationAssetName(entityObserver, layerName, prevName, newName);
+                            AnimStateGraphState.updateAnimationAssetName(entityObserver, layerName, prevName, newName);
                         }
                     });
                     const historyEnabled = this._assets[0].history.enabled;
@@ -677,7 +676,7 @@ class AnimstategraphView {
                     const layerName = this._assets[0].get(`data.layers.${this._selectedLayer}.name`);
                     this._args.entities.forEach((entityObserver) => {
                         if (entityObserver.get('components.anim.stateGraphAsset') === this._assets[0].get('id')) {
-                            AnimstategraphState.updateAnimationAssetName(entityObserver, layerName, newName, prevName);
+                            AnimStateGraphState.updateAnimationAssetName(entityObserver, layerName, newName, prevName);
                         }
                     });
                     const historyEnabled = this._assets[0].history.enabled;
@@ -945,4 +944,4 @@ class AnimstategraphView {
     }
 }
 
-export { AnimstategraphView };
+export { AnimStateGraphView };

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -7,7 +7,7 @@ import { LOAD_SCRIPT_AS_ASSET, LOAD_SCRIPT_BEFORE_ENGINE, LOAD_SCRIPT_AFTER_ENGI
 
 import { AnimationAssetInspector } from './assets/animation';
 import { AnimationAssetInspectorPreview } from './assets/animation-preview';
-import { AnimstategraphAssetInspector } from './assets/animstategraph';
+import { AnimStateGraphAssetInspector } from './assets/animstategraph';
 import type { AssetInspectorPreviewBase } from './assets/asset-preview-base';
 import { AudioAssetInspector } from './assets/audio';
 import { BundleAssetInspector } from './assets/bundle';
@@ -44,7 +44,7 @@ import { AttributesInspector } from './attributes-inspector';
 
 const assetInspectors: Map<string, new (...args: any[]) => any> = new Map();
 assetInspectors.set('animation', AnimationAssetInspector);
-assetInspectors.set('animstategraph', AnimstategraphAssetInspector);
+assetInspectors.set('animstategraph', AnimStateGraphAssetInspector);
 assetInspectors.set('audio', AudioAssetInspector);
 assetInspectors.set('bundle', BundleAssetInspector);
 assetInspectors.set('container', ContainerAssetInspector);

--- a/src/editor/inspector/assets/animstategraph.ts
+++ b/src/editor/inspector/assets/animstategraph.ts
@@ -5,13 +5,13 @@ import type { Application } from 'playcanvas';
 import { tooltip, tooltipSimpleItem } from '@/common/tooltips';
 import type { History } from '@/editor-api';
 
-import { AnimstategraphAnimComponent } from '../../animstategraph/anim-component';
+import { AnimStateGraphAnimComponent } from '../../animstategraph/anim-component';
 import { AnimViewer } from '../../animstategraph/anim-viewer';
-import { AnimstategraphLayers } from '../../animstategraph/layers';
-import { AnimstategraphParameters } from '../../animstategraph/parameters';
-import { AnimstategraphState } from '../../animstategraph/state';
-import { AnimstategraphTransitions } from '../../animstategraph/transitions';
-import { AnimstategraphView } from '../../animstategraph/view';
+import { AnimStateGraphLayers } from '../../animstategraph/layers';
+import { AnimStateGraphParameters } from '../../animstategraph/parameters';
+import { AnimStateGraphState } from '../../animstategraph/state';
+import { AnimStateGraphTransitions } from '../../animstategraph/transitions';
+import { AnimStateGraphView } from '../../animstategraph/view';
 
 const CLASS_ANIMSTATEGRAPH = 'asset-animstategraph-inspector';
 const CLASS_ANIMSTATEGRAPH_OPEN_BUTTON = `${CLASS_ANIMSTATEGRAPH}-open-button`;
@@ -20,13 +20,13 @@ const CLASS_ANIMSTATEGRAPH_CLOSE_BUTTON_TOOLTIP = `${CLASS_ANIMSTATEGRAPH_CLOSE_
 
 const DOM = parent => [
     {
-        layersPanel: new AnimstategraphLayers(parent, {
+        layersPanel: new AnimStateGraphLayers(parent, {
             headerText: 'LAYERS',
             collapsible: true
         })
     },
     {
-        parametersPanel: new AnimstategraphParameters({
+        parametersPanel: new AnimStateGraphParameters({
             headerText: 'PARAMETERS',
             collapsible: true,
             history: parent.history
@@ -41,27 +41,27 @@ const DOM = parent => [
     }
 ];
 
-interface AnimstategraphAssetInspectorArgs extends ContainerArgs {
+interface AnimStateGraphAssetInspectorArgs extends ContainerArgs {
     assets?: ObserverList;
     history?: History;
     entities?: ObserverList;
     inspectorPanelSecondary?: Container;
 }
 
-class AnimstategraphAssetInspector extends Container {
-    _args: AnimstategraphAssetInspectorArgs;
+class AnimStateGraphAssetInspector extends Container {
+    _args: AnimStateGraphAssetInspectorArgs;
 
     _assets: Observer[] | null;
 
     history: History;
 
-    _view: AnimstategraphView;
+    _view: AnimStateGraphView;
 
-    _animComponentListener: AnimstategraphAnimComponent;
+    _animComponentListener: AnimStateGraphAnimComponent;
 
-    _stateContainer: AnimstategraphState;
+    _stateContainer: AnimStateGraphState;
 
-    _transitionsContainer: AnimstategraphTransitions;
+    _transitionsContainer: AnimStateGraphTransitions;
 
     _app: Application;
 
@@ -69,9 +69,9 @@ class AnimstategraphAssetInspector extends Container {
 
     _openEditorButton: Button;
 
-    _layersPanel: AnimstategraphLayers;
+    _layersPanel: AnimStateGraphLayers;
 
-    _parametersPanel: AnimstategraphParameters;
+    _parametersPanel: AnimStateGraphParameters;
 
     _assetEvents: EventHandle[];
 
@@ -85,7 +85,7 @@ class AnimstategraphAssetInspector extends Container {
 
     _inspectorPanelSecondary: Container;
 
-    constructor(args: AnimstategraphAssetInspectorArgs) {
+    constructor(args: AnimStateGraphAssetInspectorArgs) {
         args = Object.assign({
             class: CLASS_ANIMSTATEGRAPH
         }, args);
@@ -95,14 +95,14 @@ class AnimstategraphAssetInspector extends Container {
         this._inspectorPanelSecondary = args.inspectorPanelSecondary;
         this.readOnly = !editor.call('permissions:write');
         this.history = args.history;
-        this._view = new AnimstategraphView(this, args);
-        this._animComponentListener = new AnimstategraphAnimComponent(args, this._view);
+        this._view = new AnimStateGraphView(this, args);
+        this._animComponentListener = new AnimStateGraphAnimComponent(args, this._view);
 
         this.buildDom(DOM(this));
 
-        this._stateContainer = new AnimstategraphState(args, this._view);
+        this._stateContainer = new AnimStateGraphState(args, this._view);
         this._inspectorPanelSecondary.append(this._stateContainer);
-        this._transitionsContainer = new AnimstategraphTransitions(args, this._view);
+        this._transitionsContainer = new AnimStateGraphTransitions(args, this._view);
         this._inspectorPanelSecondary.append(this._transitionsContainer);
         setTimeout(() => {
             this._app = editor.call('viewport:app');
@@ -284,4 +284,4 @@ class AnimstategraphAssetInspector extends Container {
     }
 }
 
-export { AnimstategraphAssetInspector };
+export { AnimStateGraphAssetInspector };


### PR DESCRIPTION
## Summary

- Rename all `Animstategraph` PascalCase identifiers (classes, interfaces, types) to `AnimStateGraph`, aligning with the engine's canonical `AnimStateGraph` / `AnimStateGraphHandler` naming
- 80 occurrences across 11 files updated; no functional changes

Lowercase strings (`'animstategraph'`), directory/file names, import paths, and CSS classes are intentionally unchanged.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type:check` introduces no new errors
- [x] Verify AnimStateGraph editor still opens and functions correctly in the browser
