### PR TITLE
✨ Quality: Fix entity copy to include script asset dependencies

### DIFF
--- a/src/editor/entities/entities-copy.ts
+++ b/src/editor/entities/entities-copy.ts
@@ -8,7 +8,23 @@ editor.once('load', () => {
      */
     editor.method('entities:copy', (entities: EntityObserver[]) => {
         try {
-            editor.api.globals.entities.copyToClipboard(entities.map(e => e.apiEntity));
+            // Collect script asset dependencies from entities
+            const scriptAssetIds = new Set<string>();
+            for (const entity of entities) {
+                const scriptComponent = entity.apiEntity.script;
+                if (scriptComponent && scriptComponent.scripts) {
+                    for (const script of Object.values(scriptComponent.scripts)) {
+                        if (script && script.asset) {
+                            scriptAssetIds.add(script.asset);
+                        }
+                    }
+                }
+            }
+
+            editor.api.globals.entities.copyToClipboard(
+                entities.map(e => e.apiEntity),
+                { assets: Array.from(scriptAssetIds) }
+            );
         } catch (err) {
             if (err.name === 'QuotaExceededError') {
                 editor.call('status:error', 'Cannot copy: Selection is too large');


### PR DESCRIPTION
## ✨ Code Quality

### Problem
When copying an entity with scripts, the copy operation needs to also include all script assets referenced by the entity's script components. This ensures that when pasting to another project, the script assets exist before the entity is created.

**Severity**: `high`
**File**: `src/editor/entities/entities-copy.ts`

### Solution
Modify the copy logic to:

### Changes
- `src/editor/entities/entities-copy.ts` (modified)

Fixes #

### What's Changed
- TODO

### Checks
- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1702