### PR TITLE
[Fix] Code-editor null guards for Sentry tier 2 errors

### DIFF
--- a/src/code-editor/documents/documents-load.ts
+++ b/src/code-editor/documents/documents-load.ts
@@ -107,7 +107,7 @@ editor.once('load', () => {
                     if (importingAssetPath) {
                         // Return the immediate dependencies of the asset
                         const deps = editor.call('utils:deps-from-string', content, importingAssetPath);
-                        const depsAsAsset = Array.from(deps).map(path => editor.call('assets:getByVirtualPath', path));
+                        const depsAsAsset = Array.from(deps).map(path => editor.call('assets:getByVirtualPath', path)).filter(Boolean);
 
                         // And load them, ensuring that Monaco can resolve dependencies
                         depsAsAsset.forEach(asset => loadDocument(asset, false));

--- a/src/code-editor/documents/documents-load.ts
+++ b/src/code-editor/documents/documents-load.ts
@@ -75,6 +75,10 @@ editor.once('load', () => {
 
         // ready to sync
         doc.on('load', () => {
+            if (!doc.type) {
+                return;
+            }
+
             // check if closed by the user
             if (!documentsIndex[id]) {
                 return;

--- a/src/code-editor/files-panel/files-panel.ts
+++ b/src/code-editor/files-panel/files-panel.ts
@@ -376,7 +376,7 @@ editor.once('load', () => {
     // Select file by id (which can be passed as a string or number)
     editor.method('files:select', (id: number|string) => {
         const item = idToItem.get(String(id));
-        if (item) {
+        if (item && !item.destroyed) {
             tree.deselect();
             item.selected = true;
         }

--- a/src/code-editor/monaco/document.ts
+++ b/src/code-editor/monaco/document.ts
@@ -124,12 +124,12 @@ editor.once('load', () => {
         }
 
         const assetPath = asset.get('path');
-        const pathAssets = assetPath.map(id => editor.call('assets:get', id));
-        if (pathAssets.some(a => !a)) {
-            // Parent folder(s) have been deleted, skip loading
-            return;
+        const pathSegments = [];
+        for (const id of assetPath) {
+            const a = editor.call('assets:get', id);
+            if (!a) return;
+            pathSegments.push(a.get('name'));
         }
-        const pathSegments = pathAssets.map(a => a.get('name'));
         const path = [...pathSegments, asset.get('file').filename].join('/');
 
         const uri = monaco.Uri.parse(`${path}`);

--- a/src/code-editor/monaco/document.ts
+++ b/src/code-editor/monaco/document.ts
@@ -127,7 +127,9 @@ editor.once('load', () => {
         const pathSegments = [];
         for (const id of assetPath) {
             const a = editor.call('assets:get', id);
-            if (!a) return;
+            if (!a) {
+                return;
+            }
             pathSegments.push(a.get('name'));
         }
         const path = [...pathSegments, asset.get('file').filename].join('/');


### PR DESCRIPTION
### What's Changed

Four fixes for Tier 2 Sentry issues in the `browser_live` environment, all in the code-editor:

- **PLAY-CANVAS-G3DM** (7 events): Guard `doc.on('load')` handler in `documents-load.ts` against null `doc.type` — the collab server's checkpoint cleanup can null document data in MongoDB, causing ShareDB to deliver snapshots with `type=null`. The guard pattern already exists in `sharedb.ts:398` and `userdata-realtime.ts:36` but was missing here.
- **PLAY-CANVAS-G3EA** (4 events): Filter out undefined results from `assets:getByVirtualPath` before passing to `loadDocument()` during ESM dependency resolution — unresolved import paths return undefined which crashes on `.get('id')`.
- **PLAY-CANVAS-G3CG** (6 events): Replace two-pass check-then-map path resolution with a single-pass loop in `monaco/document.ts` — eliminates a TOCTOU race where an asset could be removed between the `some()` check and the subsequent `map(a => a.get('name'))`.
- **PLAY-CANVAS-G3E0** (1 event): Add `!item.destroyed` guard in `files:select` method — matches the pattern already used in the `documents:close` handler in the same file. Prevents `classList` access on a destroyed TreeViewItem during asset deletion races.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)