### PR TITLE
fix: size version-control side panel via flex column

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4762,8 +4762,6 @@ strong {
             place-content: flex-start;
 
             > .side-panel-widget {
-                display: flex;
-                flex-direction: column;
                 flex-grow: 1;
                 height: 100%;
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4762,6 +4762,8 @@ strong {
             place-content: flex-start;
 
             > .side-panel-widget {
+                display: flex;
+                flex-direction: column;
                 flex-grow: 1;
                 height: 100%;
 
@@ -4791,7 +4793,13 @@ strong {
                         font-size: 12px;
                     }
 
+                    &.top {
+                        flex: none;
+                    }
+
                     &.main {
+                        flex: 1 1 auto;
+                        min-height: 0;
                         border-top: 1px solid $border-primary;
                         box-sizing: border-box;
                         overflow-y: auto;
@@ -4803,6 +4811,7 @@ strong {
                     }
 
                     &.buttons {
+                        flex: none;
                         border-top: 1px solid $border-primary;
                         border-bottom: 1px solid $border-primary;
                         height: 68px;

--- a/src/editor/pickers/version-control/picker-version-control-side-panel.ts
+++ b/src/editor/pickers/version-control/picker-version-control-side-panel.ts
@@ -5,6 +5,7 @@ editor.once('load', () => {
 
     editor.method('picker:versioncontrol:createSidePanel', (args) => {
         const panel = new Container({
+            flex: true,
             class: 'side-panel-widget'
         });
 

--- a/src/editor/pickers/version-control/picker-version-control-side-panel.ts
+++ b/src/editor/pickers/version-control/picker-version-control-side-panel.ts
@@ -89,14 +89,6 @@ editor.once('load', () => {
         const enterHotkeyAction = `version-control-enter-${sidePanelIndex++}`;
 
         panel.on('show', () => {
-            // Defer height calculation so callers can update title/note text
-            // before offsetHeight is read (empty labels have 0px height)
-            requestAnimationFrame(() => {
-                if (panelMain) {
-                    panelMain.style.height = `calc(100% - ${panelTop.dom.offsetHeight + panelButtons.dom.offsetHeight}px)`;
-                }
-            });
-
             // Register Enter hotkey to click the highlighted button
             editor.call('hotkey:register', enterHotkeyAction, {
                 key: 'Enter',


### PR DESCRIPTION
## Summary

- Replaces the fragile `style.height = calc(100% - <measured>px)` hack on the version-control side panel's `.main` row with a real CSS flex column on `.side-panel-widget` (`.top`/`.buttons` are `flex: none`, `.main` is `flex: 1 1 auto; min-height: 0;`).
- Drops the `requestAnimationFrame` measurement block in [`picker-version-control-side-panel.ts`](src/editor/pickers/version-control/picker-version-control-side-panel.ts); layout is now correct on the very first frame the panel becomes visible.

## Why

The `requestAnimationFrame` ran before layout had fully stabilised on the first reveal after a page reload, so `panelTop.offsetHeight + panelButtons.offsetHeight` read as ~0. `.main` got sized to nearly 100% of its parent, the description `TextAreaInput` (with `flexGrow: 1`) expanded into the overflow, and the Confirm/Cancel buttons were pushed off-screen. Switching tabs hid/showed the panel, the rAF re-ran after layout was valid, and it rendered correctly — exactly the workaround the issue reporter described.

The CSS now expresses the intended layout natively, so there is no measurement race and no JS dependency on host-element timing.

## Fixes

- Fixes #2019 — "Checkpoint description box is too long"
- Fixes #1980 — "[EDITOR UI] Checkpoint save" (same root cause: Save/Confirm button hidden after Ctrl+S)

## Test plan

- [x] Hard reload the editor, press Ctrl+S — Create Checkpoint panel shows description field plus Confirm/Cancel buttons without needing a tab switch.
- [ ] Same on macOS (Cmd+S path).
- [x] Open Version Control via the menu, press Ctrl+S — still works.
- [x] Open each of the other pickers built on `createSidePanel` and confirm no visual regression: Create Branch, Merge Branches, Restore Checkpoint, Hard Reset Checkpoint, Close Branch, Delete Branch.
- [x] Resize the editor window with the Create Checkpoint panel open — `.main` resizes smoothly between header and footer.
