### PR TITLE
chore: use PCUI Element.style instead of dom.style

### DIFF
--- a/src/code-editor/tab-panel/tab-panel.ts
+++ b/src/code-editor/tab-panel/tab-panel.ts
@@ -220,10 +220,10 @@ editor.once('load', () => {
         }
 
         for (let i = 0; i < tabOrder.length; i++) {
-            tabOrder[i].tab.dom.style.position = 'absolute';
-            tabOrder[i].tab.dom.style.left = `${tabPositions[i]}px`;
-            tabOrder[i].tab.dom.style.width = `${widths[i]}px`;
-            tabOrder[i].tab.dom.style.top = '0';
+            tabOrder[i].tab.style.position = 'absolute';
+            tabOrder[i].tab.style.left = `${tabPositions[i]}px`;
+            tabOrder[i].tab.style.width = `${widths[i]}px`;
+            tabOrder[i].tab.style.top = '0';
         }
 
         // add animated class to other tabs

--- a/src/editor/animstategraph/view.ts
+++ b/src/editor/animstategraph/view.ts
@@ -918,8 +918,8 @@ class AnimStateGraphView {
 
         const viewportCanvas = editor.call('viewport:canvas');
         this._events.push(viewportCanvas.on('resize', () => {
-            this._graph.dom.style.width = viewportCanvas.style.width;
-            this._graph.dom.style.height = viewportCanvas.style.height;
+            this._graph.style.width = viewportCanvas.style.width;
+            this._graph.style.height = viewportCanvas.style.height;
         }));
 
         // add keyboard listener

--- a/src/editor/entities/entities-panel.ts
+++ b/src/editor/entities/entities-panel.ts
@@ -126,7 +126,7 @@ editor.once('load', () => {
         for (const { button, top, visible } of updates) {
             if (visible) {
                 button.hidden = false;
-                button.dom.style.top = `${top}px`;
+                button.style.top = `${top}px`;
             } else {
                 button.hidden = true;
             }

--- a/src/editor/guides/guide-intro.ts
+++ b/src/editor/guides/guide-intro.ts
@@ -151,8 +151,8 @@ editor.once('load', () => {
             editor.call('layout.toolbar')
         );
 
-        bubble.dom.style.top = '';
-        bubble.dom.style.bottom = '119px';
+        bubble.style.top = '';
+        bubble.style.bottom = '119px';
         return bubble;
     };
 
@@ -167,8 +167,8 @@ editor.once('load', () => {
             editor.call('layout.viewport')
         );
 
-        bubble.dom.style.left = '';
-        bubble.dom.style.right = '6px';
+        bubble.style.left = '';
+        bubble.style.right = '6px';
 
         return bubble;
     };

--- a/src/editor/help/howdoi.ts
+++ b/src/editor/help/howdoi.ts
@@ -92,8 +92,8 @@ editor.once('load', () => {
             editor.call('layout.toolbar')
         );
 
-        b.dom.style.top = '';
-        b.dom.style.bottom = '130px';
+        b.style.top = '';
+        b.style.bottom = '130px';
         return b;
     };
 

--- a/src/editor/inspector/attributes-inspector.ts
+++ b/src/editor/inspector/attributes-inspector.ts
@@ -244,7 +244,7 @@ class AttributesInspector extends Container {
                     });
 
                     if (((target instanceof LabelGroup) || (target instanceof AssetInput)) && type !== 'label') {
-                        target.label.dom.style.position = 'relative';
+                        target.label.style.position = 'relative';
 
                         // paste button
                         const btnPaste = new Button({

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -31,10 +31,10 @@ editor.once('load', () => {
     // collapses publish and download buttons
     const toggleCollapsingPublishButtons = (collapse = true) => {
         if (collapse) {
-            labelDownloadIcon.dom.style.display = 'none';
-            labelDownloadDesc.dom.style.display = 'none';
-            labelPublishDesc.dom.style.display = 'none';
-            labelPublishIcon.dom.style.display = 'none';
+            labelDownloadIcon.style.display = 'none';
+            labelDownloadDesc.style.display = 'none';
+            labelPublishDesc.style.display = 'none';
+            labelPublishIcon.style.display = 'none';
 
             btnPublish.class.add('collapsed');
             btnDownload.class.add('collapsed');
@@ -42,10 +42,10 @@ editor.once('load', () => {
             panelPlaycanvas.class.add('collapsed');
             panelSelfHost.class.add('collapsed');
         } else {
-            labelDownloadIcon.dom.style.display = 'block';
-            labelDownloadDesc.dom.style.display = 'block';
-            labelPublishDesc.dom.style.display = 'block';
-            labelPublishIcon.dom.style.display = 'block';
+            labelDownloadIcon.style.display = 'block';
+            labelDownloadDesc.style.display = 'block';
+            labelPublishDesc.style.display = 'block';
+            labelPublishIcon.style.display = 'block';
 
             btnPublish.class.remove('collapsed');
             btnDownload.class.remove('collapsed');

--- a/src/editor/pickers/picker-message.ts
+++ b/src/editor/pickers/picker-message.ts
@@ -117,9 +117,9 @@ editor.once('load', () => {
         btnOK.text = okText || 'OK';
         if (cancelText) {
             btnCancel.text = cancelText;
-            btnCancel.dom.style.display = 'flex';
+            btnCancel.style.display = 'flex';
         } else {
-            btnCancel.dom.style.display = 'none';
+            btnCancel.style.display = 'none';
         }
         overlay.hidden = false;
     });

--- a/src/editor/pickers/picker-project-main.ts
+++ b/src/editor/pickers/picker-project-main.ts
@@ -33,9 +33,9 @@ editor.once('load', () => {
         if (toggle) {
             exportProjectButton.text = '';
             exportProjectButton.dom.setAttribute('data-icon', '');
-            loader.dom.style.display = 'block';
+            loader.style.display = 'block';
         } else {
-            loader.dom.style.display = 'none';
+            loader.style.display = 'none';
             exportProjectButton.text = getExportButtonText();
             exportProjectButton.icon = 'E228';
         }
@@ -82,7 +82,7 @@ editor.once('load', () => {
         text: 'UNLOCK'
     });
     lockedContainer.append(unlockButton);
-    lockedContainer.dom.style.display = 'none';  // hide by default
+    lockedContainer.style.display = 'none';  // hide by default
 
     unlockButton.on('click', () => {
         editor.call('projects:unlockOne', currentProject.id, () => {
@@ -237,7 +237,7 @@ editor.once('load', () => {
     const loader = new Element({
         class: ['loader', 'xsmall', 'white']
     });
-    loader.dom.style.display = 'none';
+    loader.style.display = 'none';
     exportProjectButtonContainer.append(loader);
 
     exportProjectButton.on('click', () => {
@@ -457,12 +457,12 @@ editor.once('load', () => {
 
         // only show locked view if locked project
         if (currentProject.locked) {
-            lockedContainer.dom.style.display = 'flex';
-            settingsContainer.dom.style.display = 'none';
+            lockedContainer.style.display = 'flex';
+            settingsContainer.style.display = 'none';
         } else {
             // only show settings container if not locked project
-            settingsContainer.dom.style.display = 'flex';
-            lockedContainer.dom.style.display = 'none';
+            settingsContainer.style.display = 'flex';
+            lockedContainer.style.display = 'none';
         }
 
         // only show delete project button if not current project and admin

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -125,12 +125,12 @@ editor.once('load', () => {
         if (currentProject.thumbnails) {
             projectImg.style.backgroundImage = `url("${currentProject.thumbnails.m}")`;
             deleteButton.hidden = false;
-            replaceButton.dom.style.marginRight = '0px';
+            replaceButton.style.marginRight = '0px';
         } else {
             projectImg.style.backgroundImage = EMPTY_THUMBNAIL_IMAGE;
             // Disable delete thumbnail button if no thumbnails
             deleteButton.hidden = true;
-            replaceButton.dom.style.marginRight = '6px';
+            replaceButton.style.marginRight = '6px';
         }
 
         if (reducedView) {
@@ -377,7 +377,7 @@ editor.once('load', () => {
 
         statsContainer.style.backgroundImage = 'linear-gradient(rgba(0, 0, 0, 0.8) 15%, transparent)';
         deleteButton.hidden = false;
-        replaceButton.dom.style.marginRight = '0px';
+        replaceButton.style.marginRight = '0px';
     });
 
     // store all panels for each menu option
@@ -412,7 +412,7 @@ editor.once('load', () => {
         deleteThumbnail();
         // Hide delete button and adjust margin
         deleteButton.hidden = true;
-        replaceButton.dom.style.marginRight = '6px';
+        replaceButton.style.marginRight = '6px';
     });
 
     // menu
@@ -807,7 +807,7 @@ editor.once('load', () => {
     // hook to hide all alerts
     editor.method('picker:project:hideAlerts', () => {
         alerts.forEach((alert) => {
-            alert.dom.style.display = 'none';
+            alert.style.display = 'none';
             alert.destroy();
         });
         alerts = [];

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -296,14 +296,14 @@ editor.once('load', () => {
 
     const ownerWidget = new Container({ class: 'collaborator-container' });
     ownerWidgetContainer.append(ownerWidget);
-    ownerWidget.dom.style.width = '307.6px';
+    ownerWidget.style.width = '307.6px';
 
     const ownerProfilePic = new Element({
         dom: 'img',
         class: 'collaborator-image'
     });
-    ownerProfilePic.dom.style.width = '62px';
-    ownerProfilePic.dom.style.height = '62px';
+    ownerProfilePic.style.width = '62px';
+    ownerProfilePic.style.height = '62px';
     ownerProfilePic.dom.loading = 'lazy';
     ownerWidget.dom.appendChild(ownerProfilePic.dom);
 

--- a/src/editor/pickers/project-management/picker-cms.ts
+++ b/src/editor/pickers/project-management/picker-cms.ts
@@ -71,7 +71,7 @@ editor.once('load', () => {
             const usageBar = new Element({
                 class: 'usage-bar'
             });
-            usageBar.dom.style.width = `${percentageUsed}%`;
+            usageBar.style.width = `${percentageUsed}%`;
             usageBarContainer.append(usageBar);
 
             // upgrade button
@@ -734,8 +734,8 @@ editor.once('load', () => {
         // position dropdown menu
         const rect = sortButton.dom.getBoundingClientRect();
         const sortingDropdownRect = sortingDropdown.dom.getBoundingClientRect();
-        sortingDropdown.dom.style.left = `${rect.right - sortingDropdownRect.width}px`;
-        sortingDropdown.dom.style.top = `${rect.bottom + 3}px`;
+        sortingDropdown.style.left = `${rect.right - sortingDropdownRect.width}px`;
+        sortingDropdown.style.top = `${rect.bottom + 3}px`;
     });
 
     const layoutButton = new Button({

--- a/src/editor/pickers/project-management/picker-modal-delete-organization.ts
+++ b/src/editor/pickers/project-management/picker-modal-delete-organization.ts
@@ -161,7 +161,7 @@ editor.once('load', () => {
         organization = editor.call('picker:project:cms:dropdownOrg');
         organizationProjects = projects;
         labelElement.text = `Type the organization name, "${organization.full_name}" in the text box to delete this organization permanently. This action cannot be undone!`;
-        projectsWarning.dom.style.display = organizationProjects.length === 0 ? 'none' : 'block';
+        projectsWarning.style.display = organizationProjects.length === 0 ? 'none' : 'block';
         overlay.hidden = false;
     });
 });

--- a/src/editor/pickers/project-management/picker-modal-delete-project-confirmation.ts
+++ b/src/editor/pickers/project-management/picker-modal-delete-project-confirmation.ts
@@ -11,9 +11,9 @@ editor.once('load', () => {
     const toggleLoader = (toggle) => {
         if (toggle) {
             deleteButton.text = '';
-            loader.dom.style.display = 'block';
+            loader.style.display = 'block';
         } else {
-            loader.dom.style.display = 'none';
+            loader.style.display = 'none';
             deleteButton.text = 'DELETE';
         }
     };
@@ -81,7 +81,7 @@ editor.once('load', () => {
     const loader = new Element({
         class: ['loader', 'small', 'white']
     });
-    loader.dom.style.display = 'none';
+    loader.style.display = 'none';
 
     deleteButtonContainer.append(loader);
 

--- a/src/editor/pickers/store/picker-store.ts
+++ b/src/editor/pickers/store/picker-store.ts
@@ -122,8 +122,8 @@ editor.once('load', () => {
             const parent = overlay.domContent.getBoundingClientRect();
             const rect = sortButton.dom.getBoundingClientRect();
             const sortingDropdownRect = sortingDropdown.dom.getBoundingClientRect();
-            sortingDropdown.dom.style.left = `${rect.right - sortingDropdownRect.width - parent.left}px`;
-            sortingDropdown.dom.style.top = `${rect.bottom + 3 - parent.top}px`;
+            sortingDropdown.style.left = `${rect.right - sortingDropdownRect.width - parent.left}px`;
+            sortingDropdown.style.top = `${rect.bottom + 3 - parent.top}px`;
         });
     };
 

--- a/src/editor/pickers/version-control/ui/version-control-side-panel-box.ts
+++ b/src/editor/pickers/version-control/ui/version-control-side-panel-box.ts
@@ -96,8 +96,8 @@ class VersionControlSidePanelBox extends Events {
                 'Close branch after merging?',
                 args.closeSourceBranchHelp
             );
-            this.panelSourceClose.dom.style.paddingTop = '0';
-            this.panelSourceClose.dom.style.borderTop = '0';
+            this.panelSourceClose.style.paddingTop = '0';
+            this.panelSourceClose.style.borderTop = '0';
 
             this.checkboxSourceClose.on('change', (value: boolean) => {
                 this.emit('closeSourceBranch', value);


### PR DESCRIPTION
## Summary

- Replaces 51 `element.dom.style` accesses with the equivalent `element.style` getter across 16 editor files.
- The PCUI `Element` base class exposes `get style(): CSSStyleDeclaration` which returns `this._dom.style`, so this is a 1:1 substitution that uses the public PCUI API.
- Follow-up to #2026; same pattern as recent PCUI API migration PRs (#2022, #2023, #2025).
- The 2 `vc.dom.style` hits in `src/editor/viewport/gizmo/gizmo-view-cube.ts` were intentionally left alone because `vc` is a `playcanvas.ViewCube` (engine extras, `extends EventHandler`), not a PCUI `Element`.

## Files touched

- `src/editor/pickers/picker-project-main.ts` (8 occurrences)
- `src/editor/pickers/picker-builds-publish.ts` (8 occurrences)
- `src/editor/pickers/picker-project.ts` (5 occurrences)
- `src/editor/guides/guide-intro.ts` (4 occurrences)
- `src/code-editor/tab-panel/tab-panel.ts` (4 occurrences)
- `src/editor/pickers/project-management/picker-cms.ts` (3 occurrences)
- `src/editor/pickers/picker-team-management.ts` (3 occurrences)
- `src/editor/pickers/project-management/picker-modal-delete-project-confirmation.ts` (3 occurrences)
- `src/editor/pickers/store/picker-store.ts` (2 occurrences)
- `src/editor/help/howdoi.ts` (2 occurrences)
- `src/editor/pickers/version-control/ui/version-control-side-panel-box.ts` (2 occurrences)
- `src/editor/animstategraph/view.ts` (2 occurrences)
- `src/editor/pickers/picker-message.ts` (2 occurrences)
- `src/editor/pickers/project-management/picker-modal-delete-organization.ts` (1 occurrence)
- `src/editor/inspector/attributes-inspector.ts` (1 occurrence)
- `src/editor/entities/entities-panel.ts` (1 occurrence)

## Test plan

- [x] Open the project management modal: confirm sort dropdown positioning, usage bar width, and layout still render correctly.
- [x] Open the new project / delete project / delete organization modals: confirm spinners and warning visibility toggles still work.
- [x] Open the publish/builds picker, toggle collapsed state: confirm download/publish labels show/hide correctly.
- [x] Open project main picker, click export: confirm loader appears/disappears; toggle locked vs settings views.
- [x] Open the team management picker: confirm owner widget width and profile pic sizing are unchanged.
- [x] Open store picker: confirm sort dropdown menu is positioned correctly.
- [x] Trigger the help / how-do-I bubble and the intro guide bubbles: confirm bubble positioning is unchanged.
- [x] Open version control side panel and confirm "Close branch after merging?" panel padding/border styling is unchanged.
- [x] Open animstategraph viewer and resize viewport: confirm graph resizes with the canvas.
- [x] Open picker-message dialog with and without cancel text: confirm cancel button visibility.
- [x] Drag tabs in the code editor tab panel: confirm tabs animate to absolute positions correctly.
- [x] Reorder entities and watch the inline-add buttons reposition correctly.
- [x] Right-click an attribute label in the inspector to confirm the contextual paste button still positions correctly.
