### PR TITLE
[FIX] Buffer realtime ops arriving before asset registration

### DIFF
--- a/src/editor/assets/assets-sync.ts
+++ b/src/editor/assets/assets-sync.ts
@@ -19,6 +19,8 @@ editor.once('load', () => {
     const IDLE_CHECK_DELAY = 2000;
     const IDLE_CHECK_SAFE_WINDOW = 10000;
 
+    const pendingOps = new Map();
+
     let lastIdleCheck = Date.now();
     let wasIdle = false;
     let timeoutLoad = null;
@@ -175,6 +177,15 @@ editor.once('load', () => {
             editor.call('realtime:assets:op', op, asset.get('uniqueId'));
         });
 
+        // replay buffered ops that arrived before this asset was registered
+        const uniqueId = asset.get('uniqueId');
+        const ops = pendingOps.get(uniqueId);
+        if (ops) {
+            pendingOps.delete(uniqueId);
+            for (const op of ops) {
+                asset.sync.write(op);
+            }
+        }
     });
 
     // write asset operations
@@ -195,11 +206,15 @@ editor.once('load', () => {
     editor.on('realtime:op:assets', (op, uniqueId) => {
         const asset = editor.call('assets:getUnique', uniqueId);
         if (asset) {
-            // console.log('in: ' + id + ' [ ' + Object.keys(op).filter(function(i) { return i !== 'p' }).join(', ') + ' ]', op.p.join('.'));
-            // console.log(op);
             asset.sync.write(op);
         } else {
-            log.error`realtime operation on missing asset: ${op.p[1]}`;
+            // buffer ops for assets not yet registered (race between subscribe and add)
+            let ops = pendingOps.get(uniqueId);
+            if (!ops) {
+                ops = [];
+                pendingOps.set(uniqueId, ops);
+            }
+            ops.push(op);
         }
     });
 
@@ -223,5 +238,6 @@ editor.once('load', () => {
         }
 
         editor.call('assets:clear');
+        pendingOps.clear();
     });
 });

--- a/src/launch/assets/assets-sync.ts
+++ b/src/launch/assets/assets-sync.ts
@@ -14,6 +14,7 @@ editor.once('load', () => {
     const docs: Record<string, { unsubscribe: () => void; destroy: () => void }> = { };
 
     const assetNames: Record<string, string> = { };
+    const pendingOps = new Map();
 
     const queryParams = (new pc.URI(window.location.href)).getQuery() as Record<string, string>;
     const concatenateScripts = (queryParams.concatenateScripts === 'true');
@@ -389,6 +390,7 @@ editor.once('load', () => {
 
     // load all assets
     editor.on('realtime:authenticated', () => {
+        pendingOps.clear();
         editor.api.globals.rest.projects.projectAssets('launcher', true)
         .on('load', (_status: number, data: Array<{ id: string; uniqueId: string; name?: string }>) => {
             onLoad(data);
@@ -423,6 +425,16 @@ editor.once('load', () => {
             item: asset
         });
 
+        // replay buffered ops that arrived before this asset was registered
+        const uniqueId = asset.get('uniqueId');
+        const ops = pendingOps.get(uniqueId);
+        if (ops) {
+            pendingOps.delete(uniqueId);
+            for (const op of ops) {
+                asset.sync.write(op);
+            }
+        }
+
         let setting = false;
 
         asset.on('*:set', (path: string, value: unknown) => {
@@ -453,7 +465,13 @@ editor.once('load', () => {
         if (asset) {
             asset.sync.write(op);
         } else {
-            log.error`realtime operation on missing asset: ${op.p[1]}`;
+            // buffer ops for assets not yet registered (race between subscribe and add)
+            let ops = pendingOps.get(uniqueId);
+            if (!ops) {
+                ops = [];
+                pendingOps.set(uniqueId, ops);
+            }
+            ops.push(op);
         }
     });
 });


### PR DESCRIPTION
[PLAY-CANVAS-G2XR](https://sentry.sc-corp.net/organizations/sentry/issues/145616778/) — 135 events in `release:2.20.*`

### What's Changed
- During bulk asset loading (`loadAllAndSubscribe`), ShareDB ops can arrive for assets that haven't been added to the editor registry yet. The `realtime:op:assets` handler calls `assets:getUnique` which returns null, silently dropping the op and leaving local editor state stale for collaborative sessions.
- Buffer incoming ops for unregistered assets in a `Map`, replay them once the asset is added and its `ObserverSync` is initialized, and clear the buffer on disconnect/reconnect.
- Applied to both editor (`src/editor/assets/assets-sync.ts`) and launch (`src/launch/assets/assets-sync.ts`) variants.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)