### PR TITLE
refactor: declare class fields in store classes

### DIFF
--- a/src/editor/store/assetsStore.ts
+++ b/src/editor/store/assetsStore.ts
@@ -6,12 +6,6 @@ import { config } from '@/editor/config';
 import { BaseStore, EMPTY_THUMBNAIL_IMAGE, EMPTY_THUMBNAIL_IMAGE_LARGE, STORE_ITEM_PAGE_SIZE } from './baseStore';
 
 class AssetsStore extends BaseStore {
-    constructor(args?: unknown) {
-        super();
-        this.searchResults = [];
-        this.sortPolicy = 'created';
-    }
-
     get name() {
         return 'playcanvasStore';
     }

--- a/src/editor/store/baseStore.ts
+++ b/src/editor/store/baseStore.ts
@@ -7,14 +7,19 @@ const STORE_ITEM_PAGE_SIZE = 24;
 const EMPTY_THUMBNAIL_IMAGE_LARGE = 'https://playcanvas.com/static-assets/images/store-default-thumbnail.jpg';
 
 class BaseStore {
-    constructor(args?: unknown) {
-        this.searchResults = [];
-        this.items = [];
-        this.startItem = 0;
-        this.selectedSortRadioButton = null;
-        this.sortPolicy = 'created';
-        this.sortCallback = null;
-    }
+    searchResults: any = [];
+
+    items: any[] = [];
+
+    startItem = 0;
+
+    totalCount = 0;
+
+    selectedSortRadioButton: RadioButton | null = null;
+
+    sortPolicy = 'created';
+
+    sortCallback: (() => void) | null = null;
 
     setItems(items: unknown[]) {
         this.items = items;

--- a/src/editor/store/myAssetsStore.ts
+++ b/src/editor/store/myAssetsStore.ts
@@ -5,10 +5,7 @@ import { bytesToHuman } from '@/common/utils';
 import { BaseStore, EMPTY_THUMBNAIL_IMAGE, EMPTY_THUMBNAIL_IMAGE_LARGE, STORE_ITEM_PAGE_SIZE } from './baseStore';
 
 class MyAssetsStore extends BaseStore {
-    constructor(args?: unknown) {
-        super();
-        this.sortPolicy = 'createdAt';
-    }
+    sortPolicy = 'createdAt';
 
     get name() {
         return 'myAssetsStore';

--- a/src/editor/store/sketchFabStore.ts
+++ b/src/editor/store/sketchFabStore.ts
@@ -8,10 +8,7 @@ import { BaseStore, EMPTY_THUMBNAIL_IMAGE_LARGE, STORE_ITEM_PAGE_SIZE } from './
 const md = Markdown({});
 
 class SketchFabStore extends BaseStore {
-    constructor(args?: unknown) {
-        super();
-        this.sortPolicy = 'viewCount';
-    }
+    sortPolicy = 'viewCount';
 
     get name() {
         return 'sketchfabStore';


### PR DESCRIPTION
## Summary

- Declare class fields with types and initializers in `BaseStore`, replacing constructor-only assignments
- Add previously undeclared `totalCount` field to `BaseStore` (was used in subclasses without declaration)
- Remove redundant constructors from `AssetsStore`, `SketchFabStore`, and `MyAssetsStore`, replacing them with class field overrides where needed
