### PR TITLE
chore: use PCUI TextInput keydown event instead of DOM listener

### DIFF
--- a/src/editor/chat/chat-widget.ts
+++ b/src/editor/chat/chat-widget.ts
@@ -338,16 +338,14 @@ editor.once('load', () => {
         }
     });
 
-    input.dom.addEventListener('keydown', (evt: KeyboardEvent) => {
-        if (evt.keyCode === 27) {
-            // esc
+    input.on('keydown', (evt: KeyboardEvent) => {
+        if (evt.key === 'Escape') {
             input.value = '';
             onTypingEnd();
-        } else if (evt.keyCode === 13) {
-            // enter
+        } else if (evt.key === 'Enter') {
             editor.call('chat:send', input.value);
             input.value = '';
             onTypingEnd();
         }
-    }, false);
+    });
 });

--- a/src/editor/pickers/picker-scene.ts
+++ b/src/editor/pickers/picker-scene.ts
@@ -363,7 +363,7 @@ editor.once('load', () => {
             newScene.enabled = true;
         });
 
-        input.dom.addEventListener('keydown', (e) => {
+        input.on('keydown', (e: KeyboardEvent) => {
             if (e.key === 'Enter') {
                 if (!input.value) {
                     return;

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -239,7 +239,7 @@ editor.once('load', () => {
     });
     inviteInputGroup.append(inviteInput);
 
-    inviteInput.dom.addEventListener('keypress', (evt) => {
+    inviteInput.on('keydown', (evt: KeyboardEvent) => {
         if (inviteInput.value !== '') {
             inviteInput.placeholder = '';
         }


### PR DESCRIPTION
## Summary

Replace raw `someInput.dom.addEventListener('keydown'/'keypress', ...)` listeners on PCUI `TextInput` instances with the idiomatic `someInput.on('keydown', ...)` API. PCUI's `InputElement` already re-emits `keydown` through its event emitter, so reaching into the underlying DOM element is unnecessary (and `input.dom` is the wrapping `<div>`, not the `<input>`).

Also modernizes the chat widget's deprecated `evt.keyCode` checks to `evt.key === 'Enter' / 'Escape'`, and replaces the deprecated `keypress` event in `picker-team-management.ts` with `keydown`.

Files touched:
- `src/editor/chat/chat-widget.ts`
- `src/editor/pickers/picker-scene.ts`
- `src/editor/pickers/picker-team-management.ts`

## Test plan

- [x] Chat widget: typing + Enter sends a message, Escape clears the input.
- [x] Scene picker: clicking "New Scene", typing a name and pressing Enter creates and loads the scene.
- [x] Team management: invite input accepts Enter to add a collaborator and clears placeholder when typing.
