### PR TITLE
fix: match parent Element.link() signature in AssetInput

### DIFF
--- a/src/common/pcui/element/element-asset-input.ts
+++ b/src/common/pcui/element/element-asset-input.ts
@@ -321,7 +321,7 @@ class AssetInput extends Element {
         return true;
     }
 
-    link(observers: Observer | ObserverList, paths?: string[]) {
+    link(observers: Observer | Observer[], paths: string | string[]) {
         super.link(observers, paths);
         this._thumbnail.link(observers, paths);
     }


### PR DESCRIPTION
## Summary

- Fix `AssetInput.link()` signature to match the parent `Element.link()` from PCUI, resolving 7 TypeScript errors
- Changed `observers` param from `Observer | ObserverList` to `Observer | Observer[]` and `paths` from optional `string[]` to required `string | string[]`

## Details

The override used `ObserverList` instead of `Observer[]`, making `AssetInput` structurally incompatible with `Element`. This caused TS errors at every point where `AssetInput` was used as an `Element` (`.parent` assignments on lines 97/106/113, the `Element.register` call on line 434, and the `link` method itself).
