### PR TITLE
fix: prevent overlay from closing when clicking PCUI context menus

### DIFF
--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -261,6 +261,9 @@ editor.once('load', () => {
         if (closeCallback && !closeCallback()) {
             return;
         }
+        if ((evt.target as HTMLElement).closest('.pcui-menu')) {
+            return;
+        }
         originalOnPointerDown(evt);
     };
 


### PR DESCRIPTION
## Summary

- Fixes a regression from #1943 where clicking a PCUI context menu item (e.g. "New Branch", "View Changes") inside the Version Control picker closes the entire project picker overlay.
- The PCUI `Overlay` listens for `pointerdown` on `document.body` and closes when the target is outside its `domContent`. PCUI `Menu` elements are appended to `layout.root` as siblings, so they fall outside `domContent`. This adds a check to skip closing when the click target is inside a `.pcui-menu`.

## Test plan

- [x] Open Version Control in the project picker
- [x] Right-click a checkpoint and click "New Branch" -- the picker should remain open and the create-branch side panel should appear
- [x] Verify all other context menu items ("View Changes", "Restore", "Hard Reset", etc.) work without closing the picker
- [x] Verify clicking the overlay backdrop still correctly closes the picker
