### PR TITLE
fix: cast evt.target to Element in hotkey handler

### DIFF
--- a/src/editor/hotkey/hotkey.ts
+++ b/src/editor/hotkey/hotkey.ts
@@ -79,9 +79,10 @@ editor.once('load', () => {
     // Handle keydown events
     function handleKeydown(evt: KeyboardEvent) {
         // Ignore if target is input/textarea without hotkeys class
-        if (evt.target &&
-            /^(?:input|textarea)$/i.test(evt.target.tagName) &&
-            !evt.target.classList.contains('hotkeys')) {
+        const target = evt.target as Element | null;
+        if (target &&
+            /^(?:input|textarea)$/i.test(target.tagName) &&
+            !target.classList.contains('hotkeys')) {
             return;
         }
 

--- a/src/editor/hotkey/hotkey.ts
+++ b/src/editor/hotkey/hotkey.ts
@@ -79,7 +79,7 @@ editor.once('load', () => {
     // Handle keydown events
     function handleKeydown(evt: KeyboardEvent) {
         // Ignore if target is input/textarea without hotkeys class
-        const target = evt.target as Element | null;
+        const target = evt.target instanceof Element ? evt.target : null;
         if (target &&
             /^(?:input|textarea)$/i.test(target.tagName) &&
             !target.classList.contains('hotkeys')) {


### PR DESCRIPTION
## Summary

- Cast `evt.target` from `EventTarget | null` to `Element | null` in the hotkey keydown handler, fixing type errors when accessing `tagName` and `classList`

## Test plan

- [x] Verify hotkeys still work in the viewport (e.g. W/E/R for translate/rotate/scale)
- [x] Verify hotkeys are correctly ignored when typing in input/textarea fields
- [x] Verify hotkeys work in input fields with the `hotkeys` class
