### PR TITLE
fix: render skeleton gizmo for RenderComponent entities

### DIFF
--- a/src/editor/viewport/gizmo/gizmo-skeleton.ts
+++ b/src/editor/viewport/gizmo/gizmo-skeleton.ts
@@ -38,16 +38,14 @@ editor.once('load', () => {
             const entity = entities[i];
             if (entity) {
                 const model = entity.model;
-                if (model) {
-                    if (model.model) {
-                        renderBoneHierarchy(model.model.graph);
-                    }
+                if (model?.model) {
+                    renderBoneHierarchy(model.model.graph);
                 }
 
                 // render skeleton if entity with render component that has rootBone set is selected
                 const render = entity.render;
-                if (render && render._rootBone && render._rootBone.entity) {
-                    renderBoneHierarchy(render._rootBone.entity);
+                if (render && render.rootBone) {
+                    renderBoneHierarchy(render.rootBone);
                 }
             }
         }


### PR DESCRIPTION
## Summary

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4faa8de7-75bf-418c-8713-a37604d371a0" />

- **Fix skeleton gizmo for RenderComponent entities** — the skeleton was never rendered because `render._rootBone.entity` is always `undefined` (`_rootBone` is already an `Entity`, not a wrapper). Now uses the public `rootBone` getter directly.
- Flatten nested `if` for the ModelComponent path using optional chaining.

## Test plan

- [x] Select an entity with a RenderComponent that has a skinned mesh (with `rootBone` set)
- [x] Enable "Show Skeleton" in user settings
- [x] Verify the bone hierarchy is drawn in the viewport
- [x] Verify the ModelComponent skeleton path still works as before
