### PR TITLE
refactor: migrate hard-reset-checkpoint picker from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4956,11 +4956,6 @@ strong {
                         > .content {
                             flex-direction: column;
 
-                            .ui-text-field {
-                                width: auto;
-                                margin-left: 15px;
-                            }
-
                             .pcui-container {
                                 flex-direction: row;
                                 padding: 10px;
@@ -4987,13 +4982,6 @@ strong {
                                 margin: 5px auto 25px;
                             }
 
-                            .ui-label.close-icon {
-                                @extend .font-icon;
-
-                                font-size: 32px;
-                                color: $text-darkest;
-                                margin: 5px auto 25px;
-                            }
                         }
                     }
                 }

--- a/src/editor/pickers/version-control/picker-version-control-hard-reset-checkpoint.ts
+++ b/src/editor/pickers/version-control/picker-version-control-hard-reset-checkpoint.ts
@@ -1,6 +1,4 @@
-import { LegacyLabel } from '@/common/ui/label';
-import { LegacyPanel } from '@/common/ui/panel';
-import { LegacyTextField } from '@/common/ui/text-field';
+import { Container, Label, TextInput } from '@playcanvas/pcui';
 
 import { VersionControlSidePanelBox } from './ui/version-control-side-panel-box';
 
@@ -14,20 +12,18 @@ editor.once('load', () => {
         noIcon: true
     });
 
-    const panelWriteConfirm = new LegacyPanel();
-    panelWriteConfirm.flex = true;
-    panelWriteConfirm.style.padding = '10px';
-
-    const label = new LegacyLabel({
-        text: 'Type "hard reset" to confirm'
+    const panelWriteConfirm = new Container({ flex: true });
+    const label = new Label({
+        text: 'Type "hard reset" to confirm',
+        class: 'small'
     });
-    label.class.add('small');
     panelWriteConfirm.append(label);
 
-    const textField = new LegacyTextField();
-    textField.renderChanges = false;
-    textField.flexGrow = 1;
-    textField.keyChange = true;
+    const textField = new TextInput({
+        renderChanges: false,
+        flexGrow: 1,
+        keyChange: true
+    });
     panelWriteConfirm.append(textField);
 
     boxConfirm.append(panelWriteConfirm);
@@ -48,8 +44,8 @@ editor.once('load', () => {
     panel.buttonConfirm.disabled = true;
     panel.class.add('hard-reset-checkpoint');
 
-    textField.elementInput.addEventListener('keydown', (e) => {
-        if (e.keyCode === 13 && !panel.buttonConfirm.disabled) {
+    textField.on('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
             panel.emit('confirm');
         }
     });
@@ -58,11 +54,11 @@ editor.once('load', () => {
         return panel;
     });
 
-    panel.setCheckpoint = function (checkpoint: Record<string, unknown>) {
+    panel.setCheckpoint = (checkpoint: Record<string, unknown>) => {
         textField.value = '';
         panel.checkpoint = checkpoint;
         boxRestore.setCheckpoint(checkpoint);
-        panel.labelTitle.text = `Hard reset to checkpoint "${checkpoint.id.substring(0, 7)}" ?`;
+        panel.labelTitle.text = `Hard reset to checkpoint "${(checkpoint.id as string).substring(0, 7)}" ?`;
     };
 
     textField.on('change', () => {


### PR DESCRIPTION
﻿## Summary

- Replaces `LegacyLabel`, `LegacyPanel`, and `LegacyTextField` with PCUI `Label`, `Container`, and `TextInput` in the hard-reset-checkpoint picker
- Removes now-unused legacy SCSS selectors (`.ui-text-field`, `.ui-label.close-icon`) from the shared close-branch / hard-reset-checkpoint scope
- Converts `var` to `const`, `function` expression to arrow function, `keyCode` to `key`, and adds proper typing

## Test plan

- [x] Open the Hard Reset Checkpoint dialog in the version control panel
- [x] Verify the RESETTING TO and ARE YOU SURE boxes render correctly
- [x] Verify the Type hard reset to confirm label and text input appear side by side
- [x] Type hard reset and confirm the Hard Reset To Checkpoint button enables
- [x] Press Enter to confirm hard resetting
- [x] Verify the close-branch dialog still renders correctly (shares same SCSS scope)
