### PR TITLE
refactor: migrate delete-branch picker from legacy UI to PCUI

### DIFF
--- a/src/editor/pickers/version-control/picker-version-control-delete-branch.ts
+++ b/src/editor/pickers/version-control/picker-version-control-delete-branch.ts
@@ -1,6 +1,5 @@
-import { LegacyLabel } from '@/common/ui/label';
-import { LegacyPanel } from '@/common/ui/panel';
-import { LegacyTextField } from '@/common/ui/text-field';
+import { Container, Label, TextInput } from '@playcanvas/pcui';
+
 import { handleCallback } from '@/common/utils';
 
 import { VersionControlSidePanelBox } from './ui/version-control-side-panel-box';
@@ -8,44 +7,41 @@ import { VersionControlSidePanelBox } from './ui/version-control-side-panel-box'
 editor.once('load', () => {
     const boxBranch = new VersionControlSidePanelBox();
 
-    const labelIcon = new LegacyLabel({
-        text: '&#57686;',
-        unsafe: true
+    const labelIcon = new Label({
+        text: '\uE156',
+        class: 'close-icon'
     });
-    labelIcon.class.add('close-icon');
 
     const boxConfirm = new VersionControlSidePanelBox({
         header: 'ARE YOU SURE?',
         noIcon: true
     });
 
-    const panelTypeName = new LegacyPanel();
-    panelTypeName.flex = true;
-    panelTypeName.style.padding = '10px';
-
-    const label = new LegacyLabel({
-        text: 'Type branch name to confirm:'
+    const panelTypeName = new Container({ flex: true });
+    const label = new Label({
+        text: 'Type branch name to confirm:',
+        class: 'small'
     });
-    label.class.add('small');
     panelTypeName.append(label);
 
-    const fieldName = new LegacyTextField();
-    fieldName.renderChanges = false;
-    fieldName.flexGrow = 1;
-    fieldName.keyChange = true;
+    const fieldName = new TextInput({
+        renderChanges: false,
+        flexGrow: 1,
+        keyChange: true
+    });
     panelTypeName.append(fieldName);
 
-    fieldName.elementInput.addEventListener('keydown', (e) => {
-        if (e.keyCode === 13 && !panel.buttonConfirm.disabled) {
+    fieldName.on('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
             panel.emit('confirm');
         }
     });
 
     boxConfirm.append(panelTypeName);
 
-    let checkpointRequest = null;
+    let checkpointRequest: { abort: () => void } | null = null;
 
-    var panel = editor.call('picker:versioncontrol:createSidePanel', {
+    const panel = editor.call('picker:versioncontrol:createSidePanel', {
         title: 'Delete branch?',
         note: 'This action will delete all checkpoints and changes in this branch and cannot be undone!',
         mainContents: [boxConfirm.panel, labelIcon, boxBranch.panel],
@@ -83,7 +79,7 @@ editor.once('load', () => {
         }
     });
 
-    panel.setBranch = function (branch: Record<string, unknown>) {
+    panel.setBranch = (branch: Record<string, unknown>) => {
         panel.branch = branch;
         boxBranch.header = branch.name;
 


### PR DESCRIPTION
﻿## Summary

- Replaces `LegacyLabel`, `LegacyPanel`, and `LegacyTextField` with PCUI `Label`, `Container`, and `TextInput` in the delete-branch picker
- No SCSS changes needed as this dialog reuses the `close-branch` CSS class whose PCUI selectors were added in PR #1951
- Converts `var` to `const`, `function` expression to arrow function, `keyCode` to `key`, and adds proper typing

## Test plan

- [x] Open the Delete Branch dialog in the version control panel
- [x] Verify the ARE YOU SURE box, close icon, and branch box render correctly
- [x] Verify the Type branch name to confirm label and text input appear side by side
- [x] Type the branch name and confirm the Delete Branch button enables
- [x] Press Enter to confirm deleting a branch
