### PR TITLE
chore: use PCUI Button.focus() instead of dom.focus()

### DIFF
--- a/src/editor/pickers/auditor/picker-auditor.ts
+++ b/src/editor/pickers/auditor/picker-auditor.ts
@@ -71,14 +71,14 @@ editor.on('load', () => {
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
             if (document.activeElement === btnCancel.dom) {
-                btnAction.dom.focus();
+                btnAction.focus();
             } else {
-                btnCancel.dom.focus();
+                btnCancel.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnAction.dom.focus();
+            btnAction.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnCancel.dom.focus();
+            btnCancel.focus();
         }
     };
 

--- a/src/editor/pickers/picker-confirm.ts
+++ b/src/editor/pickers/picker-confirm.ts
@@ -67,14 +67,14 @@ editor.once('load', () => {
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
             if (document.activeElement === btnYes.dom) {
-                btnNo.dom.focus();
+                btnNo.focus();
             } else {
-                btnYes.dom.focus();
+                btnYes.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnYes.dom.focus();
+            btnYes.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnNo.dom.focus();
+            btnNo.focus();
         }
     };
 

--- a/src/editor/pickers/picker-engine.ts
+++ b/src/editor/pickers/picker-engine.ts
@@ -63,14 +63,14 @@ editor.once('load', () => {
             }
         } else if (evt.key === 'Tab') { // focus yes / no buttons
             if (document.activeElement === btnCancel.dom) {
-                btnAction.dom.focus();
+                btnAction.focus();
             } else {
-                btnCancel.dom.focus();
+                btnCancel.focus();
             }
         } else if (evt.key === 'ArrowRight') { // focus right button (Yes)
-            btnAction.dom.focus();
+            btnAction.focus();
         } else if (evt.key === 'ArrowLeft') { // focus left button (No)
-            btnCancel.dom.focus();
+            btnCancel.focus();
         }
     };
 


### PR DESCRIPTION
## Summary

- Replace 12 `<pcuiButton>.dom.focus()` call sites with the equivalent `<pcuiButton>.focus()` across `picker-engine.ts`, `picker-confirm.ts`, and `picker-auditor.ts`.
- PCUI's `Button.focus()` already implements `this.dom.focus()` (see `pcui/src/components/Button/index.ts` lines 86-87), so this is a behavioural no-op that hides the underlying DOM access at the call site.
- `document.activeElement === btnXxx.dom` identity comparisons in the same handlers are intentionally left untouched.

## Out of scope

- `picker-entity.ts:129` (`hierarchy.dom.focus()`) is a `TreeView`, which doesn't expose a `focus()` method - left as-is.
- `element-color-input.ts`, `element-gradient-input.ts`, `element-entity-input.ts`, `element-curve-input.ts` each contain `this.dom.focus()` inside their own `focus()` method implementation - replacing those would recurse infinitely.

## Test plan

- [x] Open the engine picker (Settings -> Engine), verify Tab / ArrowLeft / ArrowRight cycle focus between Action and Cancel as before, and Enter activates the focused button.
- [x] Open the confirm picker (e.g. delete asset), verify Tab / ArrowLeft / ArrowRight cycle focus between Yes and No, and Enter activates the focused button.
- [x] Open the auditor picker, verify Tab / ArrowLeft / ArrowRight cycle focus between Action and Cancel, and Enter activates the focused button.
