### PR TITLE
fix: ensure store item picker registers picker:open on first open

### DIFF
--- a/src/editor/pickers/store/picker-storeitem.ts
+++ b/src/editor/pickers/store/picker-storeitem.ts
@@ -433,7 +433,8 @@ editor.once('load', () => {
 
         // main panel
         const panel = new Container({
-            class: 'storeitem-root-panel'
+            class: 'storeitem-root-panel',
+            hidden: true
         });
 
         root.append(panel);
@@ -584,6 +585,7 @@ editor.once('load', () => {
         if (!storeItemPanel) {
             storeItemPanel = createPanel();
             storePanel.append(storeItemPanel);
+            storeItemPanel.hidden = false;
             licenses = await editor.call('picker:store:licenses');
         } else {
             storeItemPanel.hidden = false;


### PR DESCRIPTION
## Summary

- Fixes "picker:close fired for already closed picker storeitem" console warning when clicking the back arrow in the Store item picker
- The store item panel was created with `hidden=false` (the PCUI default), so the first open never triggered a `hidden` transition — the `show` event never fired and `picker:open` was never registered in the picker tracking system
- Creates the panel with `hidden: true` and explicitly sets `hidden = false` after appending, ensuring the `show` event fires and `picker:open` is properly paired with `picker:close`
