### PR TITLE
[TEST] Mock OneTrust consent script in test middleware

### DIFF
--- a/test-suite/lib/middleware.ts
+++ b/test-suite/lib/middleware.ts
@@ -21,4 +21,13 @@ export const middleware = async (context: BrowserContext) => {
             }
         });
     });
+
+    // mock consent cookie to prevent cookie popups interfering with tests
+    await context.route(/onetrust\/consent\.js$/, (route) => {
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: 'console.log(\'OneTrust consent mocked for testing\');'
+        });
+    });
 };


### PR DESCRIPTION
### What's Changed
- Add route handler to mock `onetrust/consent.js` in Playwright test middleware, preventing cookie consent popups from interfering with tests

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)