### PR TITLE
fix: prevent merge branches sidepanel children from shrinking

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4777,6 +4777,10 @@ strong {
                         box-sizing: border-box;
                         overflow-y: auto;
                         background: $bcg-dark;
+
+                        > * {
+                            flex-shrink: 0;
+                        }
                     }
 
                     &.buttons {


### PR DESCRIPTION
## Summary

- Fixes a layout regression in the Merge Branches sidepanel where the "Merge To" panel would shrink when the "Merge From" panel expanded (e.g. via "read more")
- Adds `flex-shrink: 0` to direct children of the `.main` content container so they maintain their size and the container scrolls instead

## Test plan

- [x] Open version control picker
- [x] Open the Merge Branches sidepanel
- [x] Click "read more" on the Merge From panel
- [x] Verify the Merge To panel does not shrink and the content area scrolls
