### PR TITLE
refactor: use PCUI Container and append() in new project picker

### DIFF
--- a/src/editor/pickers/project-management/picker-modal-new-project.ts
+++ b/src/editor/pickers/project-management/picker-modal-new-project.ts
@@ -264,7 +264,7 @@ editor.once('load', () => {
     };
 
     // helper method to toggle AJAX loader in create project button
-    const toggleLoader = (loading) => {
+    const toggleLoader = (loading: boolean) => {
         loader.hidden = !loading;
         createBtn.text = loading ? '' : 'CREATE';
     };


### PR DESCRIPTION
## Summary

- Refactor `picker-modal-new-project.ts` to use PCUI `Container` + `append()` instead of raw `Element` + `dom.appendChild()` for all parent nodes that have children
- Replace `formContent.dom.innerHTML = ''` with `formContent.clear()` for proper PCUI lifecycle cleanup
- Replace imperative `Object.assign(*.style, ...)` flex styling with `Container` constructor args (`flex`, `flexDirection`, `justifyContent`)
- Use PCUI `hidden` property for the loader element instead of manual `style.display` manipulation
- Replace all deprecated `.element` property access with `.dom`
- Remove dead code: unused `starterKitDOMElements` array, write-only `currentUser` variable, trivial `loadUIKits` wrapper function, unnecessary `if (kitsContainer)` truthy guard
- Rename shadowed variables for clarity: `container` param to `kitContainer`/`formContainer`, outer `container` to `modalContainer`, inner `overlay` to `thumbnailOverlay`

Leaf `Element` usages (custom DOM tags like `img`/`h4`, or childless nodes like `playcanvasIcon`/`loader`) are intentionally kept as `Element`.

No CSS changes needed — `Container` renders the same DOM structure, and all existing CSS classes are preserved.

## Test plan

- [x] Open the New Project picker from the dashboard
- [x] Verify starter kit thumbnails render correctly in the grid
- [x] Verify hover effect (orange tint) on starter kits works
- [x] Verify clicking a starter kit selects it (orange border) and updates the sidebar form
- [x] Verify the Name, Description, and Private toggle fields work
- [x] Verify the Owner dropdown appears for users with organizations
- [x] Verify the CREATE button submits and shows the loader spinner
- [x] Verify the close button dismisses the modal
