### PR TITLE
fix: remove dead GraphNode#addLabel calls

### DIFF
--- a/src/editor/viewport/viewport-entities-create.ts
+++ b/src/editor/viewport/viewport-entities-create.ts
@@ -41,12 +41,6 @@ editor.once('load', () => {
         const viewportHidden = editor.call('entities:visibility:isHidden', obj.get('resource_id'));
         entity._enabled = observerEnabled && !viewportHidden;
 
-        if (obj.has('labels')) {
-            obj.get('labels').forEach((label) => {
-                entity.addLabel(label);
-            });
-        }
-
         entity.template = obj.get('template');
 
         return entity;

--- a/src/launch/viewport/viewport-binding-entities.ts
+++ b/src/launch/viewport/viewport-binding-entities.ts
@@ -30,12 +30,6 @@ editor.once('load', () => {
         const viewportHidden = editor.call('entities:visibility:isHidden', obj.get('resource_id'));
         entity._enabled = observerEnabled && !viewportHidden;
 
-        if (obj.has('labels')) {
-            obj.get('labels').forEach((label: string) => {
-                entity.addLabel(label);
-            });
-        }
-
         if (obj.has('tags')) {
             obj.get('tags').forEach((tag: string) => {
                 entity.tags.add(tag);


### PR DESCRIPTION
## Summary

- Remove dead `entity.addLabel()` calls from `viewport-entities-create.ts` and `viewport-binding-entities.ts`
- The engine's `GraphNode#addLabel` API was removed in v2.x (engine PR #6705), so these calls would throw at runtime if triggered

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type:check` — no new errors (pre-existing errors in the file are unrelated)
