### PR TITLE
refactor: migrate create-checkpoint picker from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4891,21 +4891,21 @@ strong {
                         > .content {
                             flex-direction: column;
 
-                            .ui-textarea-field {
-                                width: auto;
+                            .pcui-label {
+                                margin: 3px;
+                                font-size: 12px;
+                            }
+
+                            .pcui-text-area-input {
                                 height: 100px;
                                 background: $bcg-darkest;
                             }
 
-                            .ui-button {
+                            .pcui-button {
                                 width: 140px;
                                 text-transform: uppercase;
-                                text-align: center;
                                 align-self: center;
                                 background: $bcg-primary;
-                                font-size: 12px;
-                                height: 28px;
-                                line-height: 28px;
                             }
                         }
                     }

--- a/src/editor/pickers/version-control/picker-version-control-create-checkpoint.ts
+++ b/src/editor/pickers/version-control/picker-version-control-create-checkpoint.ts
@@ -1,21 +1,18 @@
-import { LegacyButton } from '@/common/ui/button';
-import { LegacyLabel } from '@/common/ui/label';
-import { LegacyTextAreaField } from '@/common/ui/textarea-field';
+import { Button, Label, TextAreaInput } from '@playcanvas/pcui';
 
 editor.once('load', () => {
-    const labelDesc = new LegacyLabel({
+    const labelDesc = new Label({
         text: 'Description:'
     });
-    labelDesc.class.add('small');
 
-    const fieldDescription = new LegacyTextAreaField({
-        blurOnEnter: false
+    const fieldDescription = new TextAreaInput({
+        blurOnEnter: false,
+        keyChange: true,
+        renderChanges: false,
+        flexGrow: 1
     });
-    fieldDescription.renderChanges = false;
-    fieldDescription.keyChange = true;
-    fieldDescription.flexGrow = 1;
 
-    const viewChangesButton = new LegacyButton({
+    const viewChangesButton = new Button({
         text: 'View Changes'
     });
 
@@ -23,14 +20,14 @@ editor.once('load', () => {
         panel.emit('diff');
     });
 
-    const create = function () {
+    const create = () => {
         panel.emit('confirm', {
             description: fieldDescription.value.trim()
         });
     };
 
-    fieldDescription.elementInput.addEventListener('keydown', (e) => {
-        if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
+    fieldDescription.on('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
             if (!panel.buttonConfirm.disabled) {
                 create();
             }


### PR DESCRIPTION
## Summary

- Migrate the create-checkpoint version control picker from legacy UI components (`LegacyLabel`, `LegacyTextAreaField`, `LegacyButton`) to PCUI (`Label`, `TextAreaInput`, `Button`)
- Update SCSS selectors from `.ui-textarea-field` / `.ui-button` to `.pcui-text-area-input` / `.pcui-button` and remove redundant style overrides already handled by PCUI
- Replace deprecated `keyCode` with `key` for the Ctrl/Cmd+Enter keyboard shortcut
