### PR TITLE
chore: migrate deprecated PCUI Element.element to dom

### DIFF
--- a/src/editor/attributes/attributes-history.ts
+++ b/src/editor/attributes/attributes-history.ts
@@ -122,7 +122,7 @@ editor.once('load', () => {
     };
 
     const tooltip = LegacyTooltip.attach({
-        target: btnBack.element,
+        target: btnBack.dom,
         text: '-',
         align: 'top',
         root: root

--- a/src/editor/chat/chat-widget.ts
+++ b/src/editor/chat/chat-widget.ts
@@ -31,7 +31,7 @@ editor.once('load', () => {
         return chatPanel;
     });
 
-    chatPanel.element.addEventListener('mouseover', () => {
+    chatPanel.dom.addEventListener('mouseover', () => {
         editor.emit('viewport:hover', false);
     }, false);
 
@@ -43,7 +43,7 @@ editor.once('load', () => {
     chatPanel.header.append(notify);
 
     const tooltipNotify = LegacyTooltip.attach({
-        target: notify.element,
+        target: notify.dom,
         text: 'Notifications (enabled)',
         align: 'bottom',
         root: root
@@ -290,7 +290,7 @@ editor.once('load', () => {
     const clear = document.createElement('div');
     clear.innerHTML = '&#57650;';
     clear.classList.add('clear');
-    input.element.appendChild(clear);
+    input.dom.appendChild(clear);
 
     const onTypingEnd = function () {
         if (typingTimeout) {
@@ -338,7 +338,7 @@ editor.once('load', () => {
         }
     });
 
-    input.element.addEventListener('keydown', (evt: KeyboardEvent) => {
+    input.dom.addEventListener('keydown', (evt: KeyboardEvent) => {
         if (evt.keyCode === 27) {
             // esc
             input.value = '';

--- a/src/editor/entities/entities-advanced-search-ui.ts
+++ b/src/editor/entities/entities-advanced-search-ui.ts
@@ -20,7 +20,7 @@ editor.once('load', () => {
     const searchClear = new Element();
     searchClear.class.add('clear');
     searchClear.dom.innerHTML = '&#57650;';
-    search.element.appendChild(searchClear.dom);
+    search.dom.appendChild(searchClear.dom);
 
     // Button for showing filters
     const showFiltersButton = new Element();
@@ -121,7 +121,7 @@ editor.once('load', () => {
 
     smartSearchLabel.class.add('advanced-search-label-toggle');
     smartSearchLabel.label.class.add('advanced-search-label-toggle-text');
-    smartSearchLabel.element.setAttribute('text-hover', 'Toggle whether only exact matches are shown');
+    smartSearchLabel.dom.setAttribute('text-hover', 'Toggle whether only exact matches are shown');
 
     // Search by
 

--- a/src/editor/entities/entities-control.ts
+++ b/src/editor/entities/entities-control.ts
@@ -30,13 +30,13 @@ editor.once('load', () => {
     });
     btnAdd.on('click', () => {
         menuEntities.hidden = false;
-        const rect = btnAdd.element.getBoundingClientRect();
+        const rect = btnAdd.dom.getBoundingClientRect();
         menuEntities.position(rect.left, rect.top);
     });
     controls.append(btnAdd);
 
     LegacyTooltip.attach({
-        target: btnAdd.element,
+        target: btnAdd.dom,
         text: 'Add Entity',
         align: 'top',
         root: root
@@ -58,7 +58,7 @@ editor.once('load', () => {
     controls.append(btnDuplicate);
 
     const tooltipDuplicate = LegacyTooltip.attach({
-        target: btnDuplicate.element,
+        target: btnDuplicate.dom,
         text: 'Duplicate Entity',
         align: 'top',
         root: root
@@ -81,7 +81,7 @@ editor.once('load', () => {
     controls.append(btnDelete);
 
     const tooltipDelete = LegacyTooltip.attach({
-        target: btnDelete.element,
+        target: btnDelete.dom,
         text: 'Delete Entity',
         align: 'top',
         root: root
@@ -100,7 +100,7 @@ editor.once('load', () => {
     controls.append(btnMore);
 
     LegacyTooltip.attach({
-        target: btnMore.element,
+        target: btnMore.dom,
         text: 'More Options',
         align: 'top',
         root: root

--- a/src/editor/guides/guide-intro.ts
+++ b/src/editor/guides/guide-intro.ts
@@ -151,8 +151,8 @@ editor.once('load', () => {
             editor.call('layout.toolbar')
         );
 
-        bubble.element.style.top = '';
-        bubble.element.style.bottom = '119px';
+        bubble.dom.style.top = '';
+        bubble.dom.style.bottom = '119px';
         return bubble;
     };
 
@@ -167,8 +167,8 @@ editor.once('load', () => {
             editor.call('layout.viewport')
         );
 
-        bubble.element.style.left = '';
-        bubble.element.style.right = '6px';
+        bubble.dom.style.left = '';
+        bubble.dom.style.right = '6px';
 
         return bubble;
     };

--- a/src/editor/help/controls.ts
+++ b/src/editor/help/controls.ts
@@ -9,7 +9,7 @@ editor.once('load', () => {
         hidden: true
     });
 
-    overlay.element.addEventListener('mousewheel', (evt) => {
+    overlay.dom.addEventListener('mousewheel', (evt) => {
         evt.stopPropagation();
     }, { passive: true });
 

--- a/src/editor/help/howdoi.ts
+++ b/src/editor/help/howdoi.ts
@@ -40,7 +40,7 @@ editor.once('load', () => {
             return;
         }
 
-        const canvasRect = canvas.element.getBoundingClientRect();
+        const canvasRect = canvas.dom.getBoundingClientRect();
 
         const titleWidget = document.querySelector('.control-strip.top-left');
         const titleWidgetRect = titleWidget ? titleWidget.getBoundingClientRect() : null;
@@ -92,8 +92,8 @@ editor.once('load', () => {
             editor.call('layout.toolbar')
         );
 
-        b.element.style.top = '';
-        b.element.style.bottom = '130px';
+        b.dom.style.top = '';
+        b.dom.style.bottom = '130px';
         return b;
     };
 

--- a/src/editor/inspector/settings-panels/import-map.ts
+++ b/src/editor/inspector/settings-panels/import-map.ts
@@ -75,14 +75,14 @@ class ImportMapSettingsPanel extends BaseSettingsPanel {
 
 
         this._selectExistingTooltip = LegacyTooltip.attach({
-            target: this._selectExistingButton.element,
+            target: this._selectExistingButton.dom,
             text: 'Select an existing Import Map',
             align: 'bottom',
             root: editor.call('layout.root')
         });
 
         this._createDefaultTooltip = LegacyTooltip.attach({
-            target: this._createDefaultButton.element,
+            target: this._createDefaultButton.dom,
             text: 'Create a default Import Map',
             align: 'bottom',
             root: editor.call('layout.root')

--- a/src/editor/inspector/settings-panels/layers-layer-panel.ts
+++ b/src/editor/inspector/settings-panels/layers-layer-panel.ts
@@ -97,7 +97,7 @@ class LayersSettingsPanelLayerPanel extends BaseSettingsPanel {
 
         if (!this.enabled) {
             deleteTooltip = LegacyTooltip.attach({
-                target: this._btnRemove.element,
+                target: this._btnRemove.dom,
                 text: 'You cannot delete a built-in layer',
                 align: 'bottom',
                 root: editor.call('layout.root')

--- a/src/editor/inspector/settings-panels/layers-render-order-list.ts
+++ b/src/editor/inspector/settings-panels/layers-render-order-list.ts
@@ -144,7 +144,7 @@ class LayersSettingsPanelRenderOrderList extends Container {
 
         if (layer.layer < 1000) {
             deleteTooltip = LegacyTooltip.attach({
-                target: layerPanel._btnRemove.element,
+                target: layerPanel._btnRemove.dom,
                 text: 'You cannot delete a built-in layer',
                 align: 'bottom',
                 root: editor.call('layout.root')

--- a/src/editor/inspector/settings-panels/loading-screen.ts
+++ b/src/editor/inspector/settings-panels/loading-screen.ts
@@ -76,14 +76,14 @@ class LoadingScreenSettingsPanel extends BaseSettingsPanel {
 
 
         this._selectExistingTooltip = LegacyTooltip.attach({
-            target: this._selectExistingButton.element,
+            target: this._selectExistingButton.dom,
             text: 'Select an existing loading screen script',
             align: 'bottom',
             root: editor.call('layout.root')
         });
 
         this._createDefaultTooltip = LegacyTooltip.attach({
-            target: this._createDefaultButton.element,
+            target: this._createDefaultButton.dom,
             text: 'Create a default loading script',
             align: 'bottom',
             root: editor.call('layout.root')

--- a/src/editor/pickers/auditor/picker-auditor.ts
+++ b/src/editor/pickers/auditor/picker-auditor.ts
@@ -62,7 +62,7 @@ editor.on('load', () => {
         if (evt.key === 'Escape') {
             btnCancel.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
-            if (document.activeElement === btnCancel.element) {
+            if (document.activeElement === btnCancel.dom) {
                 if (btnCancel.enabled) {
                     btnCancel.emit('click');
                 }
@@ -70,15 +70,15 @@ editor.on('load', () => {
                 btnAction.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
-            if (document.activeElement === btnCancel.element) {
-                btnAction.element.focus();
+            if (document.activeElement === btnCancel.dom) {
+                btnAction.dom.focus();
             } else {
-                btnCancel.element.focus();
+                btnCancel.dom.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnAction.element.focus();
+            btnAction.dom.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnCancel.element.focus();
+            btnCancel.dom.focus();
         }
     };
 

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -273,7 +273,7 @@ editor.once('load', () => {
         if (primary.enabled && app.task.status !== 'complete') {
             primary.enabled = false;
         }
-        item.element.appendChild(primary.element);
+        item.element.appendChild(primary.dom);
 
         // set primary app
         events.push(primary.on('click', () => {
@@ -296,7 +296,7 @@ editor.once('load', () => {
         // primary icon tooltip
         const tooltipText = config.project.primaryApp === app.id ? 'Primary build' : 'Change the projects\'s primary build';
         const tooltip = LegacyTooltip.attach({
-            target: primary.element,
+            target: primary.dom,
             text: tooltipText,
             align: 'right',
             root: editor.call('layout.root')
@@ -329,14 +329,14 @@ editor.once('load', () => {
             text: app.name,
             class: 'name'
         });
-        nameRow.appendChild(name.element);
+        nameRow.appendChild(name.dom);
 
         // app version
         const version = new Label({
             text: app.version,
             class: 'version'
         });
-        nameRow.appendChild(version.element);
+        nameRow.appendChild(version.dom);
 
         // row below name
         const info = document.createElement('div');
@@ -349,7 +349,7 @@ editor.once('load', () => {
             class: 'date',
             hidden: app.task.status === 'error'
         });
-        info.appendChild(date.element);
+        info.appendChild(date.dom);
 
         // views
         const views = new Label({
@@ -357,7 +357,7 @@ editor.once('load', () => {
             class: 'views',
             hidden: app.task.status !== 'complete'
         });
-        info.appendChild(views.element);
+        info.appendChild(views.dom);
 
         // size
         const size = new Label({
@@ -365,7 +365,7 @@ editor.once('load', () => {
             class: 'size',
             hidden: app.task.status !== 'complete'
         });
-        info.appendChild(size.element);
+        info.appendChild(size.dom);
 
         // branch
         const branch = new Label({
@@ -373,7 +373,7 @@ editor.once('load', () => {
             class: 'branch',
             hidden: app.task.status !== 'complete' || projectSettings.get('useLegacyScripts')
         });
-        info.appendChild(branch.element);
+        info.appendChild(branch.dom);
 
         // error message
         const error = new Label({
@@ -381,7 +381,7 @@ editor.once('load', () => {
             class: 'error',
             hidden: app.task.status !== 'error'
         });
-        item.element.appendChild(error.element);
+        item.element.appendChild(error.dom);
 
         // release notes
         let releaseNotes = app.release_notes || '';
@@ -395,26 +395,26 @@ editor.once('load', () => {
             hidden: !error.hidden,
             renderChanges: false
         });
-        item.element.appendChild(notes.element);
+        item.element.appendChild(notes.dom);
 
         // dropdown
         const dropdown = new Button({
             class: 'dropdown'
         });
-        dropdown.element.innerHTML = '&#57689;';
-        item.element.appendChild(dropdown.element);
+        dropdown.dom.innerHTML = '&#57689;';
+        item.element.appendChild(dropdown.dom);
 
         events.push(dropdown.on('click', () => {
             dropdown.class.add('clicked');
             // change arrow
-            dropdown.element.innerHTML = '&#57687;';
+            dropdown.dom.innerHTML = '&#57687;';
             dropdownApp = app;
 
             // open menu
             dropdownMenu.hidden = false;
 
             // position dropdown menu
-            const rect = dropdown.element.getBoundingClientRect();
+            const rect = dropdown.dom.getBoundingClientRect();
             const menuItems = dropdownMenu.dom.querySelector('.pcui-menu-items') as HTMLElement;
             dropdownMenu.position(rect.right - menuItems.clientWidth, rect.bottom);
         }));
@@ -424,7 +424,7 @@ editor.once('load', () => {
             class: 'more',
             hidden: true
         });
-        item.element.appendChild(more.element);
+        item.element.appendChild(more.dom);
 
         events.push(more.on('click', () => {
             if (notes.class.contains('no-wrap')) {
@@ -438,7 +438,7 @@ editor.once('load', () => {
             }
         }));
 
-        if (notes.element.clientHeight > 22) {
+        if (notes.dom.clientHeight > 22) {
             more.hidden = false;
             notes.class.add('no-wrap');
             notes.text = releaseNotes;
@@ -451,11 +451,11 @@ editor.once('load', () => {
                 img,
                 info,
                 item.element,
-                name.element,
-                date.element,
-                size.element,
-                views.element,
-                notes.element
+                name.dom,
+                date.dom,
+                size.dom,
+                views.dom,
+                notes.dom
             ];
 
             events.push(item.on('click', (e) => {
@@ -482,8 +482,8 @@ editor.once('load', () => {
             toggleProgress(false);
 
             if (apps.length > 0) {
-                panelPlaycanvas.element.classList.add('collapsed');
-                panelSelfHost.element.classList.add('collapsed');
+                panelPlaycanvas.dom.classList.add('collapsed');
+                panelSelfHost.dom.classList.add('collapsed');
             }
 
             toggleCollapsingPublishButtons(apps.length > 0);

--- a/src/editor/pickers/picker-confirm.ts
+++ b/src/editor/pickers/picker-confirm.ts
@@ -58,7 +58,7 @@ editor.once('load', () => {
         if (evt.key === 'Escape') {
             btnNo.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
-            if (document.activeElement === btnYes.element) {
+            if (document.activeElement === btnYes.dom) {
                 if (btnYes.enabled) {
                     btnYes.emit('click');
                 }
@@ -66,15 +66,15 @@ editor.once('load', () => {
                 btnNo.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
-            if (document.activeElement === btnYes.element) {
-                btnNo.element.focus();
+            if (document.activeElement === btnYes.dom) {
+                btnNo.dom.focus();
             } else {
-                btnYes.element.focus();
+                btnYes.dom.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnYes.element.focus();
+            btnYes.dom.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnNo.element.focus();
+            btnNo.dom.focus();
         }
     };
 

--- a/src/editor/pickers/picker-engine.ts
+++ b/src/editor/pickers/picker-engine.ts
@@ -54,7 +54,7 @@ editor.once('load', () => {
         if (evt.key === 'Escape') {
             btnCancel.emit('click');
         } else if (evt.key === 'Enter') { // click focused button
-            if (document.activeElement === btnCancel.element) {
+            if (document.activeElement === btnCancel.dom) {
                 if (btnCancel.enabled) {
                     btnCancel.emit('click');
                 }
@@ -62,15 +62,15 @@ editor.once('load', () => {
                 btnAction.emit('click');
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
-            if (document.activeElement === btnCancel.element) {
-                btnAction.element.focus();
+            if (document.activeElement === btnCancel.dom) {
+                btnAction.dom.focus();
             } else {
-                btnCancel.element.focus();
+                btnCancel.dom.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnAction.element.focus();
+            btnAction.dom.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnCancel.element.focus();
+            btnCancel.dom.focus();
         }
     };
 

--- a/src/editor/pickers/picker-entity.ts
+++ b/src/editor/pickers/picker-entity.ts
@@ -126,7 +126,7 @@ editor.once('load', () => {
             if (selected.length) {
                 selected[0].focus();
             } else {
-                hierarchy.element.focus();
+                hierarchy.dom.focus();
             }
         }, 100);
     });

--- a/src/editor/pickers/picker-project-main.ts
+++ b/src/editor/pickers/picker-project-main.ts
@@ -82,7 +82,7 @@ editor.once('load', () => {
         text: 'UNLOCK'
     });
     lockedContainer.append(unlockButton);
-    lockedContainer.element.style.display = 'none';  // hide by default
+    lockedContainer.dom.style.display = 'none';  // hide by default
 
     unlockButton.on('click', () => {
         editor.call('projects:unlockOne', currentProject.id, () => {
@@ -110,7 +110,7 @@ editor.once('load', () => {
     const projectNameLabel = new Label({
         text: 'Name'
     });
-    projectNameGroup.append(projectNameLabel.element);
+    projectNameGroup.append(projectNameLabel.dom);
     const projectNameInput = new TextInput({
         enabled: isAdmin(),
         class: 'form-input',
@@ -118,7 +118,7 @@ editor.once('load', () => {
         renderChanges: true,
         keyChange: true
     });
-    projectNameGroup.append(projectNameInput.element);
+    projectNameGroup.append(projectNameInput.dom);
 
     projectNameInput.on('change', () => {
         const newValue = projectNameInput.value;
@@ -146,7 +146,7 @@ editor.once('load', () => {
     const projectDescLabel = new Label({
         text: 'Description'
     });
-    projectDescGroup.append(projectDescLabel.element);
+    projectDescGroup.append(projectDescLabel.dom);
     const projectDescInput = new TextAreaInput({
         enabled: isAdmin(),
         class: 'form-input',
@@ -162,8 +162,8 @@ editor.once('load', () => {
         saveProject({ description: descriptionBefore }, initialLoad);
     });
 
-    projectDescInput.element.id = 'description';
-    projectDescGroup.append(projectDescInput.element);
+    projectDescInput.dom.id = 'description';
+    projectDescGroup.append(projectDescInput.dom);
 
     // private settings container
     const privateSettings = new Element({
@@ -174,7 +174,7 @@ editor.once('load', () => {
     const privateLabel = new Label({
         text: 'Private Project'
     });
-    privateSettings.dom.appendChild(privateLabel.element);
+    privateSettings.dom.appendChild(privateLabel.dom);
 
     const privateToggle = new BooleanInput({
         enabled: isAdmin() && editor.call('users:allowPrivate', config.owner),
@@ -188,7 +188,7 @@ editor.once('load', () => {
         }
         editor.call('picker:project:changeVisibility', privateToggle.value ? 'Private' : 'Public');
     });
-    privateSettings.dom.appendChild(privateToggle.element);
+    privateSettings.dom.appendChild(privateToggle.dom);
 
     // project url
     const projectURLSettings = new Element({
@@ -199,13 +199,13 @@ editor.once('load', () => {
     const projectUrlLabel = new Label({
         text: 'Share Project'
     });
-    projectURLSettings.dom.appendChild(projectUrlLabel.element);
+    projectURLSettings.dom.appendChild(projectUrlLabel.dom);
 
     const projectURLButton = new Button({
         icon: 'E357',
         text: 'Copy URL'
     });
-    projectURLSettings.dom.appendChild(projectURLButton.element);
+    projectURLSettings.dom.appendChild(projectURLButton.dom);
 
     projectURLButton.on('click', () => {
         navigator.clipboard.writeText(`${config.url.home}/editor/project/${currentProject.id}`);
@@ -253,7 +253,7 @@ editor.once('load', () => {
         enabled: false,
         hidden: true
     });
-    deleteProjectButton.element.id = 'delete-project-button';
+    deleteProjectButton.dom.id = 'delete-project-button';
     actionButtonsContainer.append(deleteProjectButton);
 
     deleteProjectButton.on('click', () => {

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -72,7 +72,7 @@ editor.once('load', () => {
         if (collaborator.id === config.self.id) {
             parentContainer.dom.classList.add('user-collaborator');
         }
-        membersGrid.element.appendChild(parentContainer.dom);
+        membersGrid.dom.appendChild(parentContainer.dom);
 
         // image container (left)
         const image = new Element({
@@ -104,7 +104,7 @@ editor.once('load', () => {
         const collaboratorName = new Label({
             text: collaborator.inviter_id ? collaborator.email : collaborator.username
         });
-        firstRow.dom.appendChild(collaboratorName.element);
+        firstRow.dom.appendChild(collaboratorName.dom);
 
         const deleteCollaboratorBtn = new Button({ icon: 'E124' });
 
@@ -112,7 +112,7 @@ editor.once('load', () => {
             deleteCollaboratorBtn.enabled = currentProject.access_level === 'admin';  // only allow admins to remove collaborators
         } else {
             const configCollaboratorBtn = new Button({ icon: 'E134' });
-            firstRow.dom.appendChild(configCollaboratorBtn.element);
+            firstRow.dom.appendChild(configCollaboratorBtn.dom);
 
             deleteCollaboratorBtn.enabled = currentProject.owner !== config.self.username && currentProject.id !== config.project.id;
 
@@ -132,7 +132,7 @@ editor.once('load', () => {
             }
         });
 
-        firstRow.dom.appendChild(deleteCollaboratorBtn.element);
+        firstRow.dom.appendChild(deleteCollaboratorBtn.dom);
 
         // second row (dropdown menu or label)
         if (collaborator.inviter_id || currentUser && (currentUser.id === collaborator.id || currentProject.access_level !== 'admin')) {
@@ -162,7 +162,7 @@ editor.once('load', () => {
             const accessLevelLabel = new Label({
                 text: displayLabel
             });
-            collaboratorRightContainer.dom.appendChild(accessLevelLabel.element);
+            collaboratorRightContainer.dom.appendChild(accessLevelLabel.dom);
         } else {
             const accessLevelDropdown = new SelectInput({
                 options: [{
@@ -182,7 +182,7 @@ editor.once('load', () => {
                 updateCollaborator(collaborator, accessLevelDropdown.value);
             });
 
-            collaboratorRightContainer.dom.appendChild(accessLevelDropdown.element);
+            collaboratorRightContainer.dom.appendChild(accessLevelDropdown.dom);
         }
     };
 
@@ -239,7 +239,7 @@ editor.once('load', () => {
     });
     inviteInputGroup.append(inviteInput);
 
-    inviteInput.element.addEventListener('keypress', (evt) => {
+    inviteInput.dom.addEventListener('keypress', (evt) => {
         if (inviteInput.value !== '') {
             inviteInput.placeholder = '';
         }
@@ -305,7 +305,7 @@ editor.once('load', () => {
     ownerProfilePic.dom.style.width = '62px';
     ownerProfilePic.dom.style.height = '62px';
     ownerProfilePic.dom.loading = 'lazy';
-    ownerWidget.element.appendChild(ownerProfilePic.dom);
+    ownerWidget.dom.appendChild(ownerProfilePic.dom);
 
     const ownerWidgetRightContainer = new Container({ class: 'collaborator-right-container' });
     ownerWidget.append(ownerWidgetRightContainer);
@@ -578,7 +578,7 @@ editor.once('load', () => {
             }
 
             // Only populate first time around
-            if (currentProject.access_level !== 'none' && (membersGrid.element.childNodes.length === 0 || uiRefresh)) {
+            if (currentProject.access_level !== 'none' && (membersGrid.dom.childNodes.length === 0 || uiRefresh)) {
 
                 let currentUserIsCollaborator = false;
                 editor.call('projects:getCollaborators', currentProject, (data) => {

--- a/src/editor/pickers/project-management/picker-cms.ts
+++ b/src/editor/pickers/project-management/picker-cms.ts
@@ -61,12 +61,12 @@ editor.once('load', () => {
                 text: `${usage} / ${diskAllowance} Used`,
                 class: 'upgrade-label'
             });
-            upgradeContainer.dom.appendChild(usageLabel.element);
+            upgradeContainer.dom.appendChild(usageLabel.dom);
 
             const usageBarContainer = new Element({
                 class: 'usage-bar-container'
             });
-            upgradeContainer.dom.appendChild(usageBarContainer.element);
+            upgradeContainer.dom.appendChild(usageBarContainer.dom);
 
             const usageBar = new Element({
                 class: 'usage-bar'
@@ -79,7 +79,7 @@ editor.once('load', () => {
                 text: 'UPGRADE',
                 class: 'upgrade-button'
             });
-            upgradeContainer.dom.appendChild(upgradeButton.element);
+            upgradeContainer.dom.appendChild(upgradeButton.dom);
 
             upgradeButton.on('click', () => {
                 window.open(`${config.url.home}/upgrade?account=${currentUser.username}`);
@@ -89,7 +89,7 @@ editor.once('load', () => {
 
     // builds each of the organization dropdown menu items
     const buildOrganizationsUI = (selected = null) => {
-        organizationsToggle.element.childNodes[1].innerHTML = '';
+        organizationsToggle.dom.childNodes[1].innerHTML = '';
 
         // new organization button
         const newOrganizationBtn = new Button({
@@ -119,7 +119,8 @@ editor.once('load', () => {
                 dom: 'img',
                 class: 'organization-icon'
             });
-            organizationImage.element.src = `${config.url.api}/users/${org.id}/thumbnail?size=26`;
+            (organizationImage.dom as HTMLImageElement).src = `${config.url.api}/users/${org.id}/thumbnail?size=26`;
+
             organizationFilter.append(organizationImage);
 
             const organizationName = new Label({
@@ -132,13 +133,13 @@ editor.once('load', () => {
                 class: 'dropdown',
                 icon: 'E159'
             });
-            organizationFilter.append(dropdown.element);
+            organizationFilter.append(dropdown.dom);
 
             organizationFilter.on('click', (e) => {
                 const filterClicks = new Set([
-                    organizationFilter.element,
-                    organizationImage.element,
-                    organizationName.element
+                    organizationFilter.dom,
+                    organizationImage.dom,
+                    organizationName.dom
                 ]);
 
                 if (e.target === dropdown.dom) {
@@ -150,7 +151,7 @@ editor.once('load', () => {
                         orgDropdownMenu.hidden = false;
 
                         // position dropdown menu
-                        const rect = dropdown.element.getBoundingClientRect();
+                        const rect = dropdown.dom.getBoundingClientRect();
                         orgDropdownMenu.position(rect.left, rect.bottom + 3);
                     } else {
                         orgDropdownMenu.hidden = true;
@@ -230,7 +231,7 @@ editor.once('load', () => {
             sortProjects(sortPolicy);
         });
 
-        descendingItem.element.id = 'checkbox-menu-item';
+        descendingItem.dom.id = 'checkbox-menu-item';
 
         sortByModified.on('click', () => {
             updateRadioButtons(modifiedRadio);
@@ -276,7 +277,7 @@ editor.once('load', () => {
         const projectContainer = new Container({
             class: 'project-container'
         });
-        root.dom.appendChild(projectContainer.element);
+        root.dom.appendChild(projectContainer.dom);
 
         const projectThumbnailContainer = new Container({
             class: 'project-thumbnail-container'
@@ -309,7 +310,7 @@ editor.once('load', () => {
 
         // Add Editor settings button to currently open project
         if (!IS_EMPTY_STATE && project.id === currentProject.id) {
-            projectContainer.element.classList.add('currentlyOpen');
+            projectContainer.dom.classList.add('currentlyOpen');
 
             const extendedSettings = new Button({
                 class: 'extended-settings-button',
@@ -358,11 +359,11 @@ editor.once('load', () => {
 
         if (project.access_level !== 'none') {
             const forksLabel = new Label({ class: 'stat', text: `${project.fork_count ? project.fork_count : 0}` });  // forks
-            forksLabel.element.id = 'forks-stat';
+            forksLabel.dom.id = 'forks-stat';
             const viewsLabel = new Label({ class: 'stat', text: `${project.views}` });  // views
-            viewsLabel.element.id = 'views-stat';
+            viewsLabel.dom.id = 'views-stat';
             const playsLabel = new Label({ class: 'stat', text: project.primary_app_url ? `${project.plays}` : 'N/A' });  // plays
-            playsLabel.element.id = 'plays-stat';
+            playsLabel.dom.id = 'plays-stat';
 
             statsContainer.append(forksLabel);
             statsContainer.append(viewsLabel);
@@ -372,13 +373,13 @@ editor.once('load', () => {
         statsContainer.append(sizeLabel);
 
         if (project.disabled) {
-            projectContainer.element.classList.add('disabled');
+            projectContainer.dom.classList.add('disabled');
         }
         if (project.access_level === 'none') {
-            projectContainer.element.classList.add('noAccess');
+            projectContainer.dom.classList.add('noAccess');
         }
         if (project.locked) {
-            projectContainer.element.classList.add('locked');
+            projectContainer.dom.classList.add('locked');
         }
 
     };
@@ -415,10 +416,10 @@ editor.once('load', () => {
     // on closing menu remove 'clicked' class from respective dropdown
     orgDropdownMenu.on('hide', () => {
         if (selectedDropdown) {
-            const clicked = selectedDropdown.element.classList.contains('clicked');
+            const clicked = selectedDropdown.dom.classList.contains('clicked');
             if (clicked) {
                 selectedDropdown.icon = 'E159';
-                selectedDropdown.element.classList.remove('clicked');
+                selectedDropdown.dom.classList.remove('clicked');
             }
         }
     });
@@ -537,7 +538,7 @@ editor.once('load', () => {
         collapsible: true,
         headerText: 'PROJECTS'
     });
-    leftPanel.dom.appendChild(projectsToggle.element);
+    leftPanel.dom.appendChild(projectsToggle.dom);
 
     // filter list
     const allFilter = new Button({
@@ -589,13 +590,13 @@ editor.once('load', () => {
         collapsed: false,
         headerText: 'ORGANIZATIONS'
     });
-    leftPanel.dom.appendChild(organizationsToggle.element);
+    leftPanel.dom.appendChild(organizationsToggle.dom);
 
     const addOrganizationButton = new Button({
         class: 'organization-add',
         icon: 'E370'
     });
-    organizationsToggle.element.childNodes[0].appendChild(addOrganizationButton.element);
+    organizationsToggle.dom.childNodes[0].appendChild(addOrganizationButton.dom);
 
     addOrganizationButton.on('click', () => {
         editor.call('picker:project:newOrganization');
@@ -606,7 +607,7 @@ editor.once('load', () => {
         class: 'misc-container',
         flex: true
     });
-    leftPanel.dom.appendChild(miscContainer.element);
+    leftPanel.dom.appendChild(miscContainer.dom);
 
     // quick links container
     const quickLinksContainer = new Container({
@@ -685,7 +686,7 @@ editor.once('load', () => {
     const controlsContainer = new Container({
         class: 'list-project-controls'
     });
-    rightPanel.dom.appendChild(controlsContainer.element);
+    rightPanel.dom.appendChild(controlsContainer.dom);
 
     const searchBar = new TextInput({
         placeholder: 'Search',
@@ -724,17 +725,17 @@ editor.once('load', () => {
     sortButton.on('click', () => {
         sortingDropdown.hidden = !sortingDropdown.hidden;
 
-        if (sortButton.element.classList.contains('closed')) {
-            sortButton.element.classList.remove('closed');
-            sortButton.element.classList.add('open');
+        if (sortButton.dom.classList.contains('closed')) {
+            sortButton.dom.classList.remove('closed');
+            sortButton.dom.classList.add('open');
         } else {
-            sortButton.element.classList.remove('open');
-            sortButton.element.classList.add('closed');
+            sortButton.dom.classList.remove('open');
+            sortButton.dom.classList.add('closed');
         }
 
         // position dropdown menu
-        const rect = sortButton.element.getBoundingClientRect();
-        const sortingDropdownRect = sortingDropdown.element.getBoundingClientRect();
+        const rect = sortButton.dom.getBoundingClientRect();
+        const sortingDropdownRect = sortingDropdown.dom.getBoundingClientRect();
         sortingDropdown.dom.style.left = `${rect.right - sortingDropdownRect.width}px`;
         sortingDropdown.dom.style.top = `${rect.bottom + 3}px`;
     });
@@ -749,14 +750,14 @@ editor.once('load', () => {
     const projectsContainer = new Element({
         class: 'projects-container-grid'
     });
-    rightPanel.dom.appendChild(projectsContainer.element);
+    rightPanel.dom.appendChild(projectsContainer.dom);
 
     const noProjectsButton = new Button({
         class: 'no-projects-button',
         icon: 'E370',
         hidden: true
     });
-    rightPanel.dom.appendChild(noProjectsButton.element);
+    rightPanel.dom.appendChild(noProjectsButton.dom);
 
     noProjectsButton.on('click', () => {
         editor.call('picker:project:newProject');
@@ -885,7 +886,7 @@ editor.once('load', () => {
         projectsToSearch = [];  // reset projects in view
 
         if (!(currentUser.id in projects) || projects[currentUser.id].length === 0) {
-            projectsContainer.element.innerHTML = '';
+            projectsContainer.dom.innerHTML = '';
             noProjectsButton.hidden = false;
             projects[currentUser.id] = [];
         } else {
@@ -894,7 +895,7 @@ editor.once('load', () => {
             if (events.length > 0) {
                 destroyEvents();
             }
-            projectsContainer.element.innerHTML = '';
+            projectsContainer.dom.innerHTML = '';
             projectsContainer.hidden = projects.length === 0;
             projects[currentUser.id].forEach((proj) => {
                 projectsToSearch.push([proj.name, proj]);
@@ -956,7 +957,7 @@ editor.once('load', () => {
         }
 
         refreshProjects();
-        updateLastText(projectsContainer.element.childNodes, projects[currentUser.id], sorting_policy);
+        updateLastText(projectsContainer.dom.childNodes, projects[currentUser.id], sorting_policy);
     };
 
     // LOCAL UTILS
@@ -1057,8 +1058,8 @@ editor.once('load', () => {
 
         // reset sorting dropdown state
         sortingDropdown.hidden = true;
-        sortButton.element.classList.remove('open');
-        sortButton.element.classList.add('closed');
+        sortButton.dom.classList.remove('open');
+        sortButton.dom.classList.add('closed');
 
         // reset selected to 'All' filter
         setSelectedFilter(allFilter);
@@ -1106,7 +1107,7 @@ editor.once('load', () => {
 
     // hook to refresh list of organizations
     editor.method('picker:project:cms:refreshOrgs', (organization, deleteOrg = false) => {
-        const orgsList = organizationsToggle.element.childNodes[1];
+        const orgsList = organizationsToggle.dom.childNodes[1];
         orgsList.innerHTML = '';
         if (!deleteOrg) {
             rootUser.organizations.push(organization);

--- a/src/editor/pickers/project-management/picker-modal-delete-organization.ts
+++ b/src/editor/pickers/project-management/picker-modal-delete-organization.ts
@@ -161,7 +161,7 @@ editor.once('load', () => {
         organization = editor.call('picker:project:cms:dropdownOrg');
         organizationProjects = projects;
         labelElement.text = `Type the organization name, "${organization.full_name}" in the text box to delete this organization permanently. This action cannot be undone!`;
-        projectsWarning.element.style.display = organizationProjects.length === 0 ? 'none' : 'block';
+        projectsWarning.dom.style.display = organizationProjects.length === 0 ? 'none' : 'block';
         overlay.hidden = false;
     });
 });

--- a/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
@@ -349,7 +349,7 @@ editor.once('load', () => {
 
         const onDragMove = (evt: MouseEvent): void => {
             const rect = panelFrames.innerElement.getBoundingClientRect();
-            const height = draggedPanel.element.offsetHeight;
+            const height = draggedPanel.dom.offsetHeight;
             const top = evt.clientY - rect.top - 6;
             const overPanelIndex = Math.floor(top / height);
             const overPanel = panels[overPanelIndex];
@@ -372,7 +372,7 @@ editor.once('load', () => {
             }
 
             const oldIndex = draggedIndex;
-            const newIndex = Array.prototype.indexOf.call(panelFrames.innerElement.childNodes, draggedPanel.element);
+            const newIndex = Array.prototype.indexOf.call(panelFrames.innerElement.childNodes, draggedPanel.dom);
 
             // change order in sprite asset
             if (oldIndex !== newIndex) {

--- a/src/editor/pickers/store/picker-store.ts
+++ b/src/editor/pickers/store/picker-store.ts
@@ -120,7 +120,7 @@ editor.once('load', () => {
 
             // position dropdown menu
             const parent = overlay.domContent.getBoundingClientRect();
-            const rect = sortButton.element.getBoundingClientRect();
+            const rect = sortButton.dom.getBoundingClientRect();
             const sortingDropdownRect = sortingDropdown.dom.getBoundingClientRect();
             sortingDropdown.dom.style.left = `${rect.right - sortingDropdownRect.width - parent.left}px`;
             sortingDropdown.dom.style.top = `${rect.bottom + 3 - parent.top}px`;
@@ -547,7 +547,7 @@ editor.once('load', () => {
             class: 'load-more-button'
         });
         rightPanel.append(loadMoreButton);
-        intersectionObserver.observe(loadMoreButton.element);
+        intersectionObserver.observe(loadMoreButton.dom);
         loadMoreButton.on('click', () => {
             loadMoreStore();
         });

--- a/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
+++ b/src/editor/pickers/version-control/picker-version-control-checkpoints.ts
@@ -223,7 +223,7 @@ editor.once('load', () => {
 
     // Set the checkpoints to be displayed
     panel.setCheckpoints = function (checkpoints: { id: string; createdAt?: string }[] | null) {
-        const scrollTop = panel.branch != null && panel.scrollTopMap[panel.branch.id] != null ? panel.scrollTopMap[panel.branch.id] : panelCheckpoints.element.scrollTop;
+        const scrollTop = panel.branch != null && panel.scrollTopMap[panel.branch.id] != null ? panel.scrollTopMap[panel.branch.id] : panelCheckpoints.dom.scrollTop;
 
         listCheckpoints.clear();
         lastCheckpointDateDisplayed = null;

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -93,7 +93,7 @@ editor.once('load', () => {
     const searchClear = document.createElement('div');
     searchClear.innerHTML = '&#57650;';
     searchClear.classList.add('clear');
-    search.element.appendChild(searchClear);
+    search.dom.appendChild(searchClear);
 
     searchClear.addEventListener('click', () => {
         search.value = '';
@@ -145,7 +145,7 @@ editor.once('load', () => {
     const btnLoadMoreBranches = new Button({
         text: 'LOAD MORE'
     });
-    loadMoreListItem.element.append(btnLoadMoreBranches.element);
+    loadMoreListItem.element.append(btnLoadMoreBranches.dom);
     btnLoadMoreBranches.on('click', (e: MouseEvent) => {
         e.stopPropagation(); // do not select parent list item on click
         loadBranches();
@@ -781,7 +781,7 @@ editor.once('load', () => {
         item.element.id = `branch-${branch.id}`;
 
         const panel = new Container();
-        item.element.appendChild(panel.element);
+        item.element.appendChild(panel.dom);
 
         const labelIcon = new Label({
             class: 'icon',
@@ -848,7 +848,7 @@ editor.once('load', () => {
             contextBranch = branch;
             menuBranches.contextBranchIsFavorite = item.isFavorite;
             menuBranches.hidden = false;
-            const rect = dropdown.element.getBoundingClientRect();
+            const rect = dropdown.dom.getBoundingClientRect();
             menuBranches.position(rect.right - menuBranches.innerElement.clientWidth, rect.bottom);
         });
 
@@ -1196,7 +1196,7 @@ editor.once('load', () => {
                     const h = editor.call('picker:versioncontrol:transformCheckpointData', data);
                     existingCheckpoints.unshift(h);
                     panelCheckpoints.setCheckpoints(existingCheckpoints);
-                    panelCheckpoints.element.scrollTop = 0;
+                    panelCheckpoints.dom.scrollTop = 0;
                 }
             }
         }));

--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -187,7 +187,7 @@ editor.once('load', () => {
     const launchWithWebGpu = createButton('webgpu', `Launch with WebGPU${editor.projectEngineV2 ? '' : ' (beta)'}`);
 
     const tooltipPreferWebGpu = LegacyTooltip.attach({
-        target: launchWithWebGpu.parent.element,
+        target: launchWithWebGpu.parent.dom,
         text: `Launch the scene using WebGPU${editor.projectEngineV2 ? '' : ' (beta)'}.`,
         align: 'right',
         root: root
@@ -196,7 +196,7 @@ editor.once('load', () => {
 
     const launchWithWebGL2 = createButton('webgl2', 'Launch with WebGL 2.0');
     const tooltipPreferWebGl2 = LegacyTooltip.attach({
-        target: launchWithWebGL2.parent.element,
+        target: launchWithWebGL2.parent.dom,
         text: 'Launch the scene using WebGL 2.0.',
         align: 'right',
         root: root
@@ -205,7 +205,7 @@ editor.once('load', () => {
 
     const launchWithWebGL1 = createButton('webgl1', 'Launch with WebGL 1.0');
     const tooltipPreferWebGl1 = LegacyTooltip.attach({
-        target: launchWithWebGL1.parent.element,
+        target: launchWithWebGL1.parent.dom,
         text: 'Launch the scene using WebGL 1.0.',
         align: 'right',
         root: root
@@ -215,7 +215,7 @@ editor.once('load', () => {
 
     const optionProfiler = createOption('profiler', 'Profiler');
     const tooltipProfiler = LegacyTooltip.attach({
-        target: optionProfiler.parent.element,
+        target: optionProfiler.parent.dom,
         text: 'Enable the visual performance profiler in the launch page.',
         align: 'right',
         root: root
@@ -239,7 +239,7 @@ editor.once('load', () => {
     });
 
     const tooltipDebug = LegacyTooltip.attach({
-        target: optionDebug.parent.element,
+        target: optionDebug.parent.dom,
         text: 'Enable the logging of warning and error messages to the JavaScript console.',
         align: 'right',
         root: root
@@ -249,7 +249,7 @@ editor.once('load', () => {
     if (!legacyScripts) {
         const optionConcatenate = createOption('concatenate', 'Concatenate Scripts (Classic)');
         const tooltipConcatenate = LegacyTooltip.attach({
-            target: optionConcatenate.parent.element,
+            target: optionConcatenate.parent.dom,
             text: 'Concatenate Classic scripts on launch to reduce scene load time.',
             align: 'right',
             root: root
@@ -261,7 +261,7 @@ editor.once('load', () => {
         const optionDisableBundles = createOption('disableBundles', 'Disable Asset Bundles');
 
         const tooltipBundles = LegacyTooltip.attach({
-            target: optionDisableBundles.parent.element,
+            target: optionDisableBundles.parent.dom,
             text: 'Disable loading assets from Asset Bundles.',
             align: 'right',
             root: root
@@ -281,7 +281,7 @@ editor.once('load', () => {
         settings.set('editor.launchMinistats', value);
     });
     LegacyTooltip.attach({
-        target: optionMiniStats.parent.element,
+        target: optionMiniStats.parent.dom,
         text: 'Show the MiniStats in the launched application.',
         align: 'right',
         root: root
@@ -291,7 +291,7 @@ editor.once('load', () => {
     const force = config.engineVersions.force;
     const optionForce = createOption('force', `Force Engine V${force.version[0]}`);
     const tooltipForce = LegacyTooltip.attach({
-        target: optionForce.parent.element,
+        target: optionForce.parent.dom,
         text: `Force the launcher to use v${force.version}.`,
         align: 'right',
         root: root
@@ -311,7 +311,7 @@ editor.once('load', () => {
             settings.set('editor.launchReleaseCandidate', value);
         });
         LegacyTooltip.attach({
-            target: optionReleaseCandidate.parent.element,
+            target: optionReleaseCandidate.parent.dom,
             text: `Launch the scene using the engine release candidate (version ${releaseCandidate}).`,
             align: 'right',
             root: root


### PR DESCRIPTION
## Summary

- Migrate deprecated PCUI `.element` accessor to the recommended `.dom` getter across the editor codebase (pickers, inspector settings panels, attributes, entities, help/guides, chat, viewport-controls, etc.).
- Leave Legacy UI (`src/common/ui/`) instances untouched — `LegacyElement` and its subclasses use `element` intrinsically.
- Skip engine `ElementComponent` access (`entity.element`, `'components.element.*'` config paths) and plain-object `element` fields (e.g. `entry.element`, `ConflictField.element`).
- `innerElement` migrations are out of scope for this PR.

## Files touched

25 files under `src/editor/` — purely a mechanical accessor rename, no behavioural changes.

## Test plan

- [x] `npm run lint` clean on touched files
- [x] `npm run type:check` shows no new errors introduced by this change (pre-existing errors only)
- [x] Smoke-test affected pickers (version-control, builds-publish, project management, conflict manager, sprite editor, store) and inspector panels in a running editor build
