### PR TITLE
[FIX] Restore Sentry browser metadata

### DIFF
--- a/src/common/sentry.ts
+++ b/src/common/sentry.ts
@@ -1,9 +1,11 @@
-import { BrowserClient, defaultStackParser, makeFetchTransport, Scope } from '@sentry/browser';
+import { BrowserClient, defaultStackParser, getDefaultIntegrations, makeFetchTransport, Scope } from '@sentry/browser';
+import { getIntegrationsToSetup } from '@sentry/core';
 
 import type { FingerprintedError } from './error';
 import packageJson from '../../package.json';
 
 const SENTRY_DSN = 'https://0defef72baf64d99bf53b92a23d5bd14@sentry.sc-prod.net/87';
+const BREADCRUMBS_INTEGRATION = 'Breadcrumbs';
 
 const SANITIZE_KEYS = /password|token|secret|passwd|authorization|api_key|apikey|sentry_dsn|access_token|stripetoken|mysql_pwd|credentials/i;
 
@@ -20,6 +22,11 @@ type SentryConfig = {
 };
 
 let scope: Scope | null = null;
+
+const getSentryIntegrations = (disableBreadcrumbs: boolean) => getIntegrationsToSetup({
+    defaultIntegrations: getDefaultIntegrations({}).filter(i => !disableBreadcrumbs || i.name !== BREADCRUMBS_INTEGRATION),
+    integrations: []
+});
 
 const sanitize = (obj: unknown, memo = new WeakSet()): unknown => {
     if (Array.isArray(obj)) {
@@ -62,7 +69,9 @@ if (sentryConfig.enabled) {
         stackParser: defaultStackParser,
         environment: sentryConfig.env,
         release: packageJson.version,
-        integrations: [],
+        attachStacktrace: true,
+        sendDefaultPii: true,
+        integrations: getSentryIntegrations(sentryConfig.disable_breadcrumbs),
         beforeSend: (event, hint) => {
             // filter errors from user code (asset scripts)
             const frames = event.exception?.values?.[0]?.stacktrace?.frames;


### PR DESCRIPTION
### What's Changed
- restore Sentry's default browser integrations so browser, os, and request metadata are attached again
- keep `disable_breadcrumbs` support while enabling richer event context with stack traces and default PII collection

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- [x] `npx eslint src/common/sentry.ts`
- [x] `npm run type:check` (fails due to unrelated existing repo TypeScript errors)