### PR TITLE
refactor: declare class fields in conflict-manager UI

### DIFF
--- a/src/editor/pickers/conflict-manager/ui/conflict-field.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-field.ts
@@ -9,9 +9,7 @@ import { LegacyPanel } from '@/common/ui/panel';
 
 // Base class for fields
 class ConflictField {
-    constructor() {
-        this.element = null;
-    }
+    element: any = null;
 
     onAddedToDom() {
         // reset height
@@ -25,6 +23,36 @@ class ConflictField {
 
     get height() {
         return this.element.parent.element.clientHeight;
+    }
+
+    static create(type: string, value: unknown): ConflictField {
+        switch (type) {
+            case 'asset':
+                return new ConflictFieldAsset(value);
+            case 'curve':
+            case 'curveset':
+                return new ConflictFieldCurve(value);
+            case 'entity':
+                return new ConflictFieldEntity(value);
+            case 'layer':
+            case 'batchGroup':
+                return new ConflictFieldLayer(value);
+            case 'sublayer':
+                return new ConflictFieldSublayer(value);
+            case 'vec2':
+            case 'vec3':
+            case 'vec4':
+                return new ConflictFieldVector(value);
+            case 'rgb':
+            case 'rgba':
+                return new ConflictFieldColor(value);
+            case 'json':
+                return new ConflictFieldJson(value);
+            case 'object':
+                return new ConflictFieldNotRenderable();
+            default:
+                return new ConflictFieldString(value);
+        }
     }
 }
 
@@ -194,13 +222,13 @@ class ConflictFieldDeleted extends ConflictField {
         this.element = new LegacyPanel();
         this.element.class.add('field-deleted');
 
-        let label =  new LegacyLabel({
+        let label = new LegacyLabel({
             text: 'DELETED'
         });
         label.class.add('title');
         this.element.append(label);
 
-        label =  new LegacyLabel({
+        label = new LegacyLabel({
             text: 'This item was deleted on this branch'
         });
         this.element.append(label);
@@ -215,13 +243,13 @@ class ConflictFieldCreated extends ConflictField {
         this.element = new LegacyPanel();
         this.element.class.add('field-edited');
 
-        let label =  new LegacyLabel({
+        let label = new LegacyLabel({
             text: 'CREATED'
         });
         label.class.add('title');
         this.element.append(label);
 
-        label =  new LegacyLabel({
+        label = new LegacyLabel({
             text: 'This item was created on this branch'
         });
         this.element.append(label);
@@ -236,13 +264,13 @@ class ConflictFieldEdited extends ConflictField {
         this.element = new LegacyPanel();
         this.element.class.add('field-edited');
 
-        let label =  new LegacyLabel({
+        let label = new LegacyLabel({
             text: 'EDITED'
         });
         label.class.add('title');
         this.element.append(label);
 
-        label =  new LegacyLabel({
+        label = new LegacyLabel({
             text: 'This item was edited on this branch'
         });
         this.element.append(label);
@@ -275,6 +303,12 @@ class ConflictFieldNotRenderable extends ConflictField {
 
 // An array field is a list of other fields
 class ConflictArrayField extends ConflictField {
+    private _size: number;
+
+    private _labelSize: LegacyLabel;
+
+    private _list: LegacyList;
+
     constructor(type: string, value: unknown[]) {
         super();
 
@@ -305,37 +339,6 @@ class ConflictArrayField extends ConflictField {
         return this._size;
     }
 }
-
-// Creates a field with the specified value based on the specified type
-ConflictField.create = function (type: string, value: unknown) {
-    switch (type) {
-        case 'asset':
-            return new ConflictFieldAsset(value);
-        case 'curve':
-        case 'curveset':
-            return new ConflictFieldCurve(value);
-        case 'entity':
-            return new ConflictFieldEntity(value);
-        case 'layer':
-        case 'batchGroup':
-            return new ConflictFieldLayer(value);
-        case 'sublayer':
-            return new ConflictFieldSublayer(value);
-        case 'vec2':
-        case 'vec3':
-        case 'vec4':
-            return new ConflictFieldVector(value);
-        case 'rgb':
-        case 'rgba':
-            return new ConflictFieldColor(value);
-        case 'json':
-            return new ConflictFieldJson(value);
-        case 'object':
-            return new ConflictFieldNotRenderable();
-        default:
-            return new ConflictFieldString(value);
-    }
-};
 
 export {
     ConflictArrayField,

--- a/src/editor/pickers/conflict-manager/ui/conflict-resolver.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-resolver.ts
@@ -1,16 +1,44 @@
 import { Events } from '@playcanvas/observer';
 
 import { LegacyLabel } from '@/common/ui/label';
+import type { LegacyPanel } from '@/common/ui/panel';
 
 import { ConflictSection } from './conflict-section';
 
 // Shows all the conflicts for an item
 class ConflictResolver extends Events {
+    elements: (ConflictSection | LegacyLabel)[] = [];
+
+    private _conflicts: Record<string, unknown>;
+
+    private _mergeId: unknown;
+
+    isDiff: unknown;
+
+    srcAssetIndex: unknown;
+
+    dstAssetIndex: unknown;
+
+    srcEntityIndex: Record<string, unknown>;
+
+    dstEntityIndex: Record<string, unknown>;
+
+    srcSettingsIndex: Record<string, unknown>;
+
+    dstSettingsIndex: Record<string, unknown>;
+
+    private _pendingResolvedConflicts: Record<string, Record<string, unknown>> = {};
+
+    private _pendingRevertedConflicts: Record<string, boolean> = {};
+
+    private _timeoutSave: ReturnType<typeof setTimeout> | null = null;
+
+    private _parent: LegacyPanel | null = null;
+
+    private _scrollListener: () => void;
+
     constructor(conflicts: Record<string, unknown>, mergeObject: Record<string, unknown>) {
         super();
-
-        // holds conflict UI elements
-        this.elements = [];
 
         this._conflicts = conflicts;
         this._mergeId = mergeObject.id;
@@ -26,12 +54,6 @@ class ConflictResolver extends Events {
 
         this.srcSettingsIndex = mergeObject.srcCheckpoint.settings;
         this.dstSettingsIndex = mergeObject.dstCheckpoint.settings;
-
-        this._pendingResolvedConflicts = {};
-        this._pendingRevertedConflicts = {};
-        this._timeoutSave = null;
-
-        this._parent = null;
 
         this._scrollListener = () => {
             this.emit('scroll');
@@ -122,7 +144,7 @@ class ConflictResolver extends Events {
     }
 
     // Append the resolver to a parent
-    appendToParent(parent: { append: (el: unknown) => void; element: HTMLElement }) {
+    appendToParent(parent: LegacyPanel) {
         this._parent = parent;
 
         for (let i = 0, len = this.elements.length; i < len; i++) {

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -40,6 +40,22 @@ const SOURCE_PANEL = 2;
  * A row that contains the base, source and destination fields.
  */
 class ConflictSectionRow extends Events {
+    private _resolver: Record<string, unknown>;
+
+    private _name: string | undefined;
+
+    private _types: string[];
+
+    private _conflict: Record<string, unknown>;
+
+    private _resolved = false;
+
+    private _indent = 0;
+
+    private _panels: LegacyPanel[] = [];
+
+    private _fields: ConflictField[] = [];
+
     /**
      * Creates a new ConflictSectionRow.
      *
@@ -58,12 +74,6 @@ class ConflictSectionRow extends Events {
             this._types = [args.baseType || '', args.destType || '', args.sourceType || ''];
         }
         this._conflict = args.conflict;
-        this._resolved = false;
-
-        this._indent = 0;
-
-        this._panels = [];
-        this._fields = [];
 
         const values = this._convertValues(self._conflict);
 

--- a/src/editor/pickers/conflict-manager/ui/conflict-section.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section.ts
@@ -8,17 +8,42 @@ import { ConflictSectionRow, type ConflictSectionRowArgs } from './conflict-sect
 // A section contains multiple conflicts and it's meant to group
 // conflicts into meaningful categories
 class ConflictSection extends Events {
+    private _resolver: Record<string, unknown>;
+
+    private _numConflicts = 0;
+
+    private _numResolvedConflicts = 0;
+
+    private _indent = 0;
+
+    private _foldable: boolean;
+
+    private _allowCloaking: boolean;
+
+    private _cloaked = false;
+
+    private _cloakFn: () => void;
+
+    panel: LegacyPanel;
+
+    private _panelBase: LegacyPanel;
+
+    private _panelDest: LegacyPanel;
+
+    private _panelSource: LegacyPanel;
+
+    panels: LegacyPanel[];
+
+    private _labelNumConflicts: LegacyLabel;
+
+    private _rows: ConflictSectionRow[] = [];
+
     constructor(resolver: Record<string, unknown>, title: string, foldable: boolean, allowCloaking: boolean) {
         super();
 
         this._resolver = resolver;
-        this._numConflicts = 0;
-        this._numResolvedConflicts = 0;
-        this._indent = 0;
-
         this._foldable = foldable;
         this._allowCloaking = allowCloaking;
-        this._cloaked = false;
         this._cloakFn = this.cloakIfNecessary.bind(this);
 
         this.panel = new LegacyPanel(title);
@@ -64,8 +89,6 @@ class ConflictSection extends Events {
         this._labelNumConflicts.class.add('num-conflicts');
         this._labelNumConflicts.hidden = resolver.isDiff;
         this.panel.headerElement.appendChild(this._labelNumConflicts.element);
-
-        this._rows = [];
     }
 
     indent() {

--- a/src/editor/pickers/conflict-manager/ui/text-resolver.ts
+++ b/src/editor/pickers/conflict-manager/ui/text-resolver.ts
@@ -12,6 +12,48 @@ import { handleCallback } from '@/common/utils';
  * to resolve the merged file.
  */
 class TextResolver extends Events {
+    private _mergeId: unknown;
+
+    private _conflict: Record<string, unknown>;
+
+    private _sourceBranchId: unknown;
+
+    private _destBranchId: unknown;
+
+    private _isDiff: unknown;
+
+    private _panelTop: LegacyPanel;
+
+    private _labelName: LegacyLabel;
+
+    private _textualMergeConflict: Record<string, unknown> | null = null;
+
+    private _btnMarkResolved: LegacyButton;
+
+    private _btnUseAllFrom: LegacyButton;
+
+    private _btnRevert: LegacyButton;
+
+    private _menu: LegacyMenu;
+
+    private _btnUseSource: LegacyMenuItem;
+
+    private _btnUseDest: LegacyMenuItem;
+
+    private _btnNextConflict: LegacyButton;
+
+    private _btnPrevConflict: LegacyButton;
+
+    private _btnGoBack: LegacyButton;
+
+    private _iframe: HTMLIFrameElement;
+
+    private _sourceFile: string | null = null;
+
+    private _destFile: string | null = null;
+
+    private _unresolvedFile: string | null = null;
+
     /**
      * Create a new TextResolver.
      *
@@ -40,7 +82,6 @@ class TextResolver extends Events {
         this._panelTop.append(this._labelName);
 
         // find textual merge conflict
-        this._textualMergeConflict = null;
         for (let i = 0; i < conflict.data.length; i++) {
             if (conflict.data[i].isTextualMerge) {
                 this._textualMergeConflict = conflict.data[i];
@@ -132,10 +173,6 @@ class TextResolver extends Events {
         });
 
         this._iframe.src = `/editor/code/${config.project.id}?mergeId=${this._mergeId}&conflictId=${this._textualMergeConflict.id}&assetType=${this._conflict.assetType}&mergedFilePath=${this._textualMergeConflict.mergedFilePath}`;
-
-        this._sourceFile = null;
-        this._destFile = null;
-        this._unresolvedFile = null;
     }
 
     appendToParent(parent: { append: (el: unknown) => void }) {


### PR DESCRIPTION
## Summary

- Declare explicit class fields with type annotations in all conflict-manager UI classes (`ConflictField`, `ConflictArrayField`, `ConflictResolver`, `ConflictSection`, `ConflictSectionRow`, `TextResolver`)
- Initialize fields with constant defaults (`null`, `0`, `false`, `[]`, `{}`) at the point of declaration, removing redundant assignments from constructors
- Convert `ConflictField.create` from a monkey-patched function assignment to a proper `static` method on the class
