### PR TITLE
fix: viewport type safety and canvas.element -> canvas.dom

### DIFF
--- a/src/editor/viewport/camera/camera-preview.ts
+++ b/src/editor/viewport/camera/camera-preview.ts
@@ -1,5 +1,7 @@
 import { Button } from '@playcanvas/pcui';
-import { type Application, type Entity, FOG_NONE, type FogType, Vec4 } from 'playcanvas';
+import { type Application, type Entity, FOG_NONE, Vec4 } from 'playcanvas';
+
+import type { EntityObserver } from '@/editor-api';
 
 editor.once('load', () => {
 
@@ -12,7 +14,7 @@ editor.once('load', () => {
     let postRenderEvent = null;
     let events = [];
     const rect = new Vec4(0, 0.8, 0.2, 0.2);
-    let app = null;
+    let app: Application | null = null;
     let previewCamera = null;
 
     const viewport = editor.call('layout.viewport');
@@ -27,9 +29,9 @@ editor.once('load', () => {
         class: 'lock',
         icon: 'E340'
     });
-    cameraPreviewBorder.appendChild(btnPin.element);
+    cameraPreviewBorder.appendChild(btnPin.dom);
 
-    const updateCameraState = function () {
+    const updateCameraState = () => {
         if (pinnedCamera) {
             if (currentCamera && currentCamera === pinnedCamera.entity) {
                 renderCamera = false;
@@ -65,7 +67,7 @@ editor.once('load', () => {
                 preRenderEvent = app.scene.on('prerender', (camera) => {
                     // the preview camera uses the scene fog settings
                     if (previewCamera === camera) {
-                        app.scene.fog.type = (editor.call('sceneSettings')?.get('render.fog') ?? FOG_NONE) as FogType;
+                        app.scene.fog.type = (editor.call('sceneSettings')?.get('render.fog') ?? FOG_NONE) as string;
                     }
                 });
 
@@ -76,7 +78,7 @@ editor.once('load', () => {
                 });
 
                 if (lastCamera && lastCamera !== camera) {
-                    if (lastCamera && lastCamera.entity && lastCamera.data && lastCamera.entity !== currentCamera) {
+                    if (lastCamera.entity && lastCamera.data && lastCamera.entity !== currentCamera) {
                         lastCamera.enabled = false;
                     }
                     lastCamera = null;
@@ -97,7 +99,7 @@ editor.once('load', () => {
 
             if (lastCamera) {
                 // ### DISABLE CAMERA ###
-                if (lastCamera && lastCamera.entity && lastCamera.data && lastCamera.entity !== currentCamera) {
+                if (lastCamera.entity && lastCamera.data && lastCamera.entity !== currentCamera) {
                     lastCamera.enabled = false;
                 }
                 lastCamera = null;
@@ -106,7 +108,7 @@ editor.once('load', () => {
     };
 
     let frameRequest = null;
-    const deferUpdate = function () {
+    const deferUpdate = () => {
         if (frameRequest) {
             cancelAnimationFrame(frameRequest);
         }
@@ -137,7 +139,7 @@ editor.once('load', () => {
         }
 
         editor.call('camera:set', obj.entity);
-    }, false);
+    });
 
     editor.once('viewport:load', (application: Application) => {
         app = application;
@@ -170,7 +172,7 @@ editor.once('load', () => {
         updateCameraState();
     });
 
-    editor.on('selector:change', (type: string, items: import('@/editor-api').EntityObserver[]) => {
+    editor.on('selector:change', (type: string, items: EntityObserver[]) => {
         if (events.length) {
             for (let i = 0; i < events.length; i++) {
                 events[i].unbind();

--- a/src/editor/viewport/camera/camera-preview.ts
+++ b/src/editor/viewport/camera/camera-preview.ts
@@ -172,7 +172,7 @@ editor.once('load', () => {
         updateCameraState();
     });
 
-    editor.on('selector:change', (type: string, items: EntityObserver[]) => {
+    editor.on('selector:change', (type: string | null, items: EntityObserver[]) => {
         if (events.length) {
             for (let i = 0; i < events.length; i++) {
                 events[i].unbind();

--- a/src/editor/viewport/viewport-application.ts
+++ b/src/editor/viewport/viewport-application.ts
@@ -8,7 +8,7 @@ class ViewportApplication extends Application {
 
     redraw = false;
 
-    constructor(canvas: HTMLCanvasElement, options: { editorSettings?: Record<string, unknown> }) {
+    constructor(canvas: HTMLCanvasElement, options: ConstructorParameters<typeof Application>[1] & { editorSettings?: Record<string, unknown> }) {
         super(canvas, options);
 
         this._inTools = true;
@@ -44,7 +44,7 @@ class ViewportApplication extends Application {
                     cameraEntity.camera.toneMapping = this.editorSettings.cameraToneMapping;
                     cameraEntity.camera.gammaCorrection = this.editorSettings.cameraGammaCorrection;
                 }
-                showFog = this.editorSettings.showFog;
+                showFog = this.editorSettings.showFog as boolean;
             }
 
             this.scene.fog.type = showFog ? (editor.call('sceneSettings')?.get('render.fog') ?? FOG_NONE) : FOG_NONE;

--- a/src/editor/viewport/viewport-rect-select.ts
+++ b/src/editor/viewport/viewport-rect-select.ts
@@ -1,5 +1,7 @@
+import type { Canvas } from '@playcanvas/pcui';
+
 editor.once('load', () => {
-    const canvas = editor.call('viewport:canvas');
+    const canvas = editor.call('viewport:canvas') as Canvas | null;
     if (!canvas) {
         return;
     }
@@ -14,7 +16,7 @@ editor.once('load', () => {
         display: none;
         z-index: 100;
     `;
-    canvas.element.parentElement.appendChild(rectOverlay);
+    canvas.dom.parentElement.appendChild(rectOverlay);
 
     const updateRect = (x1: number, y1: number, x2: number, y2: number) => {
         const minX = Math.min(x1, x2);

--- a/src/editor/viewport/viewport-tap.ts
+++ b/src/editor/viewport/viewport-tap.ts
@@ -1,3 +1,5 @@
+import type { Canvas } from '@playcanvas/pcui';
+
 /** Tap/pointer state passed to viewport:tap:* and viewport:mouse:move handlers */
 export interface ViewportTap {
     x: number;
@@ -10,7 +12,7 @@ export interface ViewportTap {
 }
 
 editor.once('load', () => {
-    const canvas = editor.call('viewport:canvas');
+    const canvas = editor.call('viewport:canvas') as Canvas | null;
     if (!canvas) {
         return;
     }
@@ -79,7 +81,7 @@ editor.once('load', () => {
     });
 
     const evtMouseMove = function (evt: MouseEvent) {
-        const rect = canvas.element.getBoundingClientRect();
+        const rect = canvas.dom.getBoundingClientRect();
         for (let i = 0; i < taps.length; i++) {
             if (!taps[i].mouse) {
                 continue;
@@ -129,7 +131,7 @@ editor.once('load', () => {
             }
 
             items[i].down = false;
-            items[i].update(evt, canvas.element.getBoundingClientRect());
+            items[i].update(evt, canvas.dom.getBoundingClientRect());
             editor.emit('viewport:tap:end', items[i], evt);
 
             if (!items[i].move) {
@@ -142,7 +144,7 @@ editor.once('load', () => {
             }
         }
 
-        const rect = canvas.element.getBoundingClientRect();
+        const rect = canvas.dom.getBoundingClientRect();
 
         editor.emit('viewport:mouse:move', {
             x: evt.clientX - rect.left,
@@ -151,11 +153,11 @@ editor.once('load', () => {
         });
     };
 
-    canvas.element.addEventListener('mousedown', (evt) => {
+    canvas.dom.addEventListener('mousedown', (evt) => {
         if (gizmoCapture(evt)) {
             return;
         }
-        const rect = canvas.element.getBoundingClientRect();
+        const rect = canvas.dom.getBoundingClientRect();
 
         editor.emit('viewport:mouse:move', {
             x: evt.clientX - rect.left,
@@ -169,20 +171,20 @@ editor.once('load', () => {
         editor.emit('viewport:tap:start', tap, evt);
 
         if (document.activeElement && document.activeElement.tagName.toLowerCase() === 'input') {
-            document.activeElement.blur();
+            (document.activeElement as HTMLElement).blur();
         }
 
         evt.preventDefault();
     }, false);
 
-    canvas.element.addEventListener('mouseover', () => {
+    canvas.dom.addEventListener('mouseover', () => {
         editor.emit('viewport:hover', true);
         editor.call('viewport:render');
     }, false);
 
-    canvas.element.addEventListener('mouseleave', (evt) => {
+    canvas.dom.addEventListener('mouseleave', (evt) => {
         // ignore tooltip
-        const target = evt.toElement || evt.relatedTarget;
+        const target = evt.relatedTarget as Element | null;
         if (target && target.classList.contains('cursor-tooltip')) {
             return;
         }

--- a/src/editor/viewport/viewport.ts
+++ b/src/editor/viewport/viewport.ts
@@ -20,11 +20,12 @@ editor.once('load', () => {
     const disableAntiAliasing = /disableAntiAliasing=true/.test(location.search);
 
     // create playcanvas application
-    let app;
+    let app: ViewportApplication;
     try {
-        app = new ViewportApplication(canvas.element, {
-            mouse: new Mouse(canvas.element),
-            touch: 'ontouchstart' in window ? new TouchDevice(canvas.element) : null,
+        const canvasElement = canvas.dom as HTMLCanvasElement;
+        app = new ViewportApplication(canvasElement, {
+            mouse: new Mouse(canvasElement),
+            touch: 'ontouchstart' in window ? new TouchDevice(canvasElement) : null,
             editorSettings: projectUserSettings.json().editor,
             graphicsDeviceOptions: {
                 antialias: !disableAntiAliasing,


### PR DESCRIPTION
## Summary

- Fix type errors in viewport files by properly typing the canvas returned from `viewport:canvas` as `Canvas | null`
- Replace deprecated `canvas.element` with `canvas.dom` in `viewport-tap.ts` and `viewport-rect-select.ts`
- Type `ViewportApplication` constructor options to extend the base `Application` options
- Cast `editorSettings.showFog` to `boolean` to resolve type mismatch
- Clean up camera-preview types: import `EntityObserver`, widen `selector:change` type param to `string | null`, remove redundant truthiness checks

## Test plan

- [x] Verify viewport renders correctly
- [x] Verify camera preview panel works (pin/unpin, click to switch)
- [x] Verify rectangle selection overlay appears and tracks the cursor
- [x] Verify tap/click interactions in the viewport work as before
