### PR TITLE
fix: prevent picker-project dialog from shrinking below its intended height

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -2460,6 +2460,7 @@ strong {
         width: 100%;
         max-width: 1060px;
         height: 100%;
+        flex-shrink: 0;
         border: 1px solid $border-primary;
 
         @media (min-width: 1060px) {


### PR DESCRIPTION
## Summary

- Fixes a regression from #1943 where the picker-project dialog would shrink/compress when the browser viewport height was less than 600px, causing internal panels to scroll unexpectedly
- Adds `flex-shrink: 0` to `.pcui-overlay-content` so the dialog maintains its intended dimensions

## Root Cause

The PCUI `Overlay` uses `flex-direction: column` (via `pcui-flex`), making height the main axis. The overlay content's `height: 600px` became subject to flex shrinking (`flex-shrink: 1` default), so when the viewport was shorter than 600px the dialog compressed to fit. The old `LegacyOverlay` used the default `flex-direction: row`, where height was the cross axis and was never shrunk.

## Test Plan

- [x] Open the project settings dialog (picker-project)
- [x] Reduce the browser tab/window height below 600px
- [x] Verify the dialog content does not compress or scroll — it should maintain its 600px height
- [x] Open the version control side panel and verify the create branch / close branch / create checkpoint dialogs behave correctly
