### PR TITLE
[FIX] Suppress transient websocket errors from Sentry

### DIFF
--- a/src/code-editor/realtime/realtime.ts
+++ b/src/code-editor/realtime/realtime.ts
@@ -154,7 +154,7 @@ editor.once('load', () => {
         socket.onclose = onClose;
         socket.onmessage = onMessage;
         socket.onerror = () => {
-            log.error`code-editor websocket error (url: ${config.url.realtime.http})`;
+            console.warn(`code-editor websocket error (url: ${config.url.realtime.http})`);
         };
     };
 

--- a/src/editor-api/realtime/connection.ts
+++ b/src/editor-api/realtime/connection.ts
@@ -163,6 +163,7 @@ class RealtimeConnection extends Events {
         this._state = 'connecting';
 
         if (this._reconnectAttempts > MAX_ATTEMPTS) {
+            log.error`websocket failed to connect after ${MAX_ATTEMPTS} attempts (url: ${url})`;
             this._realtime.emit('cannotConnect');
             return;
         }
@@ -193,7 +194,7 @@ class RealtimeConnection extends Events {
         socket.addEventListener('message', onmessage);
 
         socket.addEventListener('error', () => {
-            log.error`websocket error (state: ${this._state}, url: ${url}, attempts: ${this._reconnectAttempts})`;
+            console.warn(`websocket error (state: ${this._state}, url: ${url}, attempts: ${this._reconnectAttempts})`);
         });
 
         // ! use event listener as sharedb overrides socket.on* handlers

--- a/src/launch/realtime/realtime.ts
+++ b/src/launch/realtime/realtime.ts
@@ -16,6 +16,7 @@ editor.once('load', () => {
 
     connect = function () {
         if (reconnectAttempts > 8) {
+            log.error`launch websocket failed to connect after 8 attempts (url: ${config.url.realtime.http})`;
             editor.emit('realtime:cannotConnect');
             return;
         }
@@ -83,7 +84,7 @@ editor.once('load', () => {
         // create new socket...
         socket = new WebSocket(config.url.realtime.http);
         socket.onerror = () => {
-            log.error`launch websocket error (url: ${config.url.realtime.http})`;
+            console.warn(`launch websocket error (url: ${config.url.realtime.http})`);
         };
         // ... and new sharedb connection
         connection = new share.Connection(socket);


### PR DESCRIPTION
### What's Changed
- Downgrade per-attempt WebSocket `onerror` logging from `log.error` (Sentry) to `console.warn` (local only) across editor, launch, and code-editor realtime connections
- Add `log.error` at the `cannotConnect` point in editor and launch so persistent failures (all retries exhausted) still reach Sentry
- Eliminates ~50 noisy Sentry events/day from transient connection hiccups that self-recover on retry (PLAY-CANVAS-G3CP)

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)