### PR TITLE
fix: add missing space in rename error log message

### DIFF
--- a/src/editor/assets/assets-rename.ts
+++ b/src/editor/assets/assets-rename.ts
@@ -2,7 +2,7 @@ editor.once('load', () => {
     const changeName = function (assetId: string | number, assetName: string) {
         editor.api.globals.rest.assets.assetUpdate(assetId, { name: assetName })
         .on('error', (err, data) => {
-            log.error`rename error: ${err}${data}`;
+            log.error`rename error: ${err} ${data}`;
             editor.call('status:error', `Couldn't update the name: ${data}`);
         });
     };


### PR DESCRIPTION
## Summary

- Adds a missing space between the HTTP status code and error message in the asset rename error log, so it reads `"rename error: 404 Asset not found"` instead of `"rename error: 404Asset not found"`

## Test plan

- Trigger a rename error (e.g. rename a deleted asset) and verify the logged message has proper spacing
