### PR TITLE
chore: migrate deprecated PCUI Element.disabled to enabled

### DIFF
--- a/src/editor/animstategraph/anim-viewer.ts
+++ b/src/editor/animstategraph/anim-viewer.ts
@@ -462,7 +462,7 @@ class AnimViewer extends Container {
         this._renderComponents = [];
         this._setPaused();
         if (this._uiContainer) {
-            this._uiContainer.disabled = true;
+            this._uiContainer.enabled = false;
             this._slider.value = 0;
             this._slider.sliderMax = 1;
         }
@@ -503,7 +503,7 @@ class AnimViewer extends Container {
         this._entity.enabled = true;
 
         if (this._uiContainer) {
-            this._uiContainer.disabled = false;
+            this._uiContainer.enabled = true;
             this._slider.value = 0;
             this._slider.max = animTrack.duration;
             this._slider.sliderMax = animTrack.duration;

--- a/src/editor/animstategraph/state.ts
+++ b/src/editor/animstategraph/state.ts
@@ -245,12 +245,12 @@ class AnimStateGraphState extends Panel {
         }));
 
         this._linkedEntitiesPanel.hidden = false;
-        this.disabled = false;
+        this.enabled = true;
         this.header.hidden = false;
 
         // disable editing for start, end and any states
         if (!enabled) {
-            this.disabled = true;
+            this.enabled = false;
             this._linkedEntitiesPanel.hidden = true;
             this.header.hidden = true;
             return;

--- a/src/editor/animstategraph/transitions.ts
+++ b/src/editor/animstategraph/transitions.ts
@@ -271,7 +271,7 @@ class AnimStateGraphTransitions extends Container {
                 removable: !transition.defaultTransition,
                 sortable: true
             });
-            transitionPanel.disabled = transition.defaultTransition;
+            transitionPanel.enabled = !transition.defaultTransition;
 
             transitionPanel.on('click:remove', () => {
                 this._view._onDeleteEdge({ edgeId: transitionId });

--- a/src/editor/assets/assets-context-menu.ts
+++ b/src/editor/assets/assets-context-menu.ts
@@ -273,7 +273,7 @@ editor.once('load', () => {
         if (key === 'script') {
             editor.on('repositories:load', (repositories) => {
                 if (repositories.get('current') !== 'directory') {
-                    item.disabled = true;
+                    item.enabled = false;
                 }
             });
         }
@@ -685,15 +685,15 @@ editor.once('load', () => {
 
         if (menuItemPaste) {
             if (!editor.call('permissions:write')) {
-                menuItemPaste.disabled = true;
+                menuItemPaste.enabled = false;
             } else if (currentAsset && currentAsset.get('type') !== 'folder') {
-                menuItemPaste.disabled = true;
+                menuItemPaste.enabled = false;
             } else {
                 const clipboard = editor.call('clipboard:get');
-                menuItemPaste.disabled = !clipboard || clipboard.type !== 'asset' || !clipboard.branchId || !clipboard.projectId;
+                menuItemPaste.enabled = clipboard?.type === 'asset' && !!clipboard.branchId && !!clipboard.projectId;
             }
 
-            menuItemCopy.disabled = !currentAsset;
+            menuItemCopy.enabled = !!currentAsset;
         }
 
         if (currentAsset) {

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -680,7 +680,7 @@ class AssetInspector extends Container {
             }
         }
 
-        this._btnDownloadAsset.disabled = disabled;
+        this._btnDownloadAsset.enabled = !disabled;
         this._btnDownloadAsset.hidden = hidden;
     }
 

--- a/src/editor/inspector/assets/audio.ts
+++ b/src/editor/inspector/assets/audio.ts
@@ -102,7 +102,7 @@ class AudioAssetInspector extends Panel {
     }
 
     _audioCanPlay(evt: Event) {
-        this._audioButton.disabled = false;
+        this._audioButton.enabled = true;
         this._audioTimeline.value = 0;
     }
 
@@ -132,7 +132,7 @@ class AudioAssetInspector extends Panel {
             return;
         }
 
-        this._audioButton.disabled = true;
+        this._audioButton.enabled = false;
         this._audioTimeline.value = 100;
 
         this._assetEvents.click = (this._audioButton.on('click', this._onClickAudioButton.bind(this)));

--- a/src/editor/inspector/assets/font.ts
+++ b/src/editor/inspector/assets/font.ts
@@ -460,7 +460,7 @@ class FontAssetInspector extends Container {
     }
 
     _toggleProcessFontButton(asset: Observer) {
-        this._processFontButton.disabled = asset.get('task') === 'running';
+        this._processFontButton.enabled = asset.get('task') !== 'running';
     }
 
     _refreshLocalizationsForAsset() {

--- a/src/editor/inspector/assets/script.ts
+++ b/src/editor/inspector/assets/script.ts
@@ -248,7 +248,7 @@ class ScriptAssetInspector extends Panel {
     }
 
     _onClickParse() {
-        this._parseButton.disabled = true;
+        this._parseButton.enabled = false;
         this._errorContainer.hidden = true;
         this._errorContainer.clear();
         editor.call('scripts:parse', this._asset, (error, result) => {
@@ -256,7 +256,7 @@ class ScriptAssetInspector extends Panel {
                 this._scriptAttributeContainer.destroy();
             }
 
-            this._parseButton.disabled = false;
+            this._parseButton.enabled = true;
             if (error) {
                 this._errorContainer.hidden = false;
                 this._errorContainer.append(new Label({ text: error.message, class: [CLASS_SCRIPT, CLASS_ERROR] }));

--- a/src/editor/inspector/assets/texture.ts
+++ b/src/editor/inspector/assets/texture.ts
@@ -602,10 +602,10 @@ class TextureAssetInspector extends Container {
         this._btnGetMeta.on('click', this._handleBtnGetMetaClick);
 
         this._btnCompressBasis.on('click', this._handleBtnCompressBasisClick);
-        this._btnCompressBasis.disabled = true;
+        this._btnCompressBasis.enabled = false;
 
         this._btnCompressLegacy.on('click', this._handleBtnCompressLegacyClick);
-        this._btnCompressLegacy.disabled = true;
+        this._btnCompressLegacy.enabled = false;
 
         // Add WebGL1 warnings below the relevant settings in the inspector
         this._webgl1NonPotWithMipmapsWarning = new InfoBox({
@@ -729,8 +729,8 @@ class TextureAssetInspector extends Container {
     _checkCompression() {
         const assets = this._assets;
         if (!editor.call('permissions:write') || !Array.isArray(assets) || !assets.length) {
-            this._btnCompressBasis.disabled = true;
-            this._btnCompressLegacy.disabled = true;
+            this._btnCompressBasis.enabled = false;
+            this._btnCompressLegacy.enabled = false;
             return;
         }
 
@@ -760,8 +760,8 @@ class TextureAssetInspector extends Container {
             }
         }
 
-        this._btnCompressBasis.disabled = !differentBasis;
-        this._btnCompressLegacy.disabled = !differentLegacy;
+        this._btnCompressBasis.enabled = differentBasis;
+        this._btnCompressLegacy.enabled = differentLegacy;
     }
 
     // set the enable state of the compression format checkboxes based on the selected textures
@@ -823,15 +823,15 @@ class TextureAssetInspector extends Container {
         this._hasLegacy = selected.dxt || selected.pvr || selected.etc1 || selected.etc2 || false;
 
         // enable/disable basis controls based on whether basis is enabled
-        const basisUiDisabled = !writeAccess || !selected.basis;
+        const basisUiEnabled = writeAccess && selected.basis;
         if (this._compressionBasisAttributesInspector) {
-            this._compressionBasisAttributesInspector.getField('meta.compress.normals').disabled = basisUiDisabled;
-            this._compressionBasisAttributesInspector.getField('meta.compress.compressionMode').disabled = basisUiDisabled;
-            this._compressionBasisAttributesInspector.getField('meta.compress.quality').disabled = basisUiDisabled;
+            this._compressionBasisAttributesInspector.getField('meta.compress.normals').enabled = basisUiEnabled;
+            this._compressionBasisAttributesInspector.getField('meta.compress.compressionMode').enabled = basisUiEnabled;
+            this._compressionBasisAttributesInspector.getField('meta.compress.quality').enabled = basisUiEnabled;
         }
 
         if (this._containerImportBasis) {
-            this._containerImportBasis.disabled = basisUiDisabled;
+            this._containerImportBasis.enabled = basisUiEnabled;
         }
 
         if (this._compressionBasisPvrWarning) {
@@ -849,12 +849,12 @@ class TextureAssetInspector extends Container {
         const fieldEtc1 = this._compressionLegacyAttributesInspector.getField('meta.compress.etc1');
         const fieldEtc2 = this._compressionLegacyAttributesInspector.getField('meta.compress.etc2');
 
-        alphaField.disabled = (hasAlpha === 0) && !selectedAlpha;
+        alphaField.enabled = (hasAlpha !== 0) || selectedAlpha;
         fieldOriginal.value = displayExt;
-        fieldDxt.disabled = !allowed.dxt && !selected.dxt;
-        fieldPvr.disabled = fieldPvrBpp.disabled = !allowed.pvr && !selected.pvr;
-        fieldEtc1.disabled = !allowed.etc1 && !selected.etc1;
-        fieldEtc2.disabled = !allowed.etc2 && !selected.etc2;
+        fieldDxt.enabled = allowed.dxt || selected.dxt;
+        fieldPvr.enabled = fieldPvrBpp.enabled = allowed.pvr || selected.pvr;
+        fieldEtc1.enabled = allowed.etc1 || selected.etc1;
+        fieldEtc2.enabled = allowed.etc2 || selected.etc2;
 
         this._updatePvrWarning();
     }
@@ -880,13 +880,13 @@ class TextureAssetInspector extends Container {
 
     _handleBtnCompressBasisClick() {
         this._handleCompress(['basis']);
-        this._btnCompressBasis.disabled = true;
+        this._btnCompressBasis.enabled = false;
     }
 
     _handleBtnCompressLegacyClick() {
         const { basis, ...rest } = this._compressionFormats; // eslint-disable-line no-unused-vars
         this._handleCompress(Object.keys(rest));
-        this._btnCompressLegacy.disabled = true;
+        this._btnCompressLegacy.enabled = false;
     }
 
     _handleBtnGetMetaClick() {
@@ -977,7 +977,7 @@ class TextureAssetInspector extends Container {
             this._containerImportBasis.append(this._btnImportBasis);
 
             panel.appendAfter(this._containerImportBasis, this._compressionBasisAttributesInspector);
-            this._containerImportBasis.disabled = true;
+            this._containerImportBasis.enabled = false;
 
             const events = [];
             const handleModuleImported = (name) => {
@@ -1039,17 +1039,17 @@ class TextureAssetInspector extends Container {
 
     _setupLegacy() {
         const fieldLegacy = this._compressionLegacyAttributesInspector.getField('compress.legacy');
-        const dirty = !this._btnCompressLegacy.disabled;
+        const dirty = this._btnCompressLegacy.enabled;
         this._showHideLegacyUi(this._hasLegacy || dirty);
         fieldLegacy.value = this._hasLegacy || dirty;
-        fieldLegacy.disabled = this._hasLegacy || dirty;
+        fieldLegacy.enabled = !(this._hasLegacy || dirty);
         this._assetEvents.push(fieldLegacy.on('change', this._showHideLegacyUi));
     }
 
     _updateLegacy() {
         const fieldLegacy = this._compressionLegacyAttributesInspector.getField('compress.legacy');
-        const dirty = !this._btnCompressLegacy.disabled;
-        fieldLegacy.disabled = this._hasLegacy || dirty;
+        const dirty = this._btnCompressLegacy.enabled;
+        fieldLegacy.enabled = !(this._hasLegacy || dirty);
     }
 
     _setupPanelReferences() {
@@ -1134,7 +1134,7 @@ class TextureAssetInspector extends Container {
 
         // only show pvr warning if any selected texture is non-square and pvr is ticked
         let hidden = true;
-        if (fieldPvr.value && !fieldPvr.disabled) {
+        if (fieldPvr.value && fieldPvr.enabled) {
             for (let i = 0; i < assets.length; i++) {
                 if (assets[i].get('meta.width') !== assets[i].get('meta.height')) {
                     hidden = false;

--- a/src/editor/inspector/components/element.ts
+++ b/src/editor/inspector/components/element.ts
@@ -811,23 +811,23 @@ class ElementComponentInspector extends ComponentInspector {
         this._field('mask').parent.hidden = !isImage;
         this._field('resetSize').parent.hidden = !isImage || (!sprite && !texture);
 
-        this._field('width').disabled = horizontalSplit || (this._field('autoWidth').value && isText);
-        this._field('height').disabled = verticalSplit || (this._field('autoHeight').value && isText);
-        this._field('autoWidth').disabled = horizontalSplit;
-        this._field('autoHeight').disabled = verticalSplit;
+        this._field('width').enabled = !(horizontalSplit || (this._field('autoWidth').value && isText));
+        this._field('height').enabled = !(verticalSplit || (this._field('autoHeight').value && isText));
+        this._field('autoWidth').enabled = !horizontalSplit;
+        this._field('autoHeight').enabled = !verticalSplit;
         this._field('fitMode').parent.hidden = !isImage || (!texture && !sprite) || material;
-        this._field('autoFitWidth').disabled = this._field('autoWidth').value && !this._field('autoWidth').disabled;
-        this._field('autoFitHeight').disabled = this._field('autoHeight').value && !this._field('autoHeight').disabled;
-        this._field('maxFontSize').parent.hidden = !isText || ((this._field('autoFitWidth').disabled || !this._field('autoFitWidth').value) && (this._field('autoFitHeight').disabled || !this._field('autoFitHeight').value));
+        this._field('autoFitWidth').enabled = !(this._field('autoWidth').value && this._field('autoWidth').enabled);
+        this._field('autoFitHeight').enabled = !(this._field('autoHeight').value && this._field('autoHeight').enabled);
+        this._field('maxFontSize').parent.hidden = !isText || ((!this._field('autoFitWidth').enabled || !this._field('autoFitWidth').value) && (!this._field('autoFitHeight').enabled || !this._field('autoFitHeight').value));
         this._field('minFontSize').parent.hidden = this._field('maxFontSize').parent.hidden;
         this._field('fontSize').parent.hidden = !isText || !this._field('maxFontSize').parent.hidden;
 
         const margins = this._field('margin').inputs;
-        margins[0].disabled = !horizontalSplit;
-        margins[2].disabled = margins[0].disabled;
+        margins[0].enabled = horizontalSplit;
+        margins[2].enabled = margins[0].enabled;
 
-        margins[1].disabled = !verticalSplit;
-        margins[3].disabled = margins[1].disabled;
+        margins[1].enabled = verticalSplit;
+        margins[3].enabled = margins[1].enabled;
     }
 
     _toggleAutoFitWidth(value: boolean) {

--- a/src/editor/inspector/components/light.ts
+++ b/src/editor/inspector/components/light.ts
@@ -554,10 +554,10 @@ class LightComponentInspector extends ComponentInspector {
         const bakeEnabled = this._field('bake').value;
         const bakeDirEnabled = this._field('bakeDir').value;
 
-        this._field('bakeDir').parent.disabled = !bakeEnabled;
-        this._field('bakeNumSamples').parent.disabled = !bakeEnabled || bakeDirEnabled;
-        this._field('bakeArea').parent.disabled = !bakeEnabled || bakeDirEnabled;
-        this._field('affectLightmapped').parent.disabled = bakeEnabled;
+        this._field('bakeDir').parent.enabled = bakeEnabled;
+        this._field('bakeNumSamples').parent.enabled = bakeEnabled && !bakeDirEnabled;
+        this._field('bakeArea').parent.enabled = bakeEnabled && !bakeDirEnabled;
+        this._field('affectLightmapped').parent.enabled = !bakeEnabled;
 
         this._field('affectSpecularity').parent.hidden = !isDirectional;
 

--- a/src/editor/inspector/components/particlesystem.ts
+++ b/src/editor/inspector/components/particlesystem.ts
@@ -507,7 +507,7 @@ class ParticlesystemComponentInspector extends ComponentInspector {
         this._field('animIndex').parent.hidden = hideAnimTiles;
         this._field('randomizeAnimIndex').parent.hidden = hideAnimTiles;
 
-        this._field('animIndex').disabled = this._field('randomizeAnimIndex').value;
+        this._field('animIndex').enabled = !this._field('randomizeAnimIndex').value;
 
         this._field('mesh').hidden = !!this._field('renderAsset').value;
         this._field('renderAsset').hidden = !!this._field('mesh').value;

--- a/src/editor/inspector/entity.ts
+++ b/src/editor/inspector/entity.ts
@@ -492,10 +492,10 @@ class EntityInspector extends Container {
 
             for (let i = 0; i < components.length; i++) {
                 let different = false;
-                const disabled = entities[0].has(`components.${components[i]}`);
+                const hasComponent = entities[0].has(`components.${components[i]}`);
 
                 for (let n = 1; n < entities.length; n++) {
-                    if (disabled !== entities[n].has(`components.${components[i]}`)) {
+                    if (hasComponent !== entities[n].has(`components.${components[i]}`)) {
                         different = true;
                         break;
                     }
@@ -512,10 +512,10 @@ class EntityInspector extends Container {
                     });
 
                     if (!(abstractComponents.has(components[i])) && !(hiddenComponents.has(components[i]))) {
-                        items[submenu].items[index].disabled = different ? false : disabled;
+                        items[submenu].items[index].enabled = different ? true : !hasComponent;
                     }
                 } else {
-                    items[components[i]].disabled = different ? false : disabled;
+                    items[components[i]].enabled = different ? true : !hasComponent;
                 }
             }
         });

--- a/src/editor/inspector/settings-panels/import-map.ts
+++ b/src/editor/inspector/settings-panels/import-map.ts
@@ -142,14 +142,14 @@ class ImportMapSettingsPanel extends BaseSettingsPanel {
     }
 
     _clickCreateDefault() {
-        this._createDefaultButton.disabled = true;
+        this._createDefaultButton.enabled = false;
         editor.call('assets:create:json', {
             name: 'Import Map',
             json: JSON.stringify({ imports: {} }, null, 2),
             spaces: 2,
             noSelect: true,
             callback: (err, id) => {
-                this._createDefaultButton.disabled = false;
+                this._createDefaultButton.enabled = true;
                 if (err) {
                     console.error(err);
                     return;

--- a/src/editor/inspector/settings-panels/layers-layer-panel.ts
+++ b/src/editor/inspector/settings-panels/layers-layer-panel.ts
@@ -88,14 +88,14 @@ class LayersSettingsPanelLayerPanel extends BaseSettingsPanel {
             }
         });
 
-        this.disabled = args.layerKey < 1000;
+        this.enabled = args.layerKey >= 1000;
         const removeLayerEvt = this.on('click:remove', () => {
             this._removeLayer();
         });
 
         let deleteTooltip;
 
-        if (this.disabled) {
+        if (!this.enabled) {
             deleteTooltip = LegacyTooltip.attach({
                 target: this._btnRemove.element,
                 text: 'You cannot delete a built-in layer',

--- a/src/editor/inspector/settings-panels/layers-render-order-list.ts
+++ b/src/editor/inspector/settings-panels/layers-render-order-list.ts
@@ -92,7 +92,7 @@ class LayersSettingsPanelRenderOrderList extends Container {
             layerPanel.class.add(CLASS_RENDER_ORDER_LIST_ITEM_TRANSPARENT);
         }
         if (layer.layer < 1000) {
-            layerPanel._btnRemove.disabled = true;
+            layerPanel._btnRemove.enabled = false;
         }
 
         layerPanel.header.append(

--- a/src/editor/pickers/auditor/picker-auditor.ts
+++ b/src/editor/pickers/auditor/picker-auditor.ts
@@ -63,10 +63,10 @@ editor.on('load', () => {
             btnCancel.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
             if (document.activeElement === btnCancel.element) {
-                if (!btnCancel.disabled) {
+                if (btnCancel.enabled) {
                     btnCancel.emit('click');
                 }
-            } else if (!btnAction.disabled) {
+            } else if (btnAction.enabled) {
                 btnAction.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -17,13 +17,13 @@ editor.once('load', () => {
     let events = [];  // holds events that need to be destroyed
 
     // disables / enables field depending on permissions
-    const handlePermissions = function (field: { disabled: boolean }) {
-        field.disabled = !editor.call('permissions:write');
+    const handlePermissions = function (field: { enabled: boolean }) {
+        field.enabled = editor.call('permissions:write');
         return editor.on(`permissions:set:${config.self.id}`, (accessLevel) => {
             if (accessLevel === 'write' || accessLevel === 'admin') {
-                field.disabled = false;
+                field.enabled = true;
             } else {
-                field.disabled = true;
+                field.enabled = false;
             }
         });
     };
@@ -270,8 +270,8 @@ editor.once('load', () => {
             class: 'primary'
         });
         events.push(handlePermissions(primary));
-        if (!primary.disabled && app.task.status !== 'complete') {
-            primary.disabled = true;
+        if (primary.enabled && app.task.status !== 'complete') {
+            primary.enabled = false;
         }
         item.element.appendChild(primary.element);
 

--- a/src/editor/pickers/picker-confirm.ts
+++ b/src/editor/pickers/picker-confirm.ts
@@ -59,10 +59,10 @@ editor.once('load', () => {
             btnNo.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
             if (document.activeElement === btnYes.element) {
-                if (!btnYes.disabled) {
+                if (btnYes.enabled) {
                     btnYes.emit('click');
                 }
-            } else if (!btnNo.disabled) {
+            } else if (btnNo.enabled) {
                 btnNo.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons

--- a/src/editor/pickers/picker-engine.ts
+++ b/src/editor/pickers/picker-engine.ts
@@ -55,10 +55,10 @@ editor.once('load', () => {
             btnCancel.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
             if (document.activeElement === btnCancel.element) {
-                if (!btnCancel.disabled) {
+                if (btnCancel.enabled) {
                     btnCancel.emit('click');
                 }
-            } else if (!btnAction.disabled) {
+            } else if (btnAction.enabled) {
                 btnAction.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -330,7 +330,7 @@ editor.once('load', () => {
         ref: projectImg,
         filter: function (type: string, data: File[]) {
             return editor.call('permissions:write') &&
-                   !leftPanel.disabled &&
+                   leftPanel.enabled &&
                    !uploadingImage &&
                    type === 'files';
         },
@@ -362,7 +362,7 @@ editor.once('load', () => {
     let currentSelection = null;
 
     projectImg.addEventListener('click', () => {
-        if (!editor.call('permissions:write') || leftPanel.disabled || currentProject.access_level !== 'admin' || currentProject.owner_id !== config.self.id) {
+        if (!editor.call('permissions:write') || !leftPanel.enabled || currentProject.access_level !== 'admin' || currentProject.owner_id !== config.self.id) {
             return;
         }
 
@@ -761,7 +761,7 @@ editor.once('load', () => {
 
     // disable / enable the state of the left panel
     editor.method('picker:project:toggleLeftPanel', (enabled) => {
-        leftPanel.disabled = !enabled;
+        leftPanel.enabled = enabled;
     });
 
     // disables / enables a menu option on the left

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -616,17 +616,18 @@ editor.once('load', () => {
 
     const refreshButtonsState = function () {
         const selectedScenes = getSelectedScenes();
-        const disabled = !inputName.value ||
-                       !selectedScenes.length ||
-                       inputName.value.length > 1000 ||
-                       inputDescription.value.length > 10000 ||
-                       inputNotes.value.length > 10000 ||
-                       inputVersion.value.length > 20 ||
-                       isUploadingImage ||
-                       jobInProgress;
+        const enabled =
+            inputName.value.length > 0 &&
+            inputName.value.length <= 1000 &&
+            selectedScenes.length > 0 &&
+            inputDescription.value.length <= 10000 &&
+            inputNotes.value.length <= 10000 &&
+            inputVersion.value.length <= 20 &&
+            !isUploadingImage &&
+            !jobInProgress;
 
-        btnPublish.disabled = disabled;
-        btnWebDownload.disabled = disabled;
+        btnPublish.enabled = enabled;
+        btnWebDownload.enabled = enabled;
     };
 
     const createSceneItem = function (scene: Record<string, unknown>) {

--- a/src/editor/pickers/project-management/project-management.ts
+++ b/src/editor/pickers/project-management/project-management.ts
@@ -15,12 +15,12 @@ editor.once('load', () => {
 
     // disables / enables field depending on permissions
     editor.method('project:management:handlePermissions', (field, success, errorFn) => {
-        field.disabled = !editor.call('permissions:write');
+        field.enabled = editor.call('permissions:write');
         return editor.on(`permissions:set:${config.self.id}`, (accessLevel) => {
             if (accessLevel === 'write' || accessLevel === 'admin') {
-                field.disabled = false;
+                field.enabled = true;
             } else {
-                field.disabled = true;
+                field.enabled = false;
             }
         });
     });

--- a/src/editor/pickers/sprite-editor/sprite-editor-import-frames-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-import-frames-panel.ts
@@ -78,7 +78,7 @@ editor.once('load', () => {
 
         const resetButton = (): void => {
             btnImport.text = BUTTON_TEXT;
-            btnImport.disabled = false;
+            btnImport.enabled = true;
         };
 
         const showError = (message: string): void => {
@@ -106,7 +106,7 @@ editor.once('load', () => {
                 return;
             }
 
-            btnImport.disabled = true;
+            btnImport.enabled = false;
             btnImport.text = 'PROCESSING...';
 
             const reader = new FileReader();

--- a/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
@@ -83,7 +83,7 @@ editor.once('load', () => {
 
     const toggleTopButtons = function () {
         const canWrite = editor.call('permissions:write');
-        btnFavorite.enabled = canWrite && panel.branch?.closed === false;
+        btnFavorite.enabled = canWrite && !!panel.branch && !panel.branch.closed;
         btnNewCheckpoint.enabled = canWrite && panel.branch?.id === config.self.branch.id;
     };
 

--- a/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
@@ -84,7 +84,7 @@ editor.once('load', () => {
     const toggleTopButtons = function () {
         const canWrite = editor.call('permissions:write');
         btnFavorite.enabled = canWrite && !!panel.branch && !panel.branch.closed;
-        btnNewCheckpoint.enabled = canWrite && panel.branch?.id === config.self.branch.id;
+        btnNewCheckpoint.enabled = canWrite && !!panel.branch && panel.branch.id === config.self.branch.id;
     };
 
     toggleTopButtons();

--- a/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
@@ -82,8 +82,9 @@ editor.once('load', () => {
     panelBranchActions.append(btnNewCheckpoint);
 
     const toggleTopButtons = function () {
-        btnFavorite.disabled = !panel.branch || panel.branch.closed || !editor.call('permissions:write');
-        btnNewCheckpoint.disabled = !editor.call('permissions:write') || !panel.branch || panel.branch.id !== config.self.branch.id;
+        const canWrite = editor.call('permissions:write');
+        btnFavorite.enabled = canWrite && panel.branch?.closed === false;
+        btnNewCheckpoint.enabled = canWrite && panel.branch?.id === config.self.branch.id;
     };
 
     toggleTopButtons();
@@ -308,7 +309,7 @@ editor.once('load', () => {
             return;
         }
 
-        btnLoadMore.disabled = true;
+        btnLoadMore.enabled = false;
         btnLoadMore.text = 'LOADING...';
 
         // hide list of checkpoints and show spinner
@@ -327,7 +328,7 @@ editor.once('load', () => {
                 return;
             }
 
-            btnLoadMore.disabled = false;
+            btnLoadMore.enabled = true;
             btnLoadMore.text = 'LOAD MORE';
 
             // show list of checkpoints and hide spinner
@@ -802,7 +803,7 @@ editor.once('load', () => {
         }
 
         // restore state of buttons
-        btnLoadMore.disabled = false;
+        btnLoadMore.enabled = true;
         btnLoadMore.text = 'LOAD MORE';
         listCheckpoints.hidden = false;
         spinner.classList.add('hidden');
@@ -817,9 +818,9 @@ editor.once('load', () => {
     // Toggles diff mode for the checkpoint view.
     panel.toggleDiffMode = function (enabled: boolean) {
         diffMode = enabled;
-        btnFavorite.disabled = enabled;
-        btnNewCheckpoint.disabled = enabled;
-        btnDiff.disabled = enabled;
+        btnFavorite.enabled = !enabled;
+        btnNewCheckpoint.enabled = !enabled;
+        btnDiff.enabled = !enabled;
     };
 
     // Return checkpoints container panel

--- a/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
@@ -309,7 +309,7 @@ editor.once('load', () => {
             return;
         }
 
-        btnLoadMore.enabled = false;
+        btnLoadMore.disabled = true;
         btnLoadMore.text = 'LOADING...';
 
         // hide list of checkpoints and show spinner
@@ -328,7 +328,7 @@ editor.once('load', () => {
                 return;
             }
 
-            btnLoadMore.enabled = true;
+            btnLoadMore.disabled = false;
             btnLoadMore.text = 'LOAD MORE';
 
             // show list of checkpoints and hide spinner
@@ -803,7 +803,7 @@ editor.once('load', () => {
         }
 
         // restore state of buttons
-        btnLoadMore.enabled = true;
+        btnLoadMore.disabled = false;
         btnLoadMore.text = 'LOAD MORE';
         listCheckpoints.hidden = false;
         spinner.classList.add('hidden');

--- a/src/editor/pickers/version-control/picker-version-control-close-branch.ts
+++ b/src/editor/pickers/version-control/picker-version-control-close-branch.ts
@@ -35,7 +35,7 @@ editor.once('load', () => {
     panelTypeName.append(fieldName);
 
     fieldName.on('keydown', (e: KeyboardEvent) => {
-        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
+        if (e.key === 'Enter' && panel.buttonConfirm.enabled) {
             panel.emit('confirm');
         }
     });
@@ -59,13 +59,13 @@ editor.once('load', () => {
 
     panel.createTargetCheckpoint = true;
 
-    panel.buttonConfirm.disabled = true;
+    panel.buttonConfirm.enabled = false;
     fieldName.on('change', () => {
         if (!panel.branch) {
             return;
         }
 
-        panel.buttonConfirm.disabled = fieldName.value.toLowerCase() !== panel.branch.name.toLowerCase();
+        panel.buttonConfirm.enabled = fieldName.value.toLowerCase() === panel.branch.name.toLowerCase();
     });
 
     boxBranch.on('createTargetCheckpoint', (value) => {
@@ -78,7 +78,7 @@ editor.once('load', () => {
 
     panel.on('hide', () => {
         fieldName.value = '';
-        panel.buttonConfirm.disabled = true;
+        panel.buttonConfirm.enabled = false;
         boxBranch.clear();
         if (checkpointRequest) {
             checkpointRequest.abort();

--- a/src/editor/pickers/version-control/picker-version-control-create-branch.ts
+++ b/src/editor/pickers/version-control/picker-version-control-create-branch.ts
@@ -53,7 +53,7 @@ editor.once('load', () => {
     panel.class.add('create-branch');
 
     const createBranch = () => {
-        if (panel.buttonConfirm.disabled) {
+        if (!panel.buttonConfirm.enabled) {
             return;
         }
         panel.emit('confirm', {
@@ -66,7 +66,7 @@ editor.once('load', () => {
         boxFrom.clear();
         boxNewBranch.header = ' ';
         fieldBranchName.value = '';
-        panel.buttonConfirm.disabled = true;
+        panel.buttonConfirm.enabled = false;
     });
 
     panel.on('show', () => {
@@ -76,7 +76,7 @@ editor.once('load', () => {
     });
 
     fieldBranchName.on('change', (value) => {
-        panel.buttonConfirm.disabled = !value;
+        panel.buttonConfirm.enabled = !!value;
         boxNewBranch.header = value || ' ';
     });
 

--- a/src/editor/pickers/version-control/picker-version-control-create-checkpoint.ts
+++ b/src/editor/pickers/version-control/picker-version-control-create-checkpoint.ts
@@ -28,7 +28,7 @@ editor.once('load', () => {
 
     fieldDescription.on('keydown', (e: KeyboardEvent) => {
         if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-            if (!panel.buttonConfirm.disabled) {
+            if (panel.buttonConfirm.enabled) {
                 create();
             }
         }
@@ -48,15 +48,15 @@ editor.once('load', () => {
     });
     panel.class.add('create-checkpoint');
 
-    panel.buttonConfirm.disabled = true;
+    panel.buttonConfirm.enabled = false;
 
     fieldDescription.on('change', (value) => {
-        panel.buttonConfirm.disabled = !value.trim();
+        panel.buttonConfirm.enabled = !!value.trim();
     });
 
     panel.on('hide', () => {
         fieldDescription.value = '';
-        panel.buttonConfirm.disabled = true;
+        panel.buttonConfirm.enabled = false;
     });
 
     panel.on('show', () => {

--- a/src/editor/pickers/version-control/picker-version-control-delete-branch.ts
+++ b/src/editor/pickers/version-control/picker-version-control-delete-branch.ts
@@ -32,7 +32,7 @@ editor.once('load', () => {
     panelTypeName.append(fieldName);
 
     fieldName.on('keydown', (e: KeyboardEvent) => {
-        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
+        if (e.key === 'Enter' && panel.buttonConfirm.enabled) {
             panel.emit('confirm');
         }
     });
@@ -56,13 +56,13 @@ editor.once('load', () => {
     });
     panel.class.add('close-branch');
 
-    panel.buttonConfirm.disabled = true;
+    panel.buttonConfirm.enabled = false;
     fieldName.on('change', () => {
         if (!panel.branch) {
             return;
         }
 
-        panel.buttonConfirm.disabled = fieldName.value.toLowerCase() !== panel.branch.name.toLowerCase();
+        panel.buttonConfirm.enabled = fieldName.value.toLowerCase() === panel.branch.name.toLowerCase();
     });
 
     panel.on('show', () => {
@@ -71,7 +71,7 @@ editor.once('load', () => {
 
     panel.on('hide', () => {
         fieldName.value = '';
-        panel.buttonConfirm.disabled = true;
+        panel.buttonConfirm.enabled = false;
         boxBranch.clear();
         if (checkpointRequest) {
             checkpointRequest.abort();

--- a/src/editor/pickers/version-control/picker-version-control-hard-reset-checkpoint.ts
+++ b/src/editor/pickers/version-control/picker-version-control-hard-reset-checkpoint.ts
@@ -41,11 +41,11 @@ editor.once('load', () => {
             }
         }
     });
-    panel.buttonConfirm.disabled = true;
+    panel.buttonConfirm.enabled = false;
     panel.class.add('hard-reset-checkpoint');
 
     textField.on('keydown', (e: KeyboardEvent) => {
-        if (e.key === 'Enter' && !panel.buttonConfirm.disabled) {
+        if (e.key === 'Enter' && panel.buttonConfirm.enabled) {
             panel.emit('confirm');
         }
     });
@@ -66,7 +66,7 @@ editor.once('load', () => {
             return;
         }
 
-        panel.buttonConfirm.disabled = (textField.value !== 'hard reset' && textField.value !== '"hard reset"');
+        panel.buttonConfirm.enabled = (textField.value === 'hard reset' || textField.value === '"hard reset"');
     });
 
     panel.on('hide', () => {

--- a/src/editor/pickers/version-control/picker-version-control-overlay-merge.ts
+++ b/src/editor/pickers/version-control/picker-version-control-overlay-merge.ts
@@ -112,7 +112,7 @@ editor.once('load', () => {
             }
 
             // update dropdown
-            btnSwitch.disabled = false;
+            btnSwitch.enabled = true;
             dropdownBranches.options = branches.map((branch) => {
                 return {
                     v: branch.id, t: branch.name
@@ -125,7 +125,7 @@ editor.once('load', () => {
     overlay.on('hide', () => {
         dropdownBranches.options = [];
         dropdownBranches.value = null;
-        btnSwitch.disabled = true;
+        btnSwitch.enabled = false;
     });
 
     editor.method('picker:versioncontrol:mergeOverlay', () => {

--- a/src/editor/pickers/version-control/picker-version-control-side-panel.ts
+++ b/src/editor/pickers/version-control/picker-version-control-side-panel.ts
@@ -95,12 +95,12 @@ editor.once('load', () => {
                 key: 'Enter',
                 callback: function (e: KeyboardEvent) {
                     if (btnCancel.class.contains('highlighted')) {
-                        if (btnCancel.disabled) {
+                        if (!btnCancel.enabled) {
                             return;
                         }
                         btnCancel.emit('click');
                     } else if (btnConfirm.class.contains('highlighted')) {
-                        if (btnConfirm.disabled) {
+                        if (!btnConfirm.enabled) {
                             return;
                         }
                         btnConfirm.emit('click');

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -290,8 +290,8 @@ editor.once('load', () => {
     const togglePanels = function (enabled: boolean) {
         editor.call('picker:project:setClosable', enabled && config.scene.id);
         editor.call('picker:project:toggleLeftPanel', enabled);
-        panelBranches.disabled = !enabled;
-        panelBranchesFilter.disabled = !enabled;
+        panelBranches.enabled = enabled;
+        panelBranchesFilter.enabled = enabled;
     };
 
     const checkpointCallbackQueue = [];
@@ -838,7 +838,7 @@ editor.once('load', () => {
                 showCheckpoints();
             }
 
-            if (panelBranches.disabled) {
+            if (!panelBranches.enabled) {
                 return;
             }
 
@@ -1041,7 +1041,7 @@ editor.once('load', () => {
 
     const loadBranches = function () {
         // change status of loading button
-        btnLoadMoreBranches.disabled = true;
+        btnLoadMoreBranches.enabled = false;
         btnLoadMoreBranches.text = 'LOADING...';
 
         // if we are reloading
@@ -1062,7 +1062,7 @@ editor.once('load', () => {
             }
 
             // change status of loading button
-            btnLoadMoreBranches.disabled = false;
+            btnLoadMoreBranches.enabled = true;
             btnLoadMoreBranches.text = 'LOAD MORE';
             loadMoreListItem.hidden = !data.pagination.hasMore;
 


### PR DESCRIPTION
## Summary

- Replaces the deprecated PCUI `Element.disabled` getter/setter with `enabled` across the editor (33 files), per the deprecation in `@playcanvas/pcui`'s `Element` class.
- Preserves intent for chained/dependent reads — e.g. `fieldPvr.disabled = fieldPvrBpp.disabled = ...` was split into two `enabled` assignments, and `const dirty = !btn.disabled` became `const dirty = btn.enabled`.
- Out-of-scope (intentionally untouched): `LegacyElement` subclasses under `src/common/ui/*`, `LegacyButton`/`LegacyPanel`/`LegacyTooltip` callers (including `conflict-manager` pickers and `attributes:add*` consumers), CSS class strings, project/data-model `disabled` fields from API responses, and theme color keys.

## Migration patterns applied

```ts
btn.disabled = expr;            // -> btn.enabled = !(expr);
if (btn.disabled) { ... }       // -> if (!btn.enabled) { ... }
if (!btn.disabled) { ... }      // -> if (btn.enabled) { ... }
const dirty = !btn.disabled;    // -> const dirty = btn.enabled;
a.disabled = b.disabled = expr; // -> split into two `enabled = !(expr)` assignments
```

A few inline type annotations and helpers (`handlePermissions`, `project:management:handlePermissions`, the local `disabled`/`enabled` flag in `picker-publish-new` and `inspector/entity`) were updated/renamed for readability when the inverted semantics warranted it.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type:check` introduces no new errors (only pre-existing TS issues remain)
- [x] Repo-wide grep for `\.disabled` in `editor/src` only returns out-of-scope hits (Legacy subclasses, attribute-panel callers, data-model fields)
- [x] Smoke test inspectors that toggle field enable state (texture compression, element component margins, light bake settings, particle anim index)
- [x] Smoke test version-control side panels (create/close/delete branch, hard-reset checkpoint, create checkpoint) — confirm Confirm button enables only when input is valid
- [x] Smoke test publish dialog buttons and asset-context-menu paste/copy enablement
