### PR TITLE
refactor: migrate close-branch picker from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4961,6 +4961,32 @@ strong {
                                 margin-left: 15px;
                             }
 
+                            .pcui-container {
+                                flex-direction: row;
+                                padding: 10px;
+
+                                .pcui-label {
+                                    margin: 3px;
+                                    font-size: 12px;
+                                    line-height: 22px;
+                                }
+
+                                .pcui-text-input {
+                                    margin: 3px;
+                                    margin-left: 15px;
+                                }
+                            }
+
+                            .pcui-label.close-icon {
+                                @extend .font-icon;
+
+                                font-size: 32px;
+                                line-height: 22px;
+                                overflow: visible;
+                                color: $text-darkest;
+                                margin: 5px auto 25px;
+                            }
+
                             .ui-label.close-icon {
                                 @extend .font-icon;
 

--- a/src/editor/pickers/version-control/picker-version-control-close-branch.ts
+++ b/src/editor/pickers/version-control/picker-version-control-close-branch.ts
@@ -1,6 +1,5 @@
-import { LegacyLabel } from '@/common/ui/label';
-import { LegacyPanel } from '@/common/ui/panel';
-import { LegacyTextField } from '@/common/ui/text-field';
+import { Container, Label, TextInput } from '@playcanvas/pcui';
+
 import { handleCallback } from '@/common/utils';
 
 import { VersionControlSidePanelBox } from './ui/version-control-side-panel-box';
@@ -11,44 +10,41 @@ editor.once('load', () => {
         targetCheckpointHelp: 'Tick to create a checkpoint before closing this branch. If you leave this unticked any changes will be discarded.'
     });
 
-    const labelIcon = new LegacyLabel({
-        text: '&#57686;',
-        unsafe: true
+    const labelIcon = new Label({
+        text: '\uE156',
+        class: 'close-icon'
     });
-    labelIcon.class.add('close-icon');
 
     const boxConfirm = new VersionControlSidePanelBox({
         header: 'ARE YOU SURE?',
         noIcon: true
     });
 
-    const panelTypeName = new LegacyPanel();
-    panelTypeName.flex = true;
-    panelTypeName.style.padding = '10px';
-
-    const label = new LegacyLabel({
-        text: 'Type branch name to confirm:'
+    const panelTypeName = new Container({ flex: true });
+    const label = new Label({
+        text: 'Type branch name to confirm:',
+        class: 'small'
     });
-    label.class.add('small');
     panelTypeName.append(label);
 
-    const fieldName = new LegacyTextField();
-    fieldName.renderChanges = false;
-    fieldName.flexGrow = 1;
-    fieldName.keyChange = true;
+    const fieldName = new TextInput({
+        renderChanges: false,
+        flexGrow: 1,
+        keyChange: true
+    });
     panelTypeName.append(fieldName);
 
-    fieldName.elementInput.addEventListener('keydown', (e) => {
-        if (e.keyCode === 13 && !panel.buttonConfirm.disabled) {
+    fieldName.on('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
             panel.emit('confirm');
         }
     });
 
     boxConfirm.append(panelTypeName);
 
-    let checkpointRequest = null;
+    let checkpointRequest: { abort: () => void } | null = null;
 
-    var panel = editor.call('picker:versioncontrol:createSidePanel', {
+    const panel = editor.call('picker:versioncontrol:createSidePanel', {
         title: 'Close branch?',
         note: 'You will no longer be able to work on this branch unless you re-open it again.',
         mainContents: [boxConfirm.panel, labelIcon, boxBranch.panel],
@@ -90,7 +86,7 @@ editor.once('load', () => {
         }
     });
 
-    panel.setBranch = function (branch: Record<string, unknown>) {
+    panel.setBranch = (branch: Record<string, unknown>) => {
         panel.branch = branch;
         boxBranch.header = branch.name;
 


### PR DESCRIPTION
﻿## Summary

- Replaces `LegacyLabel`, `LegacyPanel`, and `LegacyTextField` with PCUI `Label`, `Container`, and `TextInput` in the close-branch picker
- Updates SCSS to target PCUI class selectors alongside existing legacy selectors for the shared close-branch / hard-reset-checkpoint scope
- Converts `var` to `const`, `function` expression to arrow function, `keyCode` to `key`, and adds proper typing for `checkpointRequest`

## Test plan

- [x] Open the Close Branch dialog in the version control panel
- [x] Verify the ARE YOU SURE box, close icon, and branch box render correctly
- [x] Verify the Type branch name to confirm label and text input appear side by side
- [x] Type the branch name and confirm the Close Branch button enables
- [x] Press Enter to confirm closing a branch
- [x] Verify the hard-reset-checkpoint dialog (shares same SCSS scope) still renders correctly
