### PR TITLE
[FIX] Guard userdata submitOp when document does not exist

### DIFF
--- a/src/editor/userdata/userdata-realtime.ts
+++ b/src/editor/userdata/userdata-realtime.ts
@@ -18,22 +18,25 @@ editor.once('load', () => {
             editor.emit('realtime:userdata:error', err);
         });
 
+        // register op listener once (outside load to avoid duplicates on re-fetch)
+        data.on('op', (ops, local) => {
+            if (local) {
+                return;
+            }
+
+            for (let i = 0; i < ops.length; i++) {
+                if (ops[i].p[0]) {
+                    editor.emit(`realtime:userdata:${userId}:op:${ops[i].p[0]}`, ops[i]);
+                }
+            }
+        });
+
         // ready to sync
         data.on('load', () => {
-            // notify of operations
-            data.on('op', (ops, local) => {
-                if (local) {
-                    return;
-                }
+            if (!data.type) {
+                return;
+            }
 
-                for (let i = 0; i < ops.length; i++) {
-                    if (ops[i].p[0]) {
-                        editor.emit(`realtime:userdata:${userId}:op:${ops[i].p[0]}`, ops[i]);
-                    }
-                }
-            });
-
-            // notify of scene load
             editor.emit(`userdata:${userId}:raw`, data.data);
         });
 
@@ -49,13 +52,9 @@ editor.once('load', () => {
 
     // write userdata operations
     editor.method('realtime:userdata:op', (op: unknown) => {
-        if (!editor.call('permissions:read') || !userData) {
+        if (!editor.call('permissions:read') || !userData || !userData.type) {
             return;
         }
-
-        // console.trace();
-        // console.log('out: [ ' + Object.keys(op).filter(function(i) { return i !== 'p' }).join(', ') + ' ]', op.p.join('.'));
-        // console.log(op)
 
         userData.submitOp([op]);
     });


### PR DESCRIPTION
[PLAY-CANVAS-G2X7](https://sentry.sc-corp.net/organizations/sentry/issues/145609708/) — 102 events in `release:2.20.*`

### What's Changed
- When the `user_data` ShareDB document fails to be created during subscribe, the `load` event fires with a null type. Previously, `userdata.ts` would still create an `ObserverSync` and start forwarding ops, causing every camera movement to produce a `ShareDBError: Cannot submit op. Document has not been created` — resulting in bursts of 20-30 errors per affected user.
- Guard the `load` handler to skip emitting `userdata:raw` when `!data.type` (document missing), preventing the sync from starting on a broken document.
- Guard `submitOp` with `!userData.type` as a belt-and-suspenders check for transient null-type states.
- Move the `op` listener registration outside the `load` handler to prevent duplicate listeners if `load` fires more than once (e.g., after a ShareDB rollback + re-fetch).

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)