### PR TITLE
fix: remove index signature from ProjectSettings config type

### DIFF
--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -50,7 +50,6 @@ type ProjectSettings = {
     useTouch?: boolean,
     useGamepads?: boolean,
     maxAssetRetries: number,
-    [key: string]: unknown
 };
 
 type Project = {


### PR DESCRIPTION
## Summary
- Remove `[key: string]: unknown` from `ProjectSettings` type
- Class instances don't satisfy index signatures, preventing assignability from concrete class implementations

## Test plan
- [x] `npm run type:check` passes