### PR TITLE
refactor: migrate picker-project from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -2448,319 +2448,298 @@ strong {
     }
 }
 
-.ui-overlay.picker-project {
+.pcui-overlay.picker-project {
     z-index: 300; // larger than drop-area's
-    display: flex;
-    align-items: center;
-    justify-content: center;
 
     &.cmsView { z-index: 100000; }
     &.noAdminView { z-index: 100000; }
 
-    // make labels non-selectable - to make a label
-    // selectable add the 'selectable' class to it
-    .ui-label:not(.selectable),
-    .ui-header {
-        @extend .noSelect;
-    }
+    > .pcui-overlay-content {
+        @extend .font-regular;
 
-    &.center {
-        > .content {
-            @extend .font-regular;
+        width: 100%;
+        max-width: 1060px;
+        height: 100%;
+        border: 1px solid $border-primary;
 
-            top: auto;
-            left: auto;
-            width: 100%;
-            max-width: 1060px;
+        @media (min-width: 1060px) {
+            height: 600px;
+        }
+
+        .pcui-container.project {
             height: 100%;
-            border: 1px solid $border-primary;
+            display: flex;
 
-            @media (min-width: 1060px) {
-                height: 600px;
-            }
+            .pcui-container.left {
+                $c: &;
 
-            .ui-panel.project {
+                background-color: $bcg-dark;
+                margin: 0;
+                padding: 0;
+                flex: 0 0 188px;
+                width: 188px;
                 height: 100%;
+                border-right: 1px solid $border-primary;
+                position: relative;
 
-                > .content {
-                    display: flex;
-                    height: 100%;
+                .image {
+                    width: 187px;
+                    height: 187px;
+                    border-bottom: 1px solid $border-primary;
+                    background-color: $bcg-primary;
+                    background-size: 100%;
 
-                    .ui-panel.left {
-                        background-color: $bcg-dark;
-                        margin: 0;
-                        padding: 0;
-                        flex: 0 0 188px;
-                        width: 188px;
-                        height: 100%;
-                        border-right: 1px solid $border-primary;
+                    &.progress {
+                        background-size: 17%;
+                        background-position: 50%;
+                        background-repeat: no-repeat;
+                        background-color: $bcg-darkest;
+                    }
 
-                        > .content {
-                            $c: &;
-
-                            height: 100%;
-                            position: relative;
-
-                            .image {
-                                width: 187px;
-                                height: 187px;
-                                border-bottom: 1px solid $border-primary;
-                                background-color: $bcg-primary;
-                                background-size: 100%;
-
-                                &.progress {
-                                    background-size: 17%;
-                                    background-position: 50%;
-                                    background-repeat: no-repeat;
-                                    background-color: $bcg-darkest;
-                                }
-
-                                &:hover {
-                                    #{$c} .project-stats {
-                                        background: none !important;
-                                    }
-                                }
-
-                                &.hover:hover {
-                                    cursor: pointer;
-                                }
-                            }
-
-                            .project-stats {
-                                position: absolute;
-                                display: flex;
-                                padding-top: 3px;
-                                justify-content: flex-start;
-                                top: 0;
-                                left: 0;
-                                right: 0;
-                                height: 50px;
-                                font-size: 0.8em;
-                                color: $text-secondary;
-                                background-image: linear-gradient(rgb(0 0 0 / 80%) 15%, transparent);
-                                opacity: 1;
-                                transition: transform 0.4s ease-in-out, opacity 0.2s ease-in, background-image 0.4s ease-in-out;
-
-                                span {
-                                    @extend .font-regular;
-
-                                    &::before {
-                                        @extend .font-icon;
-
-                                        margin-right: 5px;
-                                    }
-                                }
-
-                                .forks-stat::before { content: '\E431'; }
-                                .views-stat::before { content: '\E117'; }
-                                .plays-stat::before { content: '\E180'; }
-
-                                .size-stat {
-                                    position: absolute;
-                                    top: 0;
-                                    right: 0;
-                                    padding-top: 3px;
-                                }
-                            }
-
-                            .thumbnail-buttons {
-                                position: absolute;
-                                top: 150px;
-                                width: 100%;
-                                display: flex;
-                                flex-direction: row;
-                                justify-content: center;
-                                transform: translate(0, 32px);
-                                pointer-events: none;
-                                transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out, z-index 0.25s ease-in-out;
-
-                                & > .thumbnail-replace {
-                                    flex: 9;
-                                    margin-right: 0;
-                                }
-
-                                & > .thumbnail-delete {
-                                    flex: 1;
-                                }
-                            }
-
-                            .project-cms-button {
-                                position: absolute;
-                                bottom: 10px;
-                                margin-left: 0;
-                                margin-right: 0;
-                                padding: 0;
-                                background-color: transparent;
-                                box-shadow: none;
-                                border: none;
-                                width: 100%;
-                            }
-
-                            .cms-editor-button,
-                            .cms-play-button {
-                                @extend .font-regular;
-
-                                position: absolute;
-                                left: 0;
-                                width: calc(100% - 10px);
-                                margin: 5px;
-                                border-radius: initial;
-                                box-shadow: none;
-
-                                &.pcui-disabled { cursor: not-allowed; }
-                            }
-
-                            .cms-editor-button {
-                                bottom: 40px;
-                                background-color: $text-active;
-                                color: $text-primary;
-
-                                &:hover {
-                                    color: $text-active;
-                                    background-color: $text-primary;
-                                }
-                            }
-
-                            .cms-play-button {
-                                bottom: 10px;
-                            }
-
-                            @keyframes slide-down {
-                                0% {
-                                    top: -50px;
-                                    opacity: 0;
-                                }
-
-                                100% {
-                                    top: 0;
-                                    opacity: 1;
-                                }
-                            }
-                        }
-
-                        .info {
-                            padding: 5px 10px;
-                            border-bottom: 1px solid $border-primary;
-
-                            .name {
-                                font-size: 14px;
-                                color: $text-primary;
-                                max-width: 100%;
-                                overflow: hidden;
-                                white-space: nowrap;
-                                text-overflow: ellipsis;
-                            }
-                        }
-
-                        ul {
-                            padding: 0;
-                            margin: 0;
-
-                            li {
-                                margin: 0;
-                                padding: 0 10px;
-                                height: 36px;
-                                line-height: 36px;
-                                border: none;
-                                border-bottom: 1px solid $border-primary;
-                                text-transform: uppercase;
-                                font-size: 12px;
-
-                                @extend .font-bold;
-
-                                &:hover,
-                                &.active {
-                                    color: $text-primary;
-                                    background-color: $bcg-primary;
-                                    cursor: pointer;
-                                    margin: 0;
-
-                                    &::before {
-                                        color: $text-active;
-                                    }
-                                }
-
-                                &::before {
-                                    @extend .font-icon;
-
-                                    font-size: 14px;
-                                    vertical-align: top;
-                                    padding-right: 10px;
-                                }
-
-                                &.project-main::before {
-                                    content: '\E283';
-                                }
-
-                                &.projects::before {
-                                    content: '\E267';
-                                }
-
-                                &.scenes::before {
-                                    content: '\E147';
-                                }
-
-                                &.builds-publish::before {
-                                    content: '\E226';
-                                }
-
-                                &.checkpoints::before {
-                                    content: '\E401';
-                                }
-
-                                &.version-control::before {
-                                    content: '\E399';
-                                }
-
-                                &.team::before {
-                                    content: '\E337';
-                                }
-                            }
+                    &:hover {
+                        #{$c} .project-stats {
+                            background: none !important;
                         }
                     }
 
-                    .ui-panel.right {
-                        flex: 1 1 auto;
-                        height: 100%;
-                        min-width: 0;
+                    &.hover:hover {
+                        cursor: pointer;
+                    }
+                }
 
-                        > .ui-header {
-                            border-bottom: 1px solid $border-primary;
+                .project-stats {
+                    position: absolute;
+                    display: flex;
+                    padding-top: 3px;
+                    justify-content: flex-start;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                    height: 50px;
+                    font-size: 0.8em;
+                    color: $text-secondary;
+                    background-image: linear-gradient(rgb(0 0 0 / 80%) 15%, transparent);
+                    opacity: 1;
+                    transition: transform 0.4s ease-in-out, opacity 0.2s ease-in, background-image 0.4s ease-in-out;
 
-                            .title {
-                                font-size: 12px;
-                                text-transform: uppercase;
-                                padding-left: 5px;
-                            }
+                    span {
+                        @extend .font-regular;
 
-                            .close {
-                                @extend .font-icon;
+                        &::before {
+                            @extend .font-icon;
 
-                                font-size: 14px;
-                                position: absolute;
-                                top: 0;
-                                right: 0;
-                                color: $text-secondary;
-                                background-color: transparent;
-                                border-color: transparent;
+                            margin-right: 5px;
+                        }
+                    }
 
-                                &:hover {
-                                    color: $text-primary;
-                                }
+                    .forks-stat::before { content: '\E431'; }
+                    .views-stat::before { content: '\E117'; }
+                    .plays-stat::before { content: '\E180'; }
+
+                    .size-stat {
+                        position: absolute;
+                        top: 0;
+                        right: 0;
+                        padding-top: 3px;
+                    }
+                }
+
+                .thumbnail-buttons {
+                    position: absolute;
+                    top: 150px;
+                    width: 100%;
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: center;
+                    transform: translate(0, 32px);
+                    pointer-events: none;
+                    transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out, z-index 0.25s ease-in-out;
+
+                    & > .thumbnail-replace {
+                        flex: 9;
+                        margin-right: 0;
+                    }
+
+                    & > .thumbnail-delete {
+                        flex: 1;
+                    }
+                }
+
+                .project-cms-button {
+                    position: absolute;
+                    bottom: 10px;
+                    margin-left: 0;
+                    margin-right: 0;
+                    padding: 0;
+                    background-color: transparent;
+                    box-shadow: none;
+                    border: none;
+                    width: 100%;
+                }
+
+                .cms-editor-button,
+                .cms-play-button {
+                    @extend .font-regular;
+
+                    position: absolute;
+                    left: 0;
+                    width: calc(100% - 10px);
+                    margin: 5px;
+                    border-radius: initial;
+                    box-shadow: none;
+
+                    &.pcui-disabled { cursor: not-allowed; }
+                }
+
+                .cms-editor-button {
+                    bottom: 40px;
+                    background-color: $text-active;
+                    color: $text-primary;
+
+                    &:hover {
+                        color: $text-active;
+                        background-color: $text-primary;
+                    }
+                }
+
+                .cms-play-button {
+                    bottom: 10px;
+                }
+
+                @keyframes slide-down {
+                    0% {
+                        top: -50px;
+                        opacity: 0;
+                    }
+
+                    100% {
+                        top: 0;
+                        opacity: 1;
+                    }
+                }
+
+                .info {
+                    padding: 5px 10px;
+                    border-bottom: 1px solid $border-primary;
+
+                    .name {
+                        font-size: 14px;
+                        color: $text-primary;
+                        max-width: 100%;
+                        overflow: hidden;
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
+                    }
+                }
+
+                ul {
+                    padding: 0;
+                    margin: 0;
+
+                    li {
+                        margin: 0;
+                        padding: 0 10px;
+                        height: 36px;
+                        line-height: 36px;
+                        border: none;
+                        border-bottom: 1px solid $border-primary;
+                        text-transform: uppercase;
+                        font-size: 12px;
+
+                        @extend .font-bold;
+
+                        &:hover,
+                        &.active {
+                            color: $text-primary;
+                            background-color: $bcg-primary;
+                            cursor: pointer;
+                            margin: 0;
+
+                            &::before {
+                                color: $text-active;
                             }
                         }
 
-                        > .content {
-                            height: calc(100% - 33px);
-                            overflow: hidden;
-                            overflow-y: auto;
+                        &::before {
+                            @extend .font-icon;
 
-                            > .ui-panel {
-                                > .content {
-                                    padding: 0;
-                                }
-                            }
+                            font-size: 14px;
+                            vertical-align: top;
+                            padding-right: 10px;
                         }
+
+                        &.project-main::before {
+                            content: '\E283';
+                        }
+
+                        &.projects::before {
+                            content: '\E267';
+                        }
+
+                        &.scenes::before {
+                            content: '\E147';
+                        }
+
+                        &.builds-publish::before {
+                            content: '\E226';
+                        }
+
+                        &.checkpoints::before {
+                            content: '\E401';
+                        }
+
+                        &.version-control::before {
+                            content: '\E399';
+                        }
+
+                        &.team::before {
+                            content: '\E337';
+                        }
+                    }
+                }
+            }
+
+            .pcui-panel.right {
+                flex: 1 1 auto;
+                height: 100%;
+                min-width: 0;
+
+                > .pcui-panel-header {
+                    border-bottom: 1px solid $border-primary;
+
+                    .pcui-panel-header-title {
+                        flex: 1;
+                        text-align: center;
+                        text-transform: uppercase;
+                    }
+
+                    .close {
+                        @extend .font-bold;
+
+                        font-size: 14px;
+                        position: absolute;
+                        top: 0;
+                        right: 0;
+                        color: $text-secondary;
+                        background-color: transparent;
+                        border-color: transparent;
+
+                        &:hover,
+                        &:focus {
+                            color: $text-primary;
+                            background-color: transparent;
+                            box-shadow: none;
+                        }
+                    }
+                }
+
+                > .pcui-panel-content {
+                    height: calc(100% - 33px);
+                    overflow: hidden;
+                    overflow-y: auto;
+
+                    > .pcui-container {
+                        padding: 0;
                     }
                 }
             }
@@ -2768,7 +2747,7 @@ strong {
     }
 }
 
-.ui-overlay.picker-project.reduced-view { z-index: 100000; }
+.pcui-overlay.picker-project.reduced-view { z-index: 100000; }
 
 .pcui-overlay.picker-modal-confirmation {
     z-index: 100001;  // larger than CMS

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -1,10 +1,7 @@
-import { Element, Container, Label, Button } from '@playcanvas/pcui';
+import { Button, Container, Element, Label, Overlay, Panel } from '@playcanvas/pcui';
 
-import { LegacyButton } from '@/common/ui/button';
 import { LegacyList } from '@/common/ui/list';
 import { LegacyListItem } from '@/common/ui/list-item';
-import { LegacyOverlay } from '@/common/ui/overlay';
-import { LegacyPanel } from '@/common/ui/panel';
 import { bytesToHuman } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -28,9 +25,9 @@ editor.once('load', () => {
     let statsContainer;
     const buildProjectStatsUI = () => {
         statsContainer = new Container({
+            id: 'project-stats',
             class: 'project-stats'
         });
-        statsContainer.element.id = 'project-stats';
         leftPanel.append(statsContainer);
 
         if (!noAdminView) {
@@ -65,13 +62,13 @@ editor.once('load', () => {
     };
 
     // helper method to build alert
-    const buildAlert = (root, alert, showButton = false, buttonText = '', funcParameters) => {
-        const alertContainer = new Element({
+    const buildAlert = (root: Container, alert: string, showButton = false, buttonText = '', funcParameters) => {
+        const alertContainer = new Container({
             class: 'alert'
         });
         root.dom.appendChild(alertContainer.dom);
 
-        const alertTextContainer = new Element({
+        const alertTextContainer = new Container({
             class: 'alert-text'
         });
         const alertInfo = new Element({
@@ -80,16 +77,16 @@ editor.once('load', () => {
         const alertText = new Label({
             text: alert
         });
-        alertContainer.dom.appendChild(alertTextContainer.dom);
-        alertTextContainer.dom.appendChild(alertInfo.dom);
-        alertTextContainer.dom.appendChild(alertText.element);
+        alertContainer.append(alertTextContainer);
+        alertTextContainer.append(alertInfo);
+        alertTextContainer.append(alertText);
 
         if (showButton && buttonText.length > 0) {
             const button = new Button({
                 class: 'btn',
                 text: buttonText
             });
-            alertContainer.dom.appendChild(button.element);
+            alertContainer.append(button);
 
             button.on('click', () => {
                 const callback = funcParameters.errorCallback;
@@ -114,7 +111,7 @@ editor.once('load', () => {
         const alertClose = new Button({
             class: 'alert-close'
         });
-        alertContainer.dom.appendChild(alertClose.element);
+        alertContainer.append(alertClose);
 
         alertClose.on('click', () => {
             alertContainer.dom.remove();
@@ -128,12 +125,12 @@ editor.once('load', () => {
         if (currentProject.thumbnails) {
             projectImg.style.backgroundImage = `url("${currentProject.thumbnails.m}")`;
             deleteButton.hidden = false;
-            replaceButton.element.style.marginRight = '0px';
+            replaceButton.dom.style.marginRight = '0px';
         } else {
             projectImg.style.backgroundImage = EMPTY_THUMBNAIL_IMAGE;
             // Disable delete thumbnail button if no thumbnails
             deleteButton.hidden = true;
-            replaceButton.element.style.marginRight = '6px';
+            replaceButton.dom.style.marginRight = '6px';
         }
 
         if (reducedView) {
@@ -244,7 +241,7 @@ editor.once('load', () => {
         }
 
         if (statsContainer) {
-            statsContainer.element.remove();
+            statsContainer.destroy();
         }
         editor.call('picker:project:main:refreshUI');
         editor.call('picker:team:management:refreshUI');
@@ -252,31 +249,43 @@ editor.once('load', () => {
     };
 
     // overlay
-    var overlay = new LegacyOverlay();
-    overlay.class.add('picker-project');
-    overlay.clickable = true;
-    overlay.hidden = true;
+    const overlay = new Overlay({
+        clickable: true,
+        hidden: true,
+        class: 'picker-project'
+    });
+
+    let closeCallback: (() => boolean) | null = null;
+    const originalOnPointerDown = (overlay as any)._onPointerDown;
+    (overlay as any)._onPointerDown = (evt: PointerEvent) => {
+        if (closeCallback && !closeCallback()) {
+            return;
+        }
+        originalOnPointerDown(evt);
+    };
 
     const root = editor.call('layout.root');
     root.append(overlay);
 
     // main panel
-    const panel = new LegacyPanel();
-    panel.class.add('project');
+    const panel = new Container({
+        class: 'project'
+    });
     overlay.append(panel);
 
     // left side panel
-    var leftPanel = new LegacyPanel();
+    const leftPanel = new Container({
+        class: 'left'
+    });
     panel.append(leftPanel);
-    leftPanel.class.add('left');
 
     // project image
-    var projectImg = document.createElement('div');
+    const projectImg = document.createElement('div');
     projectImg.classList.add('image');
     if (!IS_EMPTY_STATE) {
         projectImg.style.backgroundImage = config.project.thumbnails.m ? `url("${config.project.thumbnails.m}")` : EMPTY_THUMBNAIL_IMAGE;
     }
-    leftPanel.append(projectImg);
+    leftPanel.dom.appendChild(projectImg);
 
     let uploadingImage = false;
 
@@ -361,11 +370,11 @@ editor.once('load', () => {
 
         statsContainer.style.backgroundImage = 'linear-gradient(rgba(0, 0, 0, 0.8) 15%, transparent)';
         deleteButton.hidden = false;
-        replaceButton.element.style.marginRight = '0px';
+        replaceButton.dom.style.marginRight = '0px';
     });
 
     // store all panels for each menu option
-    var menuOptions = {};
+    const menuOptions = {};
     let defaultMenuOption = null;
 
     // thumbnail buttons
@@ -396,12 +405,12 @@ editor.once('load', () => {
         deleteThumbnail();
         // Hide delete button and adjust margin
         deleteButton.hidden = true;
-        replaceButton.element.style.marginRight = '6px';
+        replaceButton.dom.style.marginRight = '6px';
     });
 
     // menu
     const list = new LegacyList();
-    leftPanel.append(list);
+    leftPanel.dom.appendChild(list.element);
 
     // project CMS button
     const projectCMSButton = new Button({
@@ -437,7 +446,7 @@ editor.once('load', () => {
     });
     leftPanel.append(editorBtn);
 
-    editorBtn.element.addEventListener('mousedown', (e) => {
+    editorBtn.dom.addEventListener('mousedown', (e) => {
         let target = '_self';
         if (e.which === 2 || e.button === 4 || e.metaKey || e.ctrlKey) {
             target = '_blank';
@@ -467,21 +476,23 @@ editor.once('load', () => {
     });
 
     // right side panel
-    const rightPanel = new LegacyPanel('Project');
+    const rightPanel = new Panel({
+        headerText: 'Project',
+        class: 'right'
+    });
     panel.append(rightPanel);
-    rightPanel.class.add('right');
 
     // close button
-    const btnClose = new LegacyButton({
-        text: '&#57650;'
+    const btnClose = new Button({
+        icon: 'E132',
+        class: 'close'
     });
-    btnClose.class.add('close');
     btnClose.on('click', () => {
         if (currentSelection !== 'version control' || editor.call('vcgraph:isHidden')) {
             overlay.hidden = true;
         }
     });
-    rightPanel.headerElement.appendChild(btnClose.element);
+    rightPanel.header.append(btnClose);
 
     // LOCAL UTILS
 
@@ -520,8 +531,8 @@ editor.once('load', () => {
         // show desired option
         menuOptions[name].item.class.add('active');
         menuOptions[name].panel.hidden = false;
-        rightPanel.headerElementTitle.textContent = menuOptions[name].title;
-        rightPanel.innerElement.scrollTop = 0;
+        rightPanel.headerText = menuOptions[name].title;
+        rightPanel.content.dom.scrollTop = 0;
     };
 
     // ESC key should close popup
@@ -650,9 +661,9 @@ editor.once('load', () => {
         });
 
         if (option === 'version control') {
-            overlay.setCloseCallback(() => editor.call('vcgraph:isHidden'));
+            closeCallback = () => editor.call('vcgraph:isHidden');
         } else {
-            overlay.setCloseCallback(null);
+            closeCallback = null;
         }
 
         select(option || defaultMenuOption);


### PR DESCRIPTION
## Summary

- Replaces `LegacyOverlay`, `LegacyPanel`, and `LegacyButton` with PCUI `Overlay`, `Panel`, `Container`, and `Button` in the project picker
- Updates SCSS selectors from legacy `.ui-*` classes to PCUI `.pcui-*` classes with adjusted nesting to match the new DOM structure
- `LegacyList` and `LegacyListItem` are left as-is for now

### Details

- `LegacyOverlay` → PCUI `Overlay` (with a `closeCallback` override to replicate `setCloseCallback` behavior)
- Headerless `LegacyPanel` (main panel, left panel) → PCUI `Container`
- `LegacyPanel` with header (right panel) → PCUI `Panel` with `headerText`
- `LegacyButton` (close button) → PCUI `Button` with `icon`
- Raw DOM elements and legacy list appended via `dom.appendChild()` since PCUI `Container.append()` only accepts PCUI `Element` instances
- `var` declarations converted to `const`

## Test plan

- [x] Open the project picker and verify all menu options (Scenes, Builds & Publish, Version Control, Team, etc.) display correctly
- [x] Verify the panel title is centered and uppercase
- [x] Verify the close button works and has no border glow on hover
- [x] Verify clicking the overlay background closes the picker (except when on the Version Control tab with the graph open)
- [x] Verify the project thumbnail, stats, and thumbnail upload/delete buttons work
- [x] Verify the left-side menu list items highlight correctly on selection
