### PR TITLE
chore: use PCUI Element.class instead of dom.classList

### DIFF
--- a/src/editor/animstategraph/anim-viewer.ts
+++ b/src/editor/animstategraph/anim-viewer.ts
@@ -251,7 +251,7 @@ class AnimViewer extends Container {
     constructor(args: AnimViewerArgs) {
         super(args);
 
-        this.dom.classList.add('anim-viewer');
+        this.class.add('anim-viewer');
 
         this._canvas = new Canvas({
             useDevicePixelRatio: true
@@ -341,12 +341,12 @@ class AnimViewer extends Container {
         this.clearView();
         this._messageLabel.text = text;
         this._messageLabel.hidden = false;
-        this.dom.classList.add('hide');
+        this.class.add('hide');
     }
 
     hideMessage() {
         this._messageLabel.hidden = true;
-        this.dom.classList.remove('hide');
+        this.class.remove('hide');
     }
 
     _setPlaying() {

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -36,22 +36,22 @@ editor.once('load', () => {
             labelPublishDesc.dom.style.display = 'none';
             labelPublishIcon.dom.style.display = 'none';
 
-            btnPublish.dom.classList.add('collapsed');
-            btnDownload.dom.classList.add('collapsed');
+            btnPublish.class.add('collapsed');
+            btnDownload.class.add('collapsed');
 
-            panelPlaycanvas.dom.classList.add('collapsed');
-            panelSelfHost.dom.classList.add('collapsed');
+            panelPlaycanvas.class.add('collapsed');
+            panelSelfHost.class.add('collapsed');
         } else {
             labelDownloadIcon.dom.style.display = 'block';
             labelDownloadDesc.dom.style.display = 'block';
             labelPublishDesc.dom.style.display = 'block';
             labelPublishIcon.dom.style.display = 'block';
 
-            btnPublish.dom.classList.remove('collapsed');
-            btnDownload.dom.classList.remove('collapsed');
+            btnPublish.class.remove('collapsed');
+            btnDownload.class.remove('collapsed');
 
-            panelPlaycanvas.dom.classList.remove('collapsed');
-            panelSelfHost.dom.classList.remove('collapsed');
+            panelPlaycanvas.class.remove('collapsed');
+            panelSelfHost.class.remove('collapsed');
         }
     };
 
@@ -482,8 +482,8 @@ editor.once('load', () => {
             toggleProgress(false);
 
             if (apps.length > 0) {
-                panelPlaycanvas.dom.classList.add('collapsed');
-                panelSelfHost.dom.classList.add('collapsed');
+                panelPlaycanvas.class.add('collapsed');
+                panelSelfHost.class.add('collapsed');
             }
 
             toggleCollapsingPublishButtons(apps.length > 0);

--- a/src/editor/pickers/picker-project-main.ts
+++ b/src/editor/pickers/picker-project-main.ts
@@ -210,9 +210,9 @@ editor.once('load', () => {
     projectURLButton.on('click', () => {
         navigator.clipboard.writeText(`${config.url.home}/editor/project/${currentProject.id}`);
 
-        copiedURLPopup.dom.classList.add('open');
+        copiedURLPopup.class.add('open');
         setTimeout(() => {
-            copiedURLPopup.dom.classList.remove('open');
+            copiedURLPopup.class.remove('open');
         }, 3000);
     });
 
@@ -410,7 +410,7 @@ editor.once('load', () => {
             editor.call('picker:project:cms:refreshProjects');
         }
 
-        copiedURLPopup.dom.classList.remove('open');  // close clipboard popup
+        copiedURLPopup.class.remove('open');  // close clipboard popup
 
         editor.call('picker:project:hideAlerts');
         editor.call('picker:project:hideThumbnailControls');

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -70,7 +70,7 @@ editor.once('load', () => {
             class: 'collaborator-container'
         });
         if (collaborator.id === config.self.id) {
-            parentContainer.dom.classList.add('user-collaborator');
+            parentContainer.class.add('user-collaborator');
         }
         membersGrid.dom.appendChild(parentContainer.dom);
 

--- a/src/editor/pickers/project-management/picker-cms.ts
+++ b/src/editor/pickers/project-management/picker-cms.ts
@@ -36,10 +36,10 @@ editor.once('load', () => {
         if (label !== '') {
             progressLabel.hidden = false;
             progressLabel.text = label;
-            progressBarContainer.dom.classList.add('progress-container-expand');
+            progressBarContainer.class.add('progress-container-expand');
         } else {
             progressLabel.hidden = true;
-            progressBarContainer.dom.classList.remove('progress-container-expand');
+            progressBarContainer.class.remove('progress-container-expand');
         }
     };
 
@@ -310,7 +310,7 @@ editor.once('load', () => {
 
         // Add Editor settings button to currently open project
         if (!IS_EMPTY_STATE && project.id === currentProject.id) {
-            projectContainer.dom.classList.add('currentlyOpen');
+            projectContainer.class.add('currentlyOpen');
 
             const extendedSettings = new Button({
                 class: 'extended-settings-button',
@@ -373,13 +373,13 @@ editor.once('load', () => {
         statsContainer.append(sizeLabel);
 
         if (project.disabled) {
-            projectContainer.dom.classList.add('disabled');
+            projectContainer.class.add('disabled');
         }
         if (project.access_level === 'none') {
-            projectContainer.dom.classList.add('noAccess');
+            projectContainer.class.add('noAccess');
         }
         if (project.locked) {
-            projectContainer.dom.classList.add('locked');
+            projectContainer.class.add('locked');
         }
 
     };
@@ -416,10 +416,10 @@ editor.once('load', () => {
     // on closing menu remove 'clicked' class from respective dropdown
     orgDropdownMenu.on('hide', () => {
         if (selectedDropdown) {
-            const clicked = selectedDropdown.dom.classList.contains('clicked');
+            const clicked = selectedDropdown.class.contains('clicked');
             if (clicked) {
                 selectedDropdown.icon = 'E159';
-                selectedDropdown.dom.classList.remove('clicked');
+                selectedDropdown.class.remove('clicked');
             }
         }
     });
@@ -723,12 +723,12 @@ editor.once('load', () => {
     sortButton.on('click', () => {
         sortingDropdown.hidden = !sortingDropdown.hidden;
 
-        if (sortButton.dom.classList.contains('closed')) {
-            sortButton.dom.classList.remove('closed');
-            sortButton.dom.classList.add('open');
+        if (sortButton.class.contains('closed')) {
+            sortButton.class.remove('closed');
+            sortButton.class.add('open');
         } else {
-            sortButton.dom.classList.remove('open');
-            sortButton.dom.classList.add('closed');
+            sortButton.class.remove('open');
+            sortButton.class.add('closed');
         }
 
         // position dropdown menu
@@ -762,13 +762,13 @@ editor.once('load', () => {
     });
 
     layoutButton.on('click', () => {
-        if (projectsContainer.dom.classList.contains('projects-container-grid')) {
-            projectsContainer.dom.classList.remove('projects-container-grid');
-            projectsContainer.dom.classList.add('projects-container-list');
+        if (projectsContainer.class.contains('projects-container-grid')) {
+            projectsContainer.class.remove('projects-container-grid');
+            projectsContainer.class.add('projects-container-list');
             layoutButton.icon = 'E332';
         } else {
-            projectsContainer.dom.classList.remove('projects-container-list');
-            projectsContainer.dom.classList.add('projects-container-grid');
+            projectsContainer.class.remove('projects-container-list');
+            projectsContainer.class.add('projects-container-grid');
             layoutButton.icon = 'E284';
         }
     });
@@ -1056,8 +1056,8 @@ editor.once('load', () => {
 
         // reset sorting dropdown state
         sortingDropdown.hidden = true;
-        sortButton.dom.classList.remove('open');
-        sortButton.dom.classList.add('closed');
+        sortButton.class.remove('open');
+        sortButton.class.add('closed');
 
         // reset selected to 'All' filter
         setSelectedFilter(allFilter);

--- a/src/editor/pickers/project-management/picker-modal-new-project.ts
+++ b/src/editor/pickers/project-management/picker-modal-new-project.ts
@@ -52,20 +52,20 @@ editor.once('load', () => {
         // Blank project selected by default
         if (starterkit.name === 'Blank Project') {
             selectedKitElement = starterKit;
-            selectedKitElement.dom.classList.add('selected');
+            selectedKitElement.class.add('selected');
         }
 
         starterKit.dom.addEventListener('mouseenter', () => {
-            starterKit.dom.classList.add('hovered');
+            starterKit.class.add('hovered');
         });
 
         starterKit.dom.addEventListener('mouseleave', () => {
-            starterKit.dom.classList.remove('hovered');
+            starterKit.class.remove('hovered');
         });
 
         starterKit.dom.addEventListener('click', () => {
             if (selectedKitElement) {
-                selectedKitElement.dom.classList.remove('selected');
+                selectedKitElement.class.remove('selected');
             }
 
             selectedKitElement = starterKit;
@@ -74,7 +74,7 @@ editor.once('load', () => {
             formInputs.private = false;
             formInputs.fork_from = starterKits[fork].fork_from;
 
-            selectedKitElement.dom.classList.add('selected');
+            selectedKitElement.class.add('selected');
 
             buildSidebar();  // rebuild sidebar
         });


### PR DESCRIPTION
## Summary

- Replaces 39 `element.dom.classList` accesses with the equivalent `element.class` getter across 6 editor files.
- The PCUI `Element` base class exposes `get class(): DOMTokenList` which returns `this._dom.classList`, so this is a 1:1 substitution that uses the public PCUI API.
- Follows the same style as recent PCUI API migration PRs (#2022, #2023, #2025).

## Files touched

- `src/editor/pickers/project-management/picker-cms.ts` (21 occurrences)
- `src/editor/pickers/picker-builds-publish.ts` (10 occurrences)
- `src/editor/pickers/project-management/picker-modal-new-project.ts` (5 occurrences)
- `src/editor/pickers/picker-project-main.ts` (3 occurrences)
- `src/editor/animstategraph/anim-viewer.ts` (3 occurrences of `this.dom.classList`)
- `src/editor/pickers/picker-team-management.ts` (1 occurrence)

## Test plan

- [x] Open the project management modal and confirm currently-open / disabled / no-access / locked project styling still applies.
- [x] Toggle the CMS layout button and sort button and confirm grid/list and open/closed states work.
- [x] Open the new project modal, hover and select starter kits, and confirm hovered/selected styling.
- [x] Open the publish/builds picker, toggle the collapsed state, and confirm panels and buttons collapse correctly.
- [x] Open project main picker, click the URL copy button, and confirm the popup opens then closes after 3s.
- [x] Open the team management picker and confirm the current user's row is highlighted.
- [x] Open the anim state graph viewer and confirm the viewer container shows/hides correctly when displaying messages.
