### PR TITLE
fix: add index signature to ModelSchema for dynamic asset data schemas

### DIFF
--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -87,6 +87,7 @@ type ModelSchema = {
     scene: object,
     settings: object,
     asset: object,
+    [key: string]: object,
 };
 
 type Url = {


### PR DESCRIPTION
## Summary
- Adds `[key: string]: object` index signature to `ModelSchema` type
- Allows dynamic asset data schema keys (`materialData`, `textureData`, `animstategraphData`, etc.) to pass type checking
- Companion to playcanvas-monorepo fix that restores full schema injection in `editor-server`

## Test plan
- [ ] Run `npm run type:check` — no new errors
- [ ] Select any asset in the editor — inspector loads without errors