### PR TITLE
refactor: declare class fields in vc/graph classes

### DIFF
--- a/src/editor/vc/graph/compact-branches.ts
+++ b/src/editor/vc/graph/compact-branches.ts
@@ -2,9 +2,18 @@ editor.once('load', () => {
     //  Try to place branches above or below each other
     //  when possible, to save horizontal space
     class CompactBranches {
+        allNodes: Record<string, unknown>[];
+
+        branches: Record<string, Record<string, unknown>>;
+
+        xToNodes!: Record<number, Record<string, unknown>[]>;
+
+        maxX!: number;
+
+        xToLimits: Record<number, unknown> = {};
+
         constructor(data: { idToNode: Record<string, Record<string, unknown>>; branches: Record<string, Record<string, unknown>> }) {
             this.allNodes = Object.values(data.idToNode);
-
             this.branches = data.branches;
         }
 

--- a/src/editor/vc/graph/make-hist-graph.ts
+++ b/src/editor/vc/graph/make-hist-graph.ts
@@ -21,16 +21,25 @@
  */
 editor.once('load', () => {
     class MakeHistGraph {
+        fullGraph: Record<string, Record<string, unknown>>;
+
+        startId: string;
+
+        visited: Record<string, boolean> = {};
+
+        includeInRes: Record<string, boolean> = {};
+
+        histParents: Record<string, unknown> = {};
+
+        resGraph!: Record<string, Record<string, unknown>>;
+
+        resNodes!: Record<string, unknown>[];
+
+        startCh!: Record<string, unknown>;
+
         constructor(fullGraph: Record<string, Record<string, unknown>>, startId: string) {
             this.fullGraph = fullGraph;
-
             this.startId = startId;
-
-            this.visited = {};
-
-            this.includeInRes = {};
-
-            this.histParents = {};
         }
 
         run() {

--- a/src/editor/vc/graph/place-vc-nodes.ts
+++ b/src/editor/vc/graph/place-vc-nodes.ts
@@ -2,18 +2,25 @@ editor.once('load', () => {
     // Set the 'coords' field of every checkpoint node. The coords
     // are set relative to the previous node of our bfs traversal
     class PlaceVcNodes {
+        idToNode: Record<string, Record<string, unknown>>;
+
+        branches: Record<string, Record<string, unknown>>;
+
+        startNode: Record<string, unknown>;
+
+        q1: Record<string, unknown>[] = [];
+
+        q2: Record<string, unknown>[];
+
+        visited: Record<string, boolean> = {};
+
+        curBranch?: string;
+
         constructor(data: { idToNode: Record<string, Record<string, unknown>>; branches: Record<string, Record<string, unknown>>; startNode: Record<string, unknown> }) {
             this.idToNode = data.idToNode;
-
             this.branches = data.branches;
-
             this.startNode = data.startNode;
-
-            this.q1 = [];
-
             this.q2 = [this.startNode];
-
-            this.visited = {};
         }
 
         run() {

--- a/src/editor/vc/graph/split-node-description.ts
+++ b/src/editor/vc/graph/split-node-description.ts
@@ -2,18 +2,24 @@ editor.once('load', () => {
     // Split description into lines of up to 'maxPerLine' characters,
     // only breaking up tokens of length > 'maxPerToken'
     class SplitNodeDescription {
+        orig: string;
+
+        maxPerLine: number;
+
+        maxPerToken: number;
+
+        curTokens: string[] = [];
+
+        curLength = 0;
+
+        lines: string[] = [];
+
+        tokens!: string[];
+
         constructor(orig: string, maxPerLine: number, maxPerToken: number) {
             this.orig = orig;
-
             this.maxPerLine = maxPerLine;
-
             this.maxPerToken = maxPerToken;
-
-            this.curTokens = [];
-
-            this.curLength = 0;
-
-            this.lines = [];
         }
 
         run() {

--- a/src/editor/vc/graph/sync-hist-graph.ts
+++ b/src/editor/vc/graph/sync-hist-graph.ts
@@ -6,11 +6,19 @@
  */
 editor.once('load', () => {
     class SyncHistGraph {
+        newGraph: Record<string, Record<string, unknown>>;
+
+        oldGraph: Record<string, Record<string, unknown>>;
+
+        data: { idToNode: Record<string, Record<string, unknown>> };
+
+        oldNodes!: Record<string, unknown>[];
+
+        newNodes!: Record<string, unknown>[];
+
         constructor(newGraph: Record<string, Record<string, unknown>>, data: { idToNode: Record<string, Record<string, unknown>> }) {
             this.newGraph = newGraph;
-
             this.oldGraph = data.idToNode;
-
             this.data = data;
         }
 

--- a/src/editor/vc/graph/vc-graph.ts
+++ b/src/editor/vc/graph/vc-graph.ts
@@ -1,3 +1,6 @@
+import type { Button, Container, Menu } from '@playcanvas/pcui';
+import type Graph from '@playcanvas/pcui-graph';
+
 editor.once('load', () => {
     /**
      * Initialize and show the Version Control graph. Assign initial
@@ -6,24 +9,38 @@ editor.once('load', () => {
      * when possible to save horizontal space (compact branches).
      */
     class VcGraphLogic {
-        constructor(initData: Record<string, unknown>, params: { vcGraphContainer: { dom: HTMLElement }; vcGraphCloseBtn: { dom: HTMLElement }; vcNodeMenu: unknown; vcHistItem: unknown }) {
+        initData: Record<string, unknown>;
+
+        container: Container;
+
+        closeBtn: Button;
+
+        vcNodeMenu: Menu;
+
+        vcHistItem: unknown;
+
+        idToNode: Record<string, Record<string, unknown>> = {};
+
+        branches: Record<string, Record<string, unknown>> = {};
+
+        renderedEdges: Record<string, boolean> = {};
+
+        fullGraph: Record<string, Record<string, unknown>> = {};
+
+        graph!: Graph;
+
+        isGraphLoading = false;
+
+        startNode!: Record<string, unknown>;
+
+        origStartId?: string;
+
+        constructor(initData: Record<string, unknown>, params: { vcGraphContainer: Container; vcGraphCloseBtn: Button; vcNodeMenu: Menu; vcHistItem: unknown }) {
             this.initData = initData;
-
             this.container = params.vcGraphContainer;
-
             this.closeBtn = params.vcGraphCloseBtn;
-
             this.vcNodeMenu = params.vcNodeMenu;
-
             this.vcHistItem = params.vcHistItem;
-
-            this.idToNode = {};
-
-            this.branches = {};
-
-            this.renderedEdges = {};
-
-            this.fullGraph = {};
         }
 
         run() {

--- a/src/editor/vc/graph/vc-utils.ts
+++ b/src/editor/vc/graph/vc-utils.ts
@@ -1,4 +1,5 @@
-import { default as PCUIGraph } from '@playcanvas/pcui-graph';
+import type { Button, Container, Menu } from '@playcanvas/pcui';
+import Graph from '@playcanvas/pcui-graph';
 
 import { handleCallback } from '@/common/utils';
 
@@ -73,12 +74,14 @@ editor.once('load', () => {
 
     const CLOSED_BRANCH_SUFFIX = ' [x]';
 
+    let branchCount = 0;
+
     interface VcGraphData {
         idToNode: Record<string, Record<string, unknown>>;
         branches: Record<string, Record<string, unknown>>;
-        graph: Record<string, unknown>;
+        graph: Graph;
         renderedEdges: Record<string, boolean>;
-        vcNodeMenu?: unknown;
+        vcNodeMenu?: Menu;
         vcHistItem?: unknown;
     }
 
@@ -115,7 +118,7 @@ editor.once('load', () => {
             h.isNodeRendered = true;
         },
 
-        placeSelectedMark: function (graph: Record<string, unknown>, nodeCoords: { x: number; y: number }) {
+        placeSelectedMark: function (graph: Graph, nodeCoords: { x: number; y: number }) {
             const markCoords = {
                 coords: {
                     x: nodeCoords.x + SELECTED_MARK.offset.x,
@@ -134,7 +137,7 @@ editor.once('load', () => {
             graph.createNode(h);
         },
 
-        rmSelectedMark: function (graph: Record<string, unknown>) {
+        rmSelectedMark: function (graph: Graph) {
             graph.deleteNode(SELECTED_MARK.id);
         },
 
@@ -345,7 +348,7 @@ editor.once('load', () => {
             return `${h.parent}-${h.child}`;
         },
 
-        rmEdgesForNode: function (node: Record<string, unknown>, renderedEdges: Record<string, boolean>, graph: Record<string, unknown>) {
+        rmEdgesForNode: function (node: Record<string, unknown>, renderedEdges: Record<string, boolean>, graph: Graph) {
             VcUtils.iterAllEdges(node, (n, edge, type) => {
                 graph.deleteEdge(edge.vcEdgeId);
 
@@ -407,8 +410,8 @@ editor.once('load', () => {
             });
         },
 
-        initVcGraph: function (container: { dom: HTMLElement }, closeBtn: { dom: HTMLElement }) {
-            VcUtils.branchCount = 0;
+        initVcGraph: function (container: Container, closeBtn: Button) {
+            branchCount = 0;
 
             const h = {
                 dom: container.dom
@@ -418,7 +421,7 @@ editor.once('load', () => {
 
             const schema = VcUtils.makeSchema();
 
-            const graph = new PCUIGraph(schema, h);
+            const graph = new Graph(schema, h);
 
             graph.dom.appendChild(closeBtn.dom);
 
@@ -506,7 +509,7 @@ editor.once('load', () => {
         },
 
         nextBranchCoordX: function () {
-            return VcUtils.branchCount++;
+            return branchCount++;
         },
 
         assignBranchColors: function (data: VcGraphData) {
@@ -637,7 +640,7 @@ editor.once('load', () => {
         },
 
         // Top left coords and width/height of the box rel to screen
-        nodeToScreenCoords: function (node: Record<string, unknown>, graph: Record<string, unknown>) {
+        nodeToScreenCoords: function (node: Record<string, unknown>, graph: Graph) {
             const scale = graph.getGraphScale();
 
             const grPos = graph.getGraphPosition();

--- a/src/editor/vc/graph/vertical-consistency.ts
+++ b/src/editor/vc/graph/vertical-consistency.ts
@@ -2,10 +2,12 @@ editor.once('load', () => {
     // Check and, if necessary, update the assigned coords of each node
     // so that there is proper distance between them vertically
     class VerticalConsistency {
+        allNodes: Record<string, unknown>[];
+
+        xToMaxY: Record<number, number> = {};
+
         constructor(idToNode: Record<string, Record<string, unknown>>) {
             this.allNodes = Object.values(idToNode);
-
-            this.xToMaxY = {};
         }
 
         run() {


### PR DESCRIPTION
## Summary

- Add explicit class field declarations to all 7 classes in `src/editor/vc/graph/`: `SyncHistGraph`, `SplitNodeDescription`, `PlaceVcNodes`, `MakeHistGraph`, `CompactBranches`, `VcGraphLogic`, `VerticalConsistency`
- Initialize simple defaults (`[]`, `{}`, `0`, `false`) at the declaration site, removing redundant assignments from constructors
- Use definite assignment assertions (`!`) for fields set in `init()`/`run()` methods rather than in the constructor
