### PR TITLE
refactor: clean up diff-checkpoints picker after PCUI migration

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -5514,12 +5514,8 @@ strong {
                     width: 90px;
                     right: 15px;
                     margin: 0;
-                    font-size: 12px;
-                    line-height: 32px;
                     height: 32px;
-                    text-align: center;
                     background: $bcg-primary;
-                    border: 1px solid $border-primary;
 
                     &.compare {
                         top: 10px;
@@ -5528,14 +5524,6 @@ strong {
                     &.switch {
                         top: initial;
                         bottom: 10px;
-
-                        &::before {
-                            content: '\E128';
-
-                            @extend .font-icon;
-
-                            margin-right: 5px;
-                        }
                     }
                 }
             }

--- a/src/editor/pickers/version-control/picker-version-control-diff-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff-checkpoints.ts
@@ -130,6 +130,7 @@ editor.once('load', () => {
     // swap button
     const btnSwitch = new Button({
         text: 'SWAP',
+        icon: 'E128',
         class: 'switch',
         enabled: false
     });


### PR DESCRIPTION
## Summary

Follow-up cleanup to the diff-checkpoints PCUI migration (#1958):

- **Type safety**: Replace `Record<string, unknown>` with proper PCUI types (`Container`, `Panel`, `Label`) for `setCheckpointContent` parameters
- **Naming**: Rename `panelLeft`/`panelRight` to `containerLeft`/`containerRight` to reflect their actual type
- **Styling**: Move checkpoint header height override from inline TypeScript to SCSS (`!important`), center icon+title in headers, use flexbox for empty state label, adjust button positioning
- **API usage**: Use `icon` property instead of `text` for close buttons, `header.append()` instead of raw DOM, `enabled` instead of deprecated `disabled`
- **Cleanup**: Remove redundant `@extend .font-icon` from close button styles

## Test plan

- [x] Open version control picker, verify DIFF checkpoints panel renders correctly
- [x] Select two checkpoints, verify COMPARE and SWAP buttons enable
- [x] Clear selections, verify buttons disable
- [x] Verify close buttons (main header, left/right checkpoint) work
- [x] Verify empty state "Select a checkpoint" label is vertically centered
