### PR TITLE
fix: resolve TS errors in chat-widget

### DIFF
--- a/src/editor/chat/chat-widget.ts
+++ b/src/editor/chat/chat-widget.ts
@@ -236,7 +236,7 @@ editor.once('load', () => {
     chatPanel.append(messages);
 
     messages.innerElement.addEventListener('contextmenu', (evt: MouseEvent) => {
-        if ((evt.target as HTMLElement).tagName !== 'A') {
+        if (!(evt.target instanceof HTMLElement) || evt.target.tagName !== 'A') {
             return;
         }
 


### PR DESCRIPTION
## Summary

- Fix 3 TS errors where `number` was assigned to `textContent` (expects `string`) by wrapping with `String()`
- Fix 1 TS error where `tagName` was accessed on `EventTarget` by casting to `HTMLElement`
