### PR TITLE
feat: migrate sentry to client-managed bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@rollup/plugin-commonjs": "28.0.9",
         "@rollup/plugin-node-resolve": "15.3.1",
         "@rollup/plugin-swc": "0.4.0",
+        "@sentry/browser": "^10.48.0",
         "@swc/core": "1.15.18",
         "@types/sharedb": "3.3.13",
         "@typescript-eslint/eslint-plugin": "8.57.0",
@@ -2038,6 +2039,87 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry-internal/feedback": "10.48.0",
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry-internal/replay-canvas": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rollup/plugin-commonjs": "28.0.9",
     "@rollup/plugin-node-resolve": "15.3.1",
     "@rollup/plugin-swc": "0.4.0",
+    "@sentry/browser": "^10.48.0",
     "@swc/core": "1.15.18",
     "@types/sharedb": "3.3.13",
     "@typescript-eslint/eslint-plugin": "8.57.0",

--- a/src/code-editor/editor.ts
+++ b/src/code-editor/editor.ts
@@ -1,7 +1,9 @@
 import { type EditorMethods, Editor } from '@/common/editor';
 import { Messenger } from '@/common/messenger';
+import { setSentryTags } from '@/common/sentry';
 import * as api from '@/editor-api';
 
+import { config } from './config';
 
 class CodeEditor extends Editor<EditorMethods> {
     isCodeEditor = true;
@@ -38,6 +40,11 @@ class CodeEditor extends Editor<EditorMethods> {
 }
 
 window.editor = new CodeEditor();
+
+setSentryTags({
+    project_id: config.project?.id,
+    branch_id: config.self?.branch?.id
+});
 
 // set window name if necessary
 if (!window.name) {

--- a/src/code-editor/index.ts
+++ b/src/code-editor/index.ts
@@ -1,3 +1,6 @@
+// sentry
+import '@/common/sentry';
+
 // extensions
 import '@/common/extensions';
 

--- a/src/common/sentry.ts
+++ b/src/common/sentry.ts
@@ -1,0 +1,134 @@
+import { BrowserClient, defaultStackParser, makeFetchTransport, Scope } from '@sentry/browser';
+
+const SENTRY_DSN = 'https://0defef72baf64d99bf53b92a23d5bd14@sentry.sc-prod.net/87';
+
+const SANITIZE_KEYS = /password|token|secret|passwd|authorization|api_key|apikey|sentry_dsn|access_token|stripetoken|mysql_pwd|credentials/i;
+
+type SentryConfig = {
+    enabled: true;
+    env: string;
+    version: string;
+    send: boolean;
+    service: string;
+    page: string;
+    disable_breadcrumbs: boolean;
+} | {
+    enabled: false;
+};
+
+let scope: Scope | null = null;
+
+const sanitize = (obj: unknown, memo = new WeakSet()): unknown => {
+    if (Array.isArray(obj)) {
+        if (memo.has(obj)) {
+            return obj;
+        }
+        memo.add(obj);
+        const result = obj.map(v => sanitize(v, memo));
+        memo.delete(obj);
+        return result;
+    }
+    if (obj && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype) {
+        if (memo.has(obj)) {
+            return obj;
+        }
+        memo.add(obj);
+        const record = obj as Record<string, unknown>;
+        const result: Record<string, unknown> = {};
+        for (const key of Object.keys(record)) {
+            result[key] = SANITIZE_KEYS.test(key) ? '********' : sanitize(record[key], memo);
+        }
+        memo.delete(obj);
+        return result;
+    }
+    return obj;
+};
+
+// self-initialize from window.config.sentry (injected by backend)
+const sentryConfig = config.sentry as SentryConfig;
+
+// ensure window.log exists
+if (!window.log) {
+    (window as any).log = {};
+}
+
+if (sentryConfig.enabled) {
+    const client = new BrowserClient({
+        dsn: sentryConfig.send ? SENTRY_DSN : '',
+        transport: makeFetchTransport,
+        stackParser: defaultStackParser,
+        environment: sentryConfig.env,
+        release: sentryConfig.version,
+        integrations: [],
+        beforeSend: (event) => {
+            // filter errors from user code (asset scripts)
+            const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+            if (frames?.length) {
+                const last = frames[frames.length - 1];
+                if (last.filename && last.filename.includes('/api/assets/')) {
+                    return null;
+                }
+            }
+
+            // report error count to graphene metrics
+            if (window.metrics) {
+                metrics.increment({ metricsName: `${sentryConfig.service}.frontend_errors.count.by_page.${sentryConfig.page}` });
+            }
+
+            return sanitize(event) as typeof event;
+        }
+    });
+
+    scope = new Scope();
+    scope.setClient(client);
+    scope.setTag('page', sentryConfig.page);
+    client.init();
+
+    // capture errors via sentry
+    window.log.error = (...args: any[]) => {
+        console.error(...args);
+
+        if (args.length === 1 && args[0]?.stack) {
+            captureException(args[0]);
+        } else {
+            captureMessage(args.map(String).join(' '));
+        }
+    };
+} else {
+    window.log.error = (...args: any[]) => console.error(...args);
+}
+
+const captureException = (error: Error, source?: string) => {
+    if (!scope) {
+        return;
+    }
+    const s = source ? scope.clone() : scope;
+    if (source) {
+        s.setTag('source', source);
+    }
+    s.captureException(error);
+};
+
+const captureMessage = (message: string, level: 'warning' | 'error' = 'error', source?: string) => {
+    if (!scope) {
+        return;
+    }
+    const s = source ? scope.clone() : scope;
+    if (source) {
+        s.setTag('source', source);
+    }
+    s.captureMessage(message, level);
+};
+
+const setSentryTags = (tags: Record<string, string | number | undefined>) => {
+    if (!scope) {
+        return;
+    }
+    for (const [key, value] of Object.entries(tags)) {
+        if (value !== undefined) {
+            scope.setTag(key, String(value));
+        }
+    }
+};
+
+export { captureException, captureMessage, setSentryTags };

--- a/src/editor/blank.ts
+++ b/src/editor/blank.ts
@@ -1,3 +1,6 @@
+// sentry
+import '@/common/sentry';
+
 // playcanvas engine (exposes window.pc for plugins)
 import './expose';
 

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -1,8 +1,10 @@
 import { type EditorMethods, Editor } from '@/common/editor';
 import { Messenger } from '@/common/messenger';
+import { setSentryTags } from '@/common/sentry';
 import { MERGE_STATUS_APPLY_STARTED, MERGE_STATUS_AUTO_STARTED, MERGE_STATUS_READY_FOR_REVIEW } from '@/core/constants';
-import { config } from '@/editor/config';
 import * as api from '@/editor-api';
+
+import { config } from './config';
 
 class MainEditor extends Editor<EditorMethods> {
     constructor() {
@@ -125,3 +127,9 @@ class MainEditor extends Editor<EditorMethods> {
 
 // editor
 window.editor = new MainEditor();
+
+setSentryTags({
+    project_id: config.project?.id,
+    scene_id: config.scene?.id,
+    branch_id: config.self?.branch?.id
+});

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -1,3 +1,6 @@
+// sentry
+import '@/common/sentry';
+
 // playcanvas engine (exposes window.pc for plugins)
 import './expose';
 

--- a/src/launch/editor.ts
+++ b/src/launch/editor.ts
@@ -1,6 +1,9 @@
 import { type EditorMethods, Editor } from '@/common/editor';
 import { Messenger } from '@/common/messenger';
+import { setSentryTags } from '@/common/sentry';
 import * as api from '@/editor-api';
+
+import { config } from './config';
 
 class LaunchEditor extends Editor<EditorMethods> {
     constructor() {
@@ -18,3 +21,9 @@ class LaunchEditor extends Editor<EditorMethods> {
 
 // editor
 window.editor = new LaunchEditor();
+
+setSentryTags({
+    project_id: config.project?.id,
+    scene_id: config.scene?.id,
+    branch_id: config.self?.branch?.id
+});

--- a/src/launch/index.ts
+++ b/src/launch/index.ts
@@ -1,3 +1,6 @@
+// sentry
+import '@/common/sentry';
+
 // extensions
 import '@/common/extensions';
 


### PR DESCRIPTION
### What's Changed
- Moves Sentry initialization from server-injected platform scripts to a bundled TypeScript module at `src/common/sentry.ts`
- Uses `BrowserClient` + `Scope` (isolated client, no global `Sentry.init()`)
- Each entry point imports the module as a side-effect (`import '@/common/sentry'`)
- Editor constructors set project/scene/branch tags via `setSentryTags`
- `beforeSend` matches existing monorepo behavior: filters user-code errors from `/api/assets/`, reports to graphene metrics, sanitizes sensitive keys

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)