### PR TITLE
fix: resolve straightforward TS errors in viewport files

### DIFF
--- a/src/editor/viewport/viewport-application.ts
+++ b/src/editor/viewport/viewport-application.ts
@@ -4,6 +4,10 @@ let time;
 const rect = new Vec4(0, 0, 1, 1);
 
 class ViewportApplication extends Application {
+    editorSettings!: Record<string, unknown>;
+
+    redraw = false;
+
     constructor(canvas: HTMLCanvasElement, options: { editorSettings?: Record<string, unknown> }) {
         super(canvas, options);
 

--- a/src/editor/viewport/viewport-drop-cubemap.ts
+++ b/src/editor/viewport/viewport-drop-cubemap.ts
@@ -97,7 +97,7 @@ editor.once('load', () => {
         }
 
         if (!node) {
-            onHover(null);
+            onHover(null, null);
             return;
         }
 
@@ -108,7 +108,7 @@ editor.once('load', () => {
         if (node.model && meshInstance && (!meshInstance.node._parent || !meshInstance.node._parent._icon)) {
             onHover(node, meshInstance);
         } else {
-            onHover(null);
+            onHover(null, null);
         }
     };
 

--- a/src/editor/viewport/viewport-drop-material.ts
+++ b/src/editor/viewport/viewport-drop-material.ts
@@ -118,7 +118,7 @@ editor.once('load', () => {
         }
 
         if (!node || !editor.call('entities:get', node.getGuid())) {
-            onHover(null);
+            onHover(null, null);
             return;
         }
 
@@ -129,7 +129,7 @@ editor.once('load', () => {
         if (meshInstance && (!meshInstance.node._parent || !meshInstance.node._parent._icon) && (node.model || node.render)) {
             onHover(node, meshInstance);
         } else {
-            onHover(null);
+            onHover(null, null);
         }
     };
 


### PR DESCRIPTION
## Summary
- Add missing `editorSettings` and `redraw` class property declarations on `ViewportApplication` to fix 11 TS errors
- Pass the required second argument to `onHover(null)` calls in `viewport-drop-cubemap.ts` and `viewport-drop-material.ts` (4 call sites)

## Test plan
- [x] Verify `npm run lint` passes
- [x] Verify `npm run type:check` has no new errors in the changed files
- [x] Open a project in the editor and confirm cubemap/material drag-and-drop still works
