### PR TITLE
[Fix] Reduce Sentry noise in browser_live environment

### DIFF
--- a/src/editor-api/realtime/asset.ts
+++ b/src/editor-api/realtime/asset.ts
@@ -131,7 +131,7 @@ class RealtimeAsset extends Events {
     }
 
     _onOp(ops: any, local: boolean) {
-        if (local) {
+        if (local || !this._loaded) {
             return;
         }
 

--- a/src/editor/alerts/alert-connection.ts
+++ b/src/editor/alerts/alert-connection.ts
@@ -120,7 +120,7 @@ editor.once('load', () => {
 
     editor.on('viewport:error', (err) => {
         viewportError = true;
-        log.error(err);
+        console.error(err);
         console.trace();
         content.innerHTML = 'Failed creating WebGL Context.<br />Please check <a href="http://webglreport.com/" target="_blank">WebGL Report</a> and report to <a href="http://forum.playcanvas.com/" target="_blank">Forum</a>.';
         overlay.hidden = false;

--- a/src/editor/assets/assets-rename.ts
+++ b/src/editor/assets/assets-rename.ts
@@ -2,7 +2,7 @@ editor.once('load', () => {
     const changeName = function (assetId: string | number, assetName: string) {
         editor.api.globals.rest.assets.assetUpdate(assetId, { name: assetName })
         .on('error', (err, data) => {
-            log.error`rename error: ${err} ${data}`;
+            console.warn(`rename error: ${err} ${data}`);
             editor.call('status:error', `Couldn't update the name: ${data}`);
         });
     };

--- a/src/editor/entities/entities-treeview.ts
+++ b/src/editor/entities/entities-treeview.ts
@@ -810,7 +810,7 @@ class EntitiesTreeView extends TreeView {
                 if (child) {
                     treeViewItem.append(this._onAddEntity(child));
                 } else {
-                    log.error`cannot find child entity ${childId} of parent ${entity.get('name')} (${resourceId})`;
+                    console.warn(`cannot find child entity ${childId} of parent ${entity.get('name')} (${resourceId})`);
                     editor.call('status:error', `Cannot find child entity ${childId} of parent "${entity.get('name')}" (${resourceId})`);
                 }
             }

--- a/src/editor/relay/relay-server.ts
+++ b/src/editor/relay/relay-server.ts
@@ -281,7 +281,7 @@ class RelayServer extends Events {
      * @param msg - The message data
      */
     send(msg: string | object) {
-        if (!this._connected) {
+        if (!this._connected || this.socket.readyState !== WebSocket.OPEN) {
             return;
         }
 

--- a/src/editor/relay/relay-server.ts
+++ b/src/editor/relay/relay-server.ts
@@ -40,6 +40,8 @@ class RelayServer extends Events {
 
     private _rooms: Record<string, Set<number>>;
 
+    private _pendingRooms: Set<string>;
+
     private _userId: number | null;
 
     private socket: WebSocket;
@@ -54,6 +56,7 @@ class RelayServer extends Events {
         this._pingTimeout = null;
         this._pongTimeout = null;
         this._rooms = {};
+        this._pendingRooms = new Set();
         this._userId = null;
 
         this.on('welcome', (data) => {
@@ -150,6 +153,7 @@ class RelayServer extends Events {
             });
         }
         this._rooms = {};
+        this._pendingRooms.clear();
 
         this.emit('disconnect');
 
@@ -194,6 +198,8 @@ class RelayServer extends Events {
     }
 
     _handleRoomJoin(msg: { t: string; name: string; users?: number[]; userId?: number }) {
+        this._pendingRooms.delete(msg.name);
+
         if (msg.users) {
             this._rooms[msg.name] = new Set(msg.users);
         } else if (msg.userId) {
@@ -319,6 +325,11 @@ class RelayServer extends Events {
      * @param authentication - The authentication handling of the room.
      */
     joinRoom(name: string, authentication: RoomAuthentication) {
+        if (this._rooms[name] || this._pendingRooms.has(name)) {
+            return;
+        }
+
+        this._pendingRooms.add(name);
         this.send({
             t: 'room:join',
             name: name,


### PR DESCRIPTION
### What's Changed

Six low-hanging-fruit fixes for the top unresolved Sentry issues in the `browser_live` environment (~114 events/14d eliminated):

- **PLAY-CANVAS-G3CQ** (49 events): Guard `RealtimeAsset._onOp` when document is unloaded — prevents stale ops from emitting after `unload()` 
- **PLAY-CANVAS-G3DB** (15 events): Downgrade missing child entity `log.error` → `console.warn` — non-fatal race during scene load, user already sees status bar error
- **PLAY-CANVAS-G3AW** (10 events): Downgrade asset rename error `log.error` → `console.warn` — server 400 "invalid characters" already shown to user via status bar
- **PLAY-CANVAS-G3DQ** (6 events): Add `socket.readyState === WebSocket.OPEN` check in relay `send()` — prevents `InvalidStateError` when socket is in CLOSING state
- **PLAY-CANVAS-G3D8** (30 events): Downgrade viewport WebGL error `log.error` → `console.error` — environmental limitation, not a code bug; overlay still shown to user
- **PLAY-CANVAS-G3FT** (4 events): Track pending room joins via `_pendingRooms` Set in relay server — prevents duplicate `joinRoom()` requests from racing event listeners

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)