### PR TITLE
[FIX] Sanitize empty scene_id before sending to Sentry

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -131,6 +131,6 @@ window.editor = new MainEditor();
 setSentryTags({
     user_id: config.self?.id,
     project_id: config.project?.id,
-    scene_id: config.scene?.id,
+    scene_id: config.scene?.id || -1,
     branch_id: config.self?.branch?.id
 });

--- a/src/launch/editor.ts
+++ b/src/launch/editor.ts
@@ -25,6 +25,6 @@ window.editor = new LaunchEditor();
 setSentryTags({
     user_id: config.self?.id,
     project_id: config.project?.id,
-    scene_id: config.scene?.id,
+    scene_id: config.scene?.id || -1,
     branch_id: config.self?.branch?.id
 });


### PR DESCRIPTION
### What's Changed
- Fallback `scene_id` to `-1` in Sentry tags when `config.scene.id` is an empty string, null, or undefined
- Applied to both `setSentryTags` call sites that include `scene_id` (`src/editor/editor.ts` and `src/launch/editor.ts`)

### Context
When no scene is found, the backend sets `config.scene.id` to `''`. This empty string was flowing into Sentry tags unsanitized, producing misleading error reports (e.g. `NS_ERROR_FAILURE` events with invalid `scene_id` values).

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)