### PR TITLE
fix: guard store grid image load callback against destroyed container

### DIFF
--- a/src/editor/pickers/store/picker-store.ts
+++ b/src/editor/pickers/store/picker-store.ts
@@ -239,6 +239,10 @@ editor.once('load', () => {
         thumb.src = item.pictures[0];
 
         thumb.addEventListener('load', () => {
+            if (gridItem.destroyed) {
+                return;
+            }
+
             gridItem.on('click', () => {
                 // editor.call('picker:store:cms:close');
                 sortingDropdown.hidden = true;


### PR DESCRIPTION
## Summary

- Fixes a race condition in the asset store grid where rapidly switching between store tabs (PlayCanvas, Sketchfab, My Assets) causes a `TypeError: Cannot read properties of null (reading 'appendChild')`.
- `itemsContainer.clear()` destroys grid item containers while thumbnail images are still loading. When the `load` callback fires on a destroyed container, `Container.append()` crashes because the backing DOM has been nulled. A `gridItem.destroyed` guard prevents the stale callback from executing.
