### PR TITLE
fix: make optional config fields reflect DB-level optionality

### DIFF
--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -43,12 +43,12 @@ type ProjectSettings = {
     i18nAssets: number[],
     useLegacyAmmoPhysics: boolean,
     enableSharedArrayBuffer: boolean,
-    plugins: string[],
+    plugins?: string[],
     vr: boolean,
-    useKeyboard: boolean,
-    useMouse: boolean,
-    useTouch: boolean,
-    useGamepads: boolean,
+    useKeyboard?: boolean,
+    useMouse?: boolean,
+    useTouch?: boolean,
+    useGamepads?: boolean,
     maxAssetRetries: number,
     [key: string]: unknown
 };
@@ -107,7 +107,7 @@ type Url = {
     },
     frontend: string,
     engine: string,
-    useCustomEngine: boolean,
+    useCustomEngine?: boolean,
 };
 
 type EngineVersions = {


### PR DESCRIPTION
## Summary
- Makes `plugins`, `useKeyboard`, `useMouse`, `useTouch`, `useGamepads` optional in `ProjectSettings` and `useCustomEngine` optional in `Url`
- These fields are not guaranteed at the DB level — the server and frontend already handle their absence with defaults

## Test plan
- [x] `npm run type:check` passes (no new errors introduced)