### PR TITLE
chore: bump playcanvas to 2.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.17.0",
+        "playcanvas": "2.17.1",
         "postcss": "8.5.6",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8510,9 +8510,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.17.0.tgz",
-      "integrity": "sha512-v6Vh0vL8yFxVHSl1FzqcSOIy7tJOB7HCIacndSPDbJLpozAvFBkA/yzWWnvxGVeHV19eMZYeyqkgG0ta/tJYoQ==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.17.1.tgz",
+      "integrity": "sha512-OTBUtfYS7JeCdAkhiWgSjyMXqE2VeZDpsLxIJvMvIZ7eFrB9usDxsqCiCPuEzBRibtW7gr/w58aIhzGgHkB2EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.17.0",
+    "playcanvas": "2.17.1",
     "postcss": "8.5.6",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
## Summary
- Bumps `playcanvas` engine dependency from `2.17.0` to `2.17.1`

## Test plan
- [x] Verify `npm install` resolves correctly
- [x] Verify editor builds successfully (`npm run build`)
- [x] Smoke test editor functionality in browser