### PR TITLE
chore: bump playcanvas to 2.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.18.0",
+        "playcanvas": "2.18.1",
         "postcss": "8.5.8",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8592,9 +8592,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.0.tgz",
-      "integrity": "sha512-UufnnYsYuTCQaeFvYiSjUrDTcX7jNfy8cOydAoAySK323nLVi+8CL+lzFcWUvB5J2LRoT2oYJnPby37/6O084A==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.1.tgz",
+      "integrity": "sha512-R+60EWFgPwgwqvnzP81sZbRfwJdL8EG5MLV+vJ+aeG6+Djt4IvpfJAHzYKRHak0I4oYtCCZwdLBygFboLBMCWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.18.0",
+    "playcanvas": "2.18.1",
     "postcss": "8.5.8",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
### What's Changed
- Bump `playcanvas` engine from 2.18.0 to 2.18.1 (latest patch)
- Regenerate `package-lock.json`

### Checks
- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)