### PR TITLE
refactor: migrate merge-branches picker from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4991,20 +4991,12 @@ strong {
                         > .content {
                             flex-direction: column;
 
-                            .ui-label.left {
-                                font-size: 12px;
-                                width: 120px;
-                            }
-
-                            .ui-label.right {
-                                font-size: 12px;
-                                font-family: inconsolatamedium;
-                            }
-
-                            > .ui-label.arrow {
+                            > .pcui-label.arrow {
                                 @extend .font-icon;
 
                                 font-size: 32px;
+                                line-height: 22px;
+                                overflow: visible;
                                 color: $text-darkest;
                                 margin: -19px auto 10px;
                             }

--- a/src/editor/pickers/version-control/picker-version-control-merge-branches.ts
+++ b/src/editor/pickers/version-control/picker-version-control-merge-branches.ts
@@ -1,4 +1,5 @@
-import { LegacyLabel } from '@/common/ui/label';
+import { Label } from '@playcanvas/pcui';
+
 import { handleCallback } from '@/common/utils';
 
 import { VersionControlSidePanelBox } from './ui/version-control-side-panel-box';
@@ -12,11 +13,10 @@ editor.once('load', () => {
         closeSourceBranchHelp: 'Tick to close the source branch after merging.'
     });
 
-    const labelArrow = new LegacyLabel({
-        text: '&#57704;',
-        unsafe: true
+    const labelArrow = new Label({
+        text: '\uE168',
+        class: 'arrow'
     });
-    labelArrow.class.add('arrow');
 
     const boxInto = new VersionControlSidePanelBox({
         headerNote: 'Merge to',
@@ -24,8 +24,7 @@ editor.once('load', () => {
         targetCheckpointHelp: 'Tick to create a checkpoint in the target branch before merging. If you leave this unticked any changes in the target branch will be discarded.'
     });
 
-    // holds pending requests to get checkpoints
-    const checkpointRequests = [];
+    const checkpointRequests: { abort: () => void }[] = [];
 
     const panel = editor.call('picker:versioncontrol:createSidePanel', {
         title: 'Merge branches',
@@ -63,14 +62,13 @@ editor.once('load', () => {
         boxFrom.clear();
         boxInto.clear();
 
-        // abort all pending requests
         checkpointRequests.forEach((request) => {
             request.abort();
         });
         checkpointRequests.length = 0;
     });
 
-    const setBranchInfo = function (branch: Record<string, unknown> | null, isSourceBranch: boolean) {
+    const setBranchInfo = (branch: Record<string, unknown> | null, isSourceBranch: boolean) => {
         const panelField = isSourceBranch ? 'sourceBranch' : 'destinationBranch';
         panel[panelField] = branch;
 
@@ -82,29 +80,25 @@ editor.once('load', () => {
         box.header = branch.name;
 
         if (isSourceBranch && box.panelSourceClose) {
-            // do not show close branch if branch is permanent (like master)
             box.panelSourceClose.hidden = branch.permanent;
         }
 
-        // get checkpoint from server
-        var request = handleCallback(editor.api.globals.rest.checkpoints.checkpointGet({
+        const request = handleCallback(editor.api.globals.rest.checkpoints.checkpointGet({
             checkpointId: branch.latestCheckpointId
         }), (err, checkpoint) => {
-            // remove request from pending array
             const idx = checkpointRequests.indexOf(request);
             checkpointRequests.splice(idx, 1);
 
             box.setCheckpoint(checkpoint);
         });
 
-        // add the request to the pending array
         checkpointRequests.push(request);
     };
 
-    panel.setSourceBranch = function (sourceBranch: Record<string, unknown> | null) {
+    panel.setSourceBranch = (sourceBranch: Record<string, unknown> | null) => {
         setBranchInfo(sourceBranch, true);
     };
-    panel.setDestinationBranch = function (destinationBranch: Record<string, unknown> | null) {
+    panel.setDestinationBranch = (destinationBranch: Record<string, unknown> | null) => {
         setBranchInfo(destinationBranch, false);
     };
 


### PR DESCRIPTION
﻿## Summary

- Replaces `LegacyLabel` with PCUI `Label` for the arrow icon in the merge-branches picker
- Updates SCSS to add `.pcui-label.arrow` selector alongside existing legacy `.ui-label.arrow`
- Converts `var` to `const`, `function` expressions to arrow functions, and adds proper typing for `checkpointRequests` array

## Test plan

- [x] Open the Merge Branches dialog in the version control panel
- [x] Verify the Merge from and Merge to boxes render correctly with their branch info
- [x] Verify the arrow icon between the boxes displays correctly
- [x] Verify the source/target checkpoint and close source branch checkboxes work
- [x] Confirm the START MERGE button triggers the merge
