### PR TITLE
refactor: replace inline import('playcanvas') types with top-level imports in viewport

### DIFF
--- a/src/editor/viewport/camera/camera-fly.ts
+++ b/src/editor/viewport/camera/camera-fly.ts
@@ -1,6 +1,6 @@
-import { PROJECTION_ORTHOGRAPHIC, Vec3 } from 'playcanvas';
+import { type Application, PROJECTION_ORTHOGRAPHIC, Vec3 } from 'playcanvas';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
 
     // Variables
     let flying = false;

--- a/src/editor/viewport/camera/camera-focus.ts
+++ b/src/editor/viewport/camera/camera-focus.ts
@@ -1,6 +1,6 @@
-import { PROJECTION_ORTHOGRAPHIC, Vec3 } from 'playcanvas';
+import { type Application, PROJECTION_ORTHOGRAPHIC, Vec3 } from 'playcanvas';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
     // Focusing on a point and a distance
 
     const focusTarget = new Vec3();

--- a/src/editor/viewport/camera/camera-history.ts
+++ b/src/editor/viewport/camera/camera-history.ts
@@ -1,9 +1,11 @@
+import type { Entity } from 'playcanvas';
+
 editor.once('load', () => {
     let camera;
     let overlapping = 0;
     let position, rotation, eulers, orthoHeight;
 
-    editor.method('camera:history:start', (entity: import('playcanvas').Entity) => {
+    editor.method('camera:history:start', (entity: Entity) => {
         if (entity === camera) {
             overlapping++;
             return;
@@ -27,7 +29,7 @@ editor.once('load', () => {
         obj.history.enabled = false;
     });
 
-    editor.method('camera:history:stop', (entity?: import('playcanvas').Entity) => {
+    editor.method('camera:history:stop', (entity?: Entity) => {
         if (!camera) {
             return;
         }

--- a/src/editor/viewport/camera/camera-orbit.ts
+++ b/src/editor/viewport/camera/camera-orbit.ts
@@ -1,8 +1,8 @@
-import { PROJECTION_PERSPECTIVE, Quat, Vec2, Vec3 } from 'playcanvas';
+import { type Application, PROJECTION_PERSPECTIVE, Quat, Vec2, Vec3 } from 'playcanvas';
 
 import type { ViewportTap } from '../viewport-tap';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
     // Orbit camera with virtual point of focus
     // Zooming / Flying will not move virtual point forward/backwards
 

--- a/src/editor/viewport/camera/camera-pan.ts
+++ b/src/editor/viewport/camera/camera-pan.ts
@@ -1,8 +1,8 @@
-import { PROJECTION_PERSPECTIVE, Vec2, Vec3 } from 'playcanvas';
+import { type Application, PROJECTION_PERSPECTIVE, Vec2, Vec3 } from 'playcanvas';
 
 import type { ViewportTap } from '../viewport-tap';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
     // Panning with left mouse button while shift key is down
 
     let panning = false;

--- a/src/editor/viewport/camera/camera-preview.ts
+++ b/src/editor/viewport/camera/camera-preview.ts
@@ -1,5 +1,5 @@
 import { Button } from '@playcanvas/pcui';
-import { FOG_NONE, type FogType, Vec4 } from 'playcanvas';
+import { type Application, type Entity, FOG_NONE, type FogType, Vec4 } from 'playcanvas';
 
 editor.once('load', () => {
 
@@ -139,7 +139,7 @@ editor.once('load', () => {
         editor.call('camera:set', obj.entity);
     }, false);
 
-    editor.once('viewport:load', (application: import('playcanvas').Application) => {
+    editor.once('viewport:load', (application: Application) => {
         app = application;
     });
 
@@ -160,7 +160,7 @@ editor.once('load', () => {
         updateCameraState();
     });
 
-    editor.on('camera:change', (camera: import('playcanvas').Entity | null) => {
+    editor.on('camera:change', (camera: Entity | null) => {
         if (camera && !camera.__editorCamera) {
             currentCamera = camera;
         } else {

--- a/src/editor/viewport/camera/camera-userdata.ts
+++ b/src/editor/viewport/camera/camera-userdata.ts
@@ -1,4 +1,4 @@
-import { PROJECTION_ORTHOGRAPHIC, Quat } from 'playcanvas';
+import { type Entity, PROJECTION_ORTHOGRAPHIC, Quat } from 'playcanvas';
 
 editor.once('camera:load', () => {
     const userdata = editor.call('userdata');
@@ -65,7 +65,7 @@ editor.once('camera:load', () => {
         }
     });
 
-    editor.on('camera:change', (cameraNew: import('playcanvas').Entity) => {
+    editor.on('camera:change', (cameraNew: Entity) => {
         camera = cameraNew;
     });
 });

--- a/src/editor/viewport/camera/camera-zoom.ts
+++ b/src/editor/viewport/camera/camera-zoom.ts
@@ -1,8 +1,8 @@
-import { BoundingBox, PROJECTION_PERSPECTIVE, Vec2, Vec3 } from 'playcanvas';
+import { type Application, BoundingBox, PROJECTION_PERSPECTIVE, Vec2, Vec3 } from 'playcanvas';
 
 import type { ViewportTap } from '../viewport-tap';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
     // Moving towards mouse point in world using mouse wheel
     // Speed is relative to distance of point in world
 
@@ -175,7 +175,7 @@ editor.once('viewport:load', (app: import('playcanvas').Application) => {
         }
     };
 
-    const onFocus = function (_point: import('playcanvas').Vec3, dist: number): void {
+    const onFocus = function (_point: Vec3, dist: number): void {
         distance = Math.max(1, Math.min(zoomMax, dist));
     };
 

--- a/src/editor/viewport/camera/camera.ts
+++ b/src/editor/viewport/camera/camera.ts
@@ -1,4 +1,4 @@
-import { Entity, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, SHADOWUPDATE_THISFRAME, Vec3 } from 'playcanvas';
+import { type CameraComponent, Entity, type Layer, PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, SHADOWUPDATE_THISFRAME, Vec3 } from 'playcanvas';
 
 editor.once('load', () => {
     editor.once('viewport:load', (app) => {
@@ -26,7 +26,7 @@ editor.once('load', () => {
             return currentCamera;
         });
 
-        const addGizmoLayers = function (camera: import('playcanvas').CameraComponent, layers: import('playcanvas').Layer[]): void {
+        const addGizmoLayers = function (camera: CameraComponent, layers: Layer[]): void {
             for (let i = 0; i < layers.length; i++) {
                 const layer = layers[i];
                 const idx = camera.layers.indexOf(layer.id);
@@ -38,7 +38,7 @@ editor.once('load', () => {
             camera.layers = camera.layers; // force update
         };
 
-        const removeGizmoLayers = function (camera: import('playcanvas').CameraComponent, layers: import('playcanvas').Layer[]): void {
+        const removeGizmoLayers = function (camera: CameraComponent, layers: Layer[]): void {
             for (let i = 0; i < layers.length; i++) {
                 const layer = layers[i];
                 const idx = camera.layers.indexOf(layer.id);
@@ -51,7 +51,7 @@ editor.once('load', () => {
             camera.layers = camera.layers; // force update
         };
 
-        editor.method('camera:set', (entity?: import('playcanvas').Entity) => {
+        editor.method('camera:set', (entity?: Entity) => {
             if (!entity) {
                 entity = defaultCamera;
             }
@@ -149,7 +149,7 @@ editor.once('load', () => {
             editor.call('viewport:render');
         });
 
-        editor.method('camera:add', (entity: import('playcanvas').Entity) => {
+        editor.method('camera:add', (entity: Entity) => {
             if (camerasIndex[entity.getGuid()]) {
                 return;
             }
@@ -164,7 +164,7 @@ editor.once('load', () => {
             editor.emit('camera:add', entity);
         });
 
-        editor.method('camera:remove', (entity: import('playcanvas').Entity) => {
+        editor.method('camera:remove', (entity: Entity) => {
             if (!camerasIndex[entity.getGuid()]) {
                 return;
             }
@@ -239,7 +239,7 @@ editor.once('load', () => {
         }];
 
 
-        const createCamera = function (args: { name: string; title: string; className: string; position: import('playcanvas').Vec3; rotation: import('playcanvas').Vec3; default?: boolean; ortho?: boolean }) {
+        const createCamera = function (args: { name: string; title: string; className: string; position: Vec3; rotation: Vec3; default?: boolean; ortho?: boolean }) {
             const entity = new Entity();
             entity.__editorCamera = true;
             entity.__editorName = args.name;

--- a/src/editor/viewport/gizmo/gizmo-bounding-box.ts
+++ b/src/editor/viewport/gizmo/gizmo-bounding-box.ts
@@ -1,4 +1,4 @@
-import { BoundingBox, Color, EMITTERSHAPE_BOX, EMITTERSHAPE_SPHERE, Entity, Mat4, Vec3 } from 'playcanvas';
+import { type AppBase, BoundingBox, Color, EMITTERSHAPE_BOX, EMITTERSHAPE_SPHERE, Entity, Mat4, Vec3 } from 'playcanvas';
 
 editor.once('load', () => {
     let app = null;
@@ -278,7 +278,7 @@ editor.once('load', () => {
         return getBoundingBoxForEntity(entity, _resultBB);
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
 
         editor.on('viewport:postUpdate', () => {

--- a/src/editor/viewport/gizmo/gizmo-button.ts
+++ b/src/editor/viewport/gizmo/gizmo-button.ts
@@ -1,4 +1,4 @@
-import { Color, ElementInput, Vec3 } from 'playcanvas';
+import { type AppBase, Color, ElementInput, Vec3 } from 'playcanvas';
 
 editor.once('load', () => {
     let corners = [];
@@ -19,7 +19,7 @@ editor.once('load', () => {
 
     let visible = true;
 
-    editor.once('viewport:load', (app: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (app: AppBase) => {
         editor.method('gizmo:button:visible', (state: boolean) => {
             if (visible !== state) {
                 visible = state;

--- a/src/editor/viewport/gizmo/gizmo-camera.ts
+++ b/src/editor/viewport/gizmo/gizmo-camera.ts
@@ -1,4 +1,4 @@
-import { Color, Mat4, PROJECTION_PERSPECTIVE, Vec3 } from 'playcanvas';
+import { type AppBase, Color, Mat4, PROJECTION_PERSPECTIVE, Vec3 } from 'playcanvas';
 
 import type { EntityObserver } from '@/editor-api';
 
@@ -209,7 +209,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
     });
 

--- a/src/editor/viewport/gizmo/gizmo-collision.ts
+++ b/src/editor/viewport/gizmo/gizmo-collision.ts
@@ -23,6 +23,9 @@ import {
     Shader,
     SphereGeometry,
     TYPE_FLOAT32,
+    type AppBase,
+    type Asset,
+    type GraphicsDevice,
     Vec3,
     VertexBuffer,
     VertexFormat
@@ -412,7 +415,7 @@ editor.once('load', () => {
                     this.entity.model.model = createModelCopy(asset.resource, this.color);
                 }
             } else {
-                this.events.push(asset.once('load', (loadedAsset: import('playcanvas').Asset) => {
+                this.events.push(asset.once('load', (loadedAsset: Asset) => {
                     if (this.asset !== loadedAsset.id) {
                         return;
                     }
@@ -473,7 +476,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
 
         container = new Entity(app);
@@ -522,7 +525,7 @@ void main(void)
 
         const origFunc = materialDefault.getShaderVariant;
 
-        materialDefault.getShaderVariant = function (params: { device: import('playcanvas').GraphicsDevice; pass: number }) {
+        materialDefault.getShaderVariant = function (params: { device: GraphicsDevice; pass: number }) {
             if (params.pass === SHADER_FORWARD) {
                 if (!shaderDefault) {
                     shaderDefault = new Shader(params.device, {
@@ -615,7 +618,7 @@ void main(void)
 
         const matCapsule = cloneColorMaterial(materialDefault);
         const _getCapsuleShaderVariant = matCapsule.getShaderVariant;
-        matCapsule.getShaderVariant = function (params: { device: import('playcanvas').GraphicsDevice; pass: number }) {
+        matCapsule.getShaderVariant = function (params: { device: GraphicsDevice; pass: number }) {
             if (params.pass === SHADER_FORWARD) {
                 if (!shaderCapsuleForward) {
                     shaderCapsuleForward = new Shader(params.device, {

--- a/src/editor/viewport/gizmo/gizmo-element-anchor.ts
+++ b/src/editor/viewport/gizmo/gizmo-element-anchor.ts
@@ -1,4 +1,4 @@
-import { BlendState, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA, Color, Entity, math, PROJECTION_PERSPECTIVE, Quat, Vec3 } from 'playcanvas';
+import { type AppBase, BlendState, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA, Color, Entity, type GraphNode, type Material, math, PROJECTION_PERSPECTIVE, Quat, Vec3 } from 'playcanvas';
 
 import { FORCE_PICK_TAG, GIZMO_MASK } from '@/core/constants';
 import type { EntityObserver } from '@/editor-api';
@@ -112,13 +112,13 @@ editor.once('load', () => {
         return mat;
     };
 
-    const setModelMaterial = function (entity: Entity, material: import('playcanvas').Material) {
+    const setModelMaterial = function (entity: Entity, material: Material) {
         if (entity.model.meshInstances[0].material !== material) {
             entity.model.meshInstances[0].material = material;
         }
     };
 
-    editor.once('viewport:load', (app: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (app: AppBase) => {
         const gizmoAnchor = createAnchorGizmo();
         app.root.addChild(gizmoAnchor.root);
 
@@ -297,7 +297,7 @@ editor.once('load', () => {
             // gizmoAnchor.handles.center.setLocalPosition(resX * (pc.math.lerp(anchor.x,anchor.z,0.5) - 0.5), resY * (pc.math.lerp(anchor.y,anchor.w,0.5) - 0.5), 0, 0.1);
         });
 
-        editor.on('viewport:pick:hover', (node: Entity | null, picked: { node: import('playcanvas').GraphNode } | null) => {
+        editor.on('viewport:pick:hover', (node: Entity | null, picked: { node: GraphNode } | null) => {
             if (!node || !node.handle) {
                 if (gizmoAnchor.handle) {
                     gizmoAnchor.handle = null;

--- a/src/editor/viewport/gizmo/gizmo-element-size.ts
+++ b/src/editor/viewport/gizmo/gizmo-element-size.ts
@@ -1,4 +1,4 @@
-import { BlendState, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA, Color, Entity, Mat4, math, PROJECTION_PERSPECTIVE, Vec3 } from 'playcanvas';
+import { type AppBase, BlendState, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA, Color, Entity, Mat4, math, PROJECTION_PERSPECTIVE, Vec3 } from 'playcanvas';
 
 import { GIZMO_MASK } from '@/core/constants';
 import type { EntityObserver } from '@/editor-api';
@@ -90,7 +90,7 @@ editor.once('load', () => {
         return false;
     };
 
-    editor.once('viewport:load', (app: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (app: AppBase) => {
         const gizmo = createGizmo();
         app.root.addChild(gizmo.root);
 

--- a/src/editor/viewport/gizmo/gizmo-element.ts
+++ b/src/editor/viewport/gizmo/gizmo-element.ts
@@ -1,4 +1,4 @@
-import { Color, Vec3 } from 'playcanvas';
+import { type AppBase, Color, Vec3 } from 'playcanvas';
 
 editor.once('load', () => {
     const positions = [];
@@ -14,7 +14,7 @@ editor.once('load', () => {
 
     let visible = true;
 
-    editor.once('viewport:load', (app: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (app: AppBase) => {
         editor.method('gizmo:element:visible', (state) => {
             if (visible !== state) {
                 visible = state;

--- a/src/editor/viewport/gizmo/gizmo-layers.ts
+++ b/src/editor/viewport/gizmo/gizmo-layers.ts
@@ -1,4 +1,4 @@
-import { Layer, SORTMODE_BACK2FRONT, SORTMODE_NONE } from 'playcanvas';
+import { Layer, type LayerComposition, SORTMODE_BACK2FRONT, SORTMODE_NONE } from 'playcanvas';
 
 editor.once('load', () => {
     // holds all layers that are to be added in the beginning of the composition
@@ -60,7 +60,7 @@ editor.once('load', () => {
         return result;
     });
 
-    editor.method('gizmo:layers:removeFromComposition', (composition: import('playcanvas').LayerComposition | null) => {
+    editor.method('gizmo:layers:removeFromComposition', (composition: LayerComposition | null) => {
         if (!composition) {
             const app = editor.call('viewport:app');
             if (!app) {
@@ -78,7 +78,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.method('gizmo:layers:addToComposition', (composition?: import('playcanvas').LayerComposition) => {
+    editor.method('gizmo:layers:addToComposition', (composition?: LayerComposition) => {
         if (!composition) {
             const app = editor.call('viewport:app');
             if (!app) {

--- a/src/editor/viewport/gizmo/gizmo-light.ts
+++ b/src/editor/viewport/gizmo/gizmo-light.ts
@@ -17,6 +17,9 @@ import {
     PRIMITIVE_LINES,
     SEMANTIC_ATTR15,
     ShaderMaterial,
+    type AppBase,
+    type GraphicsDevice,
+    type Material,
     Vec3
 } from 'playcanvas';
 
@@ -300,7 +303,7 @@ editor.once('load', () => {
             materialSpotBehind.update();
         }
 
-        static createDirectional(device: import('playcanvas').GraphicsDevice) {
+        static createDirectional(device: GraphicsDevice) {
 
             const rad = math.DEG_TO_RAD;
             const size = 0.2;
@@ -329,7 +332,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createPoint(device: import('playcanvas').GraphicsDevice) {
+        static createPoint(device: GraphicsDevice) {
 
             // xz axis
             const positions = [];
@@ -342,7 +345,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createPointClose(device: import('playcanvas').GraphicsDevice) {
+        static createPointClose(device: GraphicsDevice) {
 
             // circles
             const positions = [];
@@ -359,7 +362,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createSpot(device: import('playcanvas').GraphicsDevice) {
+        static createSpot(device: GraphicsDevice) {
 
             const positions = [];
             const outers = [];
@@ -390,7 +393,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, outers, materialSpot, materialSpotBehind);
         }
 
-        static createRectangle(device: import('playcanvas').GraphicsDevice) {
+        static createRectangle(device: GraphicsDevice) {
 
             // 4 lines
             const positions = [
@@ -403,7 +406,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createDisk(device: import('playcanvas').GraphicsDevice) {
+        static createDisk(device: GraphicsDevice) {
 
             const positions = [];
             const factor = 360 / _circleSegments * math.DEG_TO_RAD;
@@ -416,7 +419,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createSphere(device: import('playcanvas').GraphicsDevice) {
+        static createSphere(device: GraphicsDevice) {
 
             // circles
             const positions = [];
@@ -433,7 +436,7 @@ editor.once('load', () => {
             return Gizmo.createModel(device, positions, null, material, materialBehind);
         }
 
-        static createModel(device: import('playcanvas').GraphicsDevice, positions: number[], outers: number[] | null, materialFront: import('playcanvas').Material, materialBack: import('playcanvas').Material) {
+        static createModel(device: GraphicsDevice, positions: number[], outers: number[] | null, materialFront: Material, materialBack: Material) {
 
             // node
             const node = new GraphNode();
@@ -522,7 +525,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
         const device = app.graphicsDevice;
 

--- a/src/editor/viewport/gizmo/gizmo-particles.ts
+++ b/src/editor/viewport/gizmo/gizmo-particles.ts
@@ -11,6 +11,7 @@ import {
     Model,
     PRIMITIVE_LINES,
     SEMANTIC_POSITION,
+    type AppBase,
     TYPE_FLOAT32,
     VertexBuffer,
     VertexFormat,
@@ -255,7 +256,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
         const device = app.graphicsDevice;
 

--- a/src/editor/viewport/gizmo/gizmo-screen.ts
+++ b/src/editor/viewport/gizmo/gizmo-screen.ts
@@ -1,4 +1,4 @@
-import { Color, Vec2, Vec3 } from 'playcanvas';
+import { type AppBase, Color, Vec2, Vec3 } from 'playcanvas';
 
 import type { EntityObserver } from '@/editor-api';
 
@@ -21,7 +21,7 @@ editor.once('load', () => {
         colors.push(Color.WHITE);
     }
 
-    editor.once('viewport:load', (app: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (app: AppBase) => {
         const entities = {};
 
         // remember selected entities

--- a/src/editor/viewport/gizmo/gizmo-skeleton.ts
+++ b/src/editor/viewport/gizmo/gizmo-skeleton.ts
@@ -1,4 +1,4 @@
-import { Color, Entity } from 'playcanvas';
+import { type AppBase, Color, Entity, type GraphNode } from 'playcanvas';
 
 import type { EntityObserver } from '@/editor-api';
 
@@ -14,14 +14,14 @@ editor.once('load', () => {
         const immediateLayer = editor.call('gizmo:layers', 'Axis Gizmo Immediate');
         const brightLayer = editor.call('gizmo:layers', 'Bright Gizmo');
 
-        const renderBone = function (parent: import('playcanvas').GraphNode, child: import('playcanvas').GraphNode) {
+        const renderBone = function (parent: GraphNode, child: GraphNode) {
             const start = parent.getPosition();
             const end = child.getPosition();
             app.drawLine(start, end, colorBehind, true, immediateLayer);
             app.drawLine(start, end, color, true, brightLayer);
         };
 
-        const renderBoneHierarchy = function (node: import('playcanvas').GraphNode) {
+        const renderBoneHierarchy = function (node: GraphNode) {
             // render node join
             if (!node.enabled) {
                 return;
@@ -65,7 +65,7 @@ editor.once('load', () => {
         }
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
 
         // hook up changes to editor.showSkeleton

--- a/src/editor/viewport/gizmo/gizmo-zone.ts
+++ b/src/editor/viewport/gizmo/gizmo-zone.ts
@@ -14,6 +14,7 @@ import {
     Model,
     PRIMITIVE_LINES,
     Quat,
+    type AppBase,
     Vec3
 } from 'playcanvas';
 
@@ -70,7 +71,7 @@ editor.once('load', () => {
         editor.call('viewport:render');
     });
 
-    editor.once('viewport:load', (application: import('playcanvas').AppBase) => {
+    editor.once('viewport:load', (application: AppBase) => {
         app = application;
 
         const container = new Entity();

--- a/src/editor/viewport/viewport-assets.ts
+++ b/src/editor/viewport/viewport-assets.ts
@@ -121,8 +121,8 @@ editor.once('load', () => {
     });
 
     // patch update for materials to re-render the viewport
-    const update = StandardMaterial.prototype.update as (this: import('playcanvas').StandardMaterial) => void;
-    StandardMaterial.prototype.update = function (this: import('playcanvas').StandardMaterial): void {
+    const update = StandardMaterial.prototype.update as (this: StandardMaterial) => void;
+    StandardMaterial.prototype.update = function (this: StandardMaterial): void {
         update.call(this);
         editor.call('viewport:render');
     };

--- a/src/editor/viewport/viewport-color-material.ts
+++ b/src/editor/viewport/viewport-color-material.ts
@@ -20,7 +20,7 @@ const createColorMaterial = (useVertexColor?: boolean) => {
 
 const addColorProperty = (material: StandardMaterial): void => {
     Object.defineProperty(material, 'color', {
-        set: function (value: import('playcanvas').Color) {
+        set: function (value: Color) {
 
             const linearColor = new Color();
             linearColor.linear(value);

--- a/src/editor/viewport/viewport-cursor.ts
+++ b/src/editor/viewport/viewport-cursor.ts
@@ -1,3 +1,5 @@
+import type { Entity, MeshInstance } from 'playcanvas';
+
 editor.once('load', () => {
     let state = false;
     let inViewport = false;
@@ -19,7 +21,7 @@ editor.once('load', () => {
         }
     });
 
-    const checkPicked = function (node: import('playcanvas').Entity | null, picked: import('playcanvas').MeshInstance | { node: { name: string } } | null): void {
+    const checkPicked = function (node: Entity | null, picked: MeshInstance | { node: { name: string } } | null): void {
         let hover = false;
 
         // if mouse in viewport && entity model has an asset

--- a/src/editor/viewport/viewport-drop-cubemap.ts
+++ b/src/editor/viewport/viewport-drop-cubemap.ts
@@ -1,4 +1,4 @@
-import { MeshInstance } from 'playcanvas';
+import { type Entity, MeshInstance } from 'playcanvas';
 
 import { config } from '@/editor/config';
 
@@ -76,7 +76,7 @@ editor.once('load', () => {
         }
     };
 
-    const onHover = function (entity: import('playcanvas').Entity | null, meshInstance: import('playcanvas').MeshInstance | null): void {
+    const onHover = function (entity: Entity | null, meshInstance: MeshInstance | null): void {
         if (entity === hoverEntity && meshInstance === hoverMeshInstance) {
             return;
         }
@@ -89,7 +89,7 @@ editor.once('load', () => {
         setCubemap();
     };
 
-    const onPickHover = function (node: import('playcanvas').Entity | null, picked: import('playcanvas').MeshInstance | unknown): void {
+    const onPickHover = function (node: Entity | null, picked: MeshInstance | unknown): void {
         let meshInstance = null;
 
         if (node && node._icon) {

--- a/src/editor/viewport/viewport-drop-material.ts
+++ b/src/editor/viewport/viewport-drop-material.ts
@@ -1,4 +1,4 @@
-import { MeshInstance } from 'playcanvas';
+import { type Entity, MeshInstance } from 'playcanvas';
 
 import { config } from '@/editor/config';
 
@@ -54,7 +54,7 @@ editor.once('load', () => {
         editor.call('viewport:render');
     };
 
-    const onHover = function (entity: import('playcanvas').Entity | null, meshInstance: import('playcanvas').MeshInstance | null): void {
+    const onHover = function (entity: Entity | null, meshInstance: MeshInstance | null): void {
         if (entity === hoverEntity && meshInstance === hoverMeshInstance) {
             return;
         }
@@ -110,7 +110,7 @@ editor.once('load', () => {
         }
     };
 
-    const onPick = function (node: import('playcanvas').Entity | null, picked: import('playcanvas').MeshInstance | unknown): void {
+    const onPick = function (node: Entity | null, picked: MeshInstance | unknown): void {
         let meshInstance = null;
 
         if (node && node._icon) {
@@ -133,7 +133,7 @@ editor.once('load', () => {
         }
     };
 
-    editor.on('viewport:pick:hover', (node: import('playcanvas').Entity | null, picked: import('playcanvas').MeshInstance | null) => {
+    editor.on('viewport:pick:hover', (node: Entity | null, picked: MeshInstance | null) => {
         hoverNode = node;
         hoverPicked = picked;
 

--- a/src/editor/viewport/viewport-focus.ts
+++ b/src/editor/viewport/viewport-focus.ts
@@ -10,7 +10,7 @@ editor.once('load', () => {
     const aabb = new BoundingBox();
     const aabbA = new BoundingBox();
 
-    const calculateChildAABB = function (entity: import('playcanvas').Entity): void {
+    const calculateChildAABB = function (entity: Entity): void {
         aabbA.add(editor.call('entities:getBoundingBoxForEntity', entity));
 
         const children = entity.children;

--- a/src/editor/viewport/viewport-grid.ts
+++ b/src/editor/viewport/viewport-grid.ts
@@ -1,8 +1,8 @@
-import { GraphNode, Mesh, MeshInstance, PRIMITIVE_LINES } from 'playcanvas';
+import { type Application, GraphNode, Mesh, MeshInstance, PRIMITIVE_LINES } from 'playcanvas';
 
 import { createColorMaterial } from './viewport-color-material';
 
-editor.once('viewport:load', (app: import('playcanvas').Application) => {
+editor.once('viewport:load', (app: Application) => {
 
     const material = createColorMaterial(true);
     material.name = 'GridMaterial';

--- a/src/editor/viewport/viewport-outline.ts
+++ b/src/editor/viewport/viewport-outline.ts
@@ -1,4 +1,4 @@
-import { Color, OutlineRenderer } from 'playcanvas';
+import { Color, type Entity, OutlineRenderer } from 'playcanvas';
 
 editor.once('load', () => {
     const app = editor.call('viewport:app');
@@ -51,7 +51,7 @@ editor.once('load', () => {
     };
 
     // request rendering of entities for a user
-    const setUserSelection = (id: number | string, entities: import('playcanvas').Entity[]): void => {
+    const setUserSelection = (id: number | string, entities: Entity[]): void => {
 
         // remove existing entities
         const existingEntities = userSelections.get(id);

--- a/src/editor/viewport/viewport-tooltips.ts
+++ b/src/editor/viewport/viewport-tooltips.ts
@@ -1,3 +1,5 @@
+import type { Entity, MeshInstance } from 'playcanvas';
+
 editor.once('load', () => {
     let inViewport = false;
     let nameLast = '';
@@ -22,7 +24,7 @@ editor.once('load', () => {
         editor.call('cursor:text', nameLast);
     };
 
-    const checkPicked = function (node: import('playcanvas').Entity | null, picked: import('playcanvas').MeshInstance | { node: { name: string } } | null): void {
+    const checkPicked = function (node: Entity | null, picked: MeshInstance | { node: { name: string } } | null): void {
         let name = '';
 
         if (inViewport && node) {


### PR DESCRIPTION
## Summary

- Replace all inline `import('playcanvas').TypeName` expressions with proper top-level imports across 31 files in `src/editor/viewport/`
- Uses inline `type` keyword (e.g. `import { type AppBase, Entity } from 'playcanvas'`) for type-only references, consistent with existing conventions
- Files with no prior playcanvas imports get a new `import type { ... } from 'playcanvas'` statement

No functional changes -- purely a readability and consistency refactor.
