### PR TITLE
feat: assign unique names to new assets within a folder

### DIFF
--- a/sass/code-editor.scss
+++ b/sass/code-editor.scss
@@ -405,10 +405,15 @@ strong {
         }
 
         > .validate {
-            float: right;
-            margin: 2px 0 0;
+            margin: 0 0 8px;
             font-size: 12px;
             color: #f30;
+            white-space: normal;
+            word-break: break-word;
+
+            &:not(.pcui-hidden) {
+                display: block;
+            }
         }
     }
 }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -913,10 +913,17 @@ strong {
         }
 
         > .validate {
-            float: right;
-            margin: 2px 0 0;
+            margin: 0 0 8px;
             font-size: 12px;
             color: #f30;
+            white-space: normal;
+            word-break: break-word;
+
+            // qualify with :not(.pcui-hidden) so PCUI's display:none keeps winning
+            // when the label is hidden (specificity wars with .pcui-element.pcui-hidden)
+            &:not(.pcui-hidden) {
+                display: block;
+            }
         }
     }
 }

--- a/src/code-editor/assets/assets-create-css.ts
+++ b/src/code-editor/assets/assets-create-css.ts
@@ -1,25 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:css', (args) => {
+    editor.method('assets:create:css', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Css',
-            type: 'css',
-            source: false,
-            preload: true,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            filename: 'asset.css',
-            file: new Blob(['\n'], { type: 'text/css' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createCss({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/assets/assets-create-folder.ts
+++ b/src/code-editor/assets/assets-create-folder.ts
@@ -1,24 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:folder', (args) => {
+    editor.method('assets:create:folder', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Folder',
-            type: 'folder',
-            source: true,
-            preload: false,
-            data: null,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createFolder({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/assets/assets-create-html.ts
+++ b/src/code-editor/assets/assets-create-html.ts
@@ -1,25 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:html', (args) => {
+    editor.method('assets:create:html', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Html',
-            type: 'html',
-            source: false,
-            preload: true,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            filename: 'asset.html',
-            file: new Blob(['\n'], { type: 'text/html' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createHtml({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/assets/assets-create-json.ts
+++ b/src/code-editor/assets/assets-create-json.ts
@@ -1,25 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:json', (args) => {
+    editor.method('assets:create:json', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Json',
-            type: 'json',
-            source: false,
-            preload: true,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            filename: 'asset.json',
-            file: new Blob(['{ }'], { type: 'application/json' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createJson({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/assets/assets-create-script.ts
+++ b/src/code-editor/assets/assets-create-script.ts
@@ -1,6 +1,21 @@
 import { Asset } from '@/editor-api';
 
 editor.once('load', () => {
+    editor.method('assets:script:checkCollision', (filename: string, parent: any) => {
+        const parentId = parent ? parent.get('id') : null;
+        const collision = editor.call('assets:list').some((asset: any) => {
+            if (asset.get('type') !== 'script') {
+                return false;
+            }
+            const path = asset.get('path');
+            const folder = path && path.length ? path[path.length - 1] : null;
+            const isSameFolder = (folder ?? null) === (parentId ?? null);
+            const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
+            return isSameFolder && isSameFile;
+        });
+        return collision ? `A script named "${filename}" already exists in this folder. Please use another name.` : null;
+    });
+
     editor.method('assets:create:script', (args: { filename?: string; parent?: any; text?: string } = {}, callback: (asset: unknown) => void = () => {}) => {
         if (!editor.call('permissions:write')) {
             return;
@@ -12,21 +27,9 @@ editor.once('load', () => {
             text
         } = args;
 
-        const parentId = parent ? parent.get('id') : null;
-
-        const hasExistingScript = editor.call('assets:list').some((asset: any) => {
-            if (asset.get('type') !== 'script') {
-                return false;
-            }
-            const path = asset.get('path');
-            const folder = path && path.length ? path[path.length - 1] : null;
-            const isSameFolder = (folder ?? null) === (parentId ?? null);
-            const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
-            return isSameFolder && isSameFile;
-        });
-
-        if (hasExistingScript) {
-            editor.call('status:error', `A script named "${filename}" already exists in this folder. Please use another name.`);
+        const collisionError = editor.call('assets:script:checkCollision', filename, parent);
+        if (collisionError) {
+            editor.call('status:error', collisionError);
             return;
         }
 

--- a/src/code-editor/assets/assets-create-script.ts
+++ b/src/code-editor/assets/assets-create-script.ts
@@ -1,18 +1,42 @@
+import { Asset } from '@/editor-api';
+
 editor.once('load', () => {
-    editor.method('assets:create:script', (args: { filename?: string; parent?: unknown } = {}, callback: (asset: unknown) => void = () => {}) => {
+    editor.method('assets:create:script', (args: { filename?: string; parent?: any; text?: string } = {}, callback: (asset: unknown) => void = () => {}) => {
         if (!editor.call('permissions:write')) {
             return;
         }
 
         const {
             filename = 'script.js',
-            parent = editor.call('assets:selected:folder')
+            parent = editor.call('assets:selected:folder'),
+            text
         } = args;
 
+        const parentId = parent ? parent.get('id') : null;
+
+        const hasExistingScript = editor.call('assets:list').some((asset: any) => {
+            if (asset.get('type') !== 'script') {
+                return false;
+            }
+            const path = asset.get('path');
+            const folder = path && path.length ? path[path.length - 1] : null;
+            const isSameFolder = (folder ?? null) === (parentId ?? null);
+            const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
+            return isSameFolder && isSameFile;
+        });
+
+        if (hasExistingScript) {
+            editor.call('status:error', `A script named "${filename}" already exists in this folder. Please use another name.`);
+            return;
+        }
+
+        const folder = parent?.apiAsset ?? parent ?? undefined;
+
         editor.api.globals.assets.createScript({
-            filename: filename,
-            folder: parent
-        }).then((asset: unknown) => {
+            filename,
+            folder,
+            text
+        }).then((asset: Asset) => {
             callback(asset);
         }).catch((err: unknown) => {
             editor.call('status:error', err);

--- a/src/code-editor/assets/assets-create-shader.ts
+++ b/src/code-editor/assets/assets-create-shader.ts
@@ -1,25 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:shader', (args?: { parent?: unknown }) => {
+    editor.method('assets:create:shader', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Shader',
-            type: 'shader',
-            source: false,
-            preload: true,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            filename: 'asset.glsl',
-            file: new Blob(['\n'], { type: 'text/x-glsl' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createShader({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/assets/assets-create-text.ts
+++ b/src/code-editor/assets/assets-create-text.ts
@@ -1,25 +1,14 @@
 editor.once('load', () => {
-    editor.method('assets:create:text', (args?: { parent?: unknown }) => {
+    editor.method('assets:create:text', (args?: { parent?: any }) => {
         if (!editor.call('permissions:write')) {
             return;
         }
+        args = args || {};
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        args = args || { };
-
-        const asset = {
-            name: 'New Text',
-            type: 'text',
-            source: false,
-            preload: true,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:selected:folder'),
-            filename: 'asset.txt',
-            file: new Blob(['\n'], { type: 'text/plain' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createText({ folder }).catch((err: unknown) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/code-editor/files-panel/files-panel.ts
+++ b/src/code-editor/files-panel/files-panel.ts
@@ -24,7 +24,10 @@ editor.once('load', () => {
     // Handle tree item renaming via the context menu
     tree.on('rename', (item: TreeViewItem, name: string) => {
         const asset = editor.call('assets:get', item._assetId);
-        editor.call('assets:rename', asset, name);
+        const error = editor.call('assets:rename', asset, name);
+        if (error) {
+            item.text = asset.get('name');
+        }
     });
 
     // Loading progress bar (doesn't actually work since the UI never get a chance to update)

--- a/src/code-editor/menu-panel/file/create.ts
+++ b/src/code-editor/menu-panel/file/create.ts
@@ -108,6 +108,7 @@ editor.once('load', () => {
         }
 
         if (type === 'script') {
+            const validate = (name: string) => editor.call('assets:script:checkCollision', name, folder);
             editor.call('picker:script-create', (filename: string) => {
                 editor.call('assets:create:script', {
                     filename: filename,
@@ -150,7 +151,7 @@ editor.once('load', () => {
                         asset.once('file.filename:set', parseScript);
                     }
                 });
-            });
+            }, undefined, validate);
         } else {
             editor.call(`assets:create:${type}`, {
                 parent: folder

--- a/src/code-editor/pickers/picker-script-create.ts
+++ b/src/code-editor/pickers/picker-script-create.ts
@@ -2,8 +2,11 @@ import { Label, Overlay, TextInput } from '@playcanvas/pcui';
 
 import { normalizeScriptName } from '@/common/script-names';
 
+const INVALID_FILENAME = 'Invalid filename';
+
 editor.once('load', () => {
     let callback: ((name: string) => void) | null = null;
+    let extraValidate: ((filename: string) => string | null) | null = null;
 
     const overlay = new Overlay({
         class: 'picker-script-create',
@@ -18,7 +21,7 @@ editor.once('load', () => {
 
     const validate = new Label({
         class: 'validate',
-        text: 'Invalid filename',
+        text: INVALID_FILENAME,
         hidden: true
     });
     overlay.append(validate);
@@ -29,15 +32,43 @@ editor.once('load', () => {
     });
     overlay.append(input);
 
+    const evaluate = (raw: string): { name: string | null; error: string | null } => {
+        const name = normalizeScriptName(raw);
+        if (name === null) {
+            return { name: null, error: INVALID_FILENAME };
+        }
+        const extra = extraValidate?.(name) ?? null;
+        return { name, error: extra };
+    };
+
     const onInputChange = () => {
-        validate.hidden = normalizeScriptName(input.value) !== null;
+        // empty input is the "neutral" state — show no error until the user types
+        if (!input.value) {
+            validate.hidden = true;
+            return;
+        }
+        const { error } = evaluate(input.value);
+        if (error) {
+            validate.text = error;
+            validate.hidden = false;
+        } else {
+            validate.hidden = true;
+        }
     };
 
     const onInputKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Enter') {
-            const normalizedScriptName = normalizeScriptName(input.value);
-            if (normalizedScriptName !== null) {
-                callback?.(normalizedScriptName);
+            if (!input.value) {
+                return;
+            }
+            const { name, error } = evaluate(input.value);
+            if (error) {
+                validate.text = error;
+                validate.hidden = false;
+                return;
+            }
+            if (name !== null) {
+                callback?.(name);
                 overlay.hidden = true;
             }
         }
@@ -63,16 +94,24 @@ editor.once('load', () => {
         input.unbind('change', onInputChange);
         input.unbind('keydown', onInputKeyDown);
         window.removeEventListener('keydown', onWindowKeyDown, true);
+        extraValidate = null;
+        validate.text = INVALID_FILENAME;
+        validate.hidden = true;
         editor.emit('picker:script-create:close');
     });
 
     editor.method('picker:script-create:validate', normalizeScriptName);
 
-    editor.method('picker:script-create', (fn: ((name: string) => void) | null, string?: string) => {
+    editor.method('picker:script-create', (fn: ((name: string) => void) | null, string?: string, validator?: (filename: string) => string | null) => {
         callback = fn ?? null;
+        extraValidate = validator ?? null;
         overlay.hidden = false;
+        validate.text = INVALID_FILENAME;
         validate.hidden = true;
         input.value = string ?? '';
+        if (input.value) {
+            onInputChange();
+        }
         input.focus(true);
     });
 

--- a/src/editor-api/assets.ts
+++ b/src/editor-api/assets.ts
@@ -4,6 +4,7 @@ import { Asset, AssetObserver } from './asset';
 import { createScript } from './assets/create-script';
 import { createTemplate } from './assets/create-template';
 import { instantiateTemplates } from './assets/instantiate-templates';
+import { getUniqueName, siblingNames } from './assets/unique-name';
 import { uploadFile } from './assets/upload';
 import { Entity } from './entity';
 import { globals as api } from './globals';
@@ -141,6 +142,8 @@ export type SceneImportSettings = {
      */
     animUseFbxFilename?: boolean;
 };
+
+export { getUniqueName, siblingNames } from './assets/unique-name';
 
 /**
  * The Assets Editor API
@@ -673,11 +676,13 @@ class Assets extends Events {
      * @returns The new asset
      */
     createCss(options: { name?: string; text?: string; folder?: Asset; preload?: boolean; onProgress?: Function; } = {}) {
+        const desired = options.name || 'new.css';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Css',
+            name,
             type: 'css',
             folder: options.folder,
-            filename: 'asset.css',
+            filename: name,
             file: new Blob([options.text || '\n'], { type: 'text/css' }),
             preload: options.preload
         }, null, options.onProgress);
@@ -727,8 +732,10 @@ class Assets extends Events {
      * @returns The new asset
      */
     createFolder(options: { name?: string; folder?: Asset; onProgress?: Function; }) {
+        const desired = options.name || 'folder';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Folder',
+            name,
             type: 'folder',
             folder: options.folder
         }, null, options.onProgress);
@@ -745,12 +752,14 @@ class Assets extends Events {
      * @returns The new asset
      */
     createHtml(options: { name?: string; text?: string; folder?: Asset; preload?: boolean; onProgress?: Function; } = {}) {
+        const desired = options.name || 'new.html';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Html',
+            name,
             type: 'html',
             folder: options.folder,
             preload: options.preload,
-            filename: 'asset.html',
+            filename: name,
             file: new Blob([options.text || '\n'], { type: 'text/html' })
         }, null, options.onProgress);
     }
@@ -771,12 +780,14 @@ class Assets extends Events {
         const spaces = options.spaces ?? 0;
         const str = JSON.stringify(options.json || {}, null, spaces);
 
+        const desired = options.name || 'new.json';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Json',
+            name,
             type: 'json',
             folder: options.folder,
             preload: options.preload,
-            filename: 'asset.json',
+            filename: name,
             file: new Blob([str], { type: 'application/json' })
         }, null, options.onProgress);
     }
@@ -916,12 +927,14 @@ class Assets extends Events {
      * @returns The new asset
      */
     createShader(options: { name?: string; text?: string; folder?: Asset; preload?: boolean; onProgress?: Function; } = {}) {
+        const desired = options.name || 'new.glsl';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Shader',
+            name,
             type: 'shader',
             folder: options.folder,
             preload: options.preload,
-            filename: 'asset.glsl',
+            filename: name,
             file: new Blob([options.text || '\n'], { type: 'text/x-glsl' })
         }, null, options.onProgress);
     }
@@ -966,12 +979,14 @@ class Assets extends Events {
      * @returns The new asset
      */
     createText(options: { name?: string; text?: string; folder?: Asset; preload?: boolean; onProgress?: Function; } = {}) {
+        const desired = options.name || 'new.txt';
+        const name = getUniqueName(desired, siblingNames(this.list(), options.folder ?? null));
         return this.upload({
-            name: options.name || 'New Text',
+            name,
             type: 'text',
             folder: options.folder,
             preload: options.preload,
-            filename: 'asset.txt',
+            filename: name,
             file: new Blob([options.text || '\n'], { type: 'text/plain' })
         }, null, options.onProgress);
     }

--- a/src/editor-api/assets/unique-name.ts
+++ b/src/editor-api/assets/unique-name.ts
@@ -1,0 +1,57 @@
+import type { Asset } from '../asset';
+
+const SUFFIX_RE = /^(.*?)\s*\((\d+)\)$/;
+
+// split a filename into base, parenthesised numeric suffix, and extension
+// e.g. "foo (3).css" -> { base: "foo", n: 3, ext: ".css" }
+//      "foo.css"    -> { base: "foo", n: 0, ext: ".css" }
+//      "foo"        -> { base: "foo", n: 0, ext: "" }
+function splitNameSuffix(name: string) {
+    const dot = name.lastIndexOf('.');
+    const stem = dot > 0 ? name.slice(0, dot) : name;
+    const ext = dot > 0 ? name.slice(dot) : '';
+    const m = stem.match(SUFFIX_RE);
+    if (m) {
+        return { base: m[1], n: parseInt(m[2], 10), ext };
+    }
+    return { base: stem, n: 0, ext };
+}
+
+// returns the first free name by suffixing " (n)" before the extension.
+// case-insensitive comparison so the result doesn't visually clash either.
+function getUniqueName(desired: string, taken: Set<string>) {
+    const lower = new Set<string>();
+    for (const t of taken) {
+        lower.add(t.toLowerCase());
+    }
+    if (!lower.has(desired.toLowerCase())) {
+        return desired;
+    }
+    const { base, n, ext } = splitNameSuffix(desired);
+    let i = n > 0 ? n + 1 : 1;
+    while (true) {
+        const candidate = `${base} (${i})${ext}`;
+        if (!lower.has(candidate.toLowerCase())) {
+            return candidate;
+        }
+        i++;
+    }
+}
+
+// build a Set of names taken by siblings in the given folder.
+// folder is null for the project root.
+function siblingNames(assets: Asset[], folder: Asset | null) {
+    const folderId = folder ? folder.get('id') : null;
+    const out = new Set<string>();
+    for (const a of assets) {
+        const path = a.get('path');
+        const parent = path && path.length ? path[path.length - 1] : null;
+        if ((parent ?? null) !== (folderId ?? null)) {
+            continue;
+        }
+        out.add(a.get('name'));
+    }
+    return out;
+}
+
+export { splitNameSuffix, getUniqueName, siblingNames };

--- a/src/editor/assets/assets-context-menu.ts
+++ b/src/editor/assets/assets-context-menu.ts
@@ -44,13 +44,16 @@ editor.once('load', () => {
                 return;
             }
 
+            const folder = editor.call('assets:selected:folder');
+            const validate = (name: string) => editor.call('assets:script:checkCollision', name, folder);
             editor.call('picker:script-create', (filename) => {
                 editor.call('assets:create:script', {
-                    filename: filename
+                    filename: filename,
+                    parent: folder
                 }, (asset: Asset) => {
                     editor.api.globals.selection.set([asset]);
                 });
-            });
+            }, undefined, validate);
         }
     });
     if (editor.call('permissions:write')) {
@@ -247,12 +250,13 @@ editor.once('load', () => {
                     if (legacyScripts) {
                         editor.call('sourcefiles:new');
                     } else {
+                        const validate = (name: string) => editor.call('assets:script:checkCollision', name, folder);
                         editor.call('picker:script-create', (filename) => {
                             editor.call('assets:create:script', {
                                 filename: filename,
                                 parent: folder
                             }, selectAsset());
-                        });
+                        }, undefined, validate);
                     }
                 } else {
                     if (assetCreateCallback[key]) {

--- a/src/editor/assets/assets-create-css.ts
+++ b/src/editor/assets/assets-create-css.ts
@@ -4,19 +4,13 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: 'New Css',
-            type: 'css',
-            source: false,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            filename: 'asset.css',
-            file: new Blob(['\n'], { type: 'text/css' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createCss({
+            folder
+        }).catch((err) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/editor/assets/assets-create-folder.ts
+++ b/src/editor/assets/assets-create-folder.ts
@@ -4,19 +4,24 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: args.name || 'New Folder',
-            type: 'folder',
-            source: true,
-            preload: false,
-            data: null,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset, args.fn, args.noSelect);
+        editor.api.globals.assets.createFolder({
+            name: args.name,
+            folder
+        }).then((asset) => {
+            if (!args.noSelect) {
+                editor.api.globals.selection.set([asset]);
+            }
+            if (args.fn) {
+                args.fn(null, asset.get('id'));
+            }
+        }).catch((err) => {
+            editor.call('status:error', err);
+            if (args.fn) {
+                args.fn(err);
+            }
+        });
     });
 });

--- a/src/editor/assets/assets-create-html.ts
+++ b/src/editor/assets/assets-create-html.ts
@@ -4,19 +4,13 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: 'New Html',
-            type: 'html',
-            source: false,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            filename: 'asset.html',
-            file: new Blob(['\n'], { type: 'text/html' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createHtml({
+            folder
+        }).catch((err) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/editor/assets/assets-create-i18n.ts
+++ b/src/editor/assets/assets-create-i18n.ts
@@ -1,39 +1,33 @@
-editor.once('load', () => {
-    const content = JSON.stringify({
-        'header': {
-            'version': 1
+const DEFAULT_LOCALIZATION_DATA = {
+    'header': {
+        'version': 1
+    },
+    'data': [{
+        'info': {
+            'locale': 'en-US'
         },
-        'data': [{
-            'info': {
-                'locale': 'en-US'
-            },
-            'messages': {
-                'key': 'Single key translation',
-                'key plural': ['One key translation', 'Translation for {number} keys']
-            }
-        }]
-    }, null, 4);
+        'messages': {
+            'key': 'Single key translation',
+            'key plural': ['One key translation', 'Translation for {number} keys']
+        }
+    }]
+};
 
+editor.once('load', () => {
     editor.method('assets:create:i18n', (args = {}) => {
         if (!editor.call('permissions:write')) {
             return;
         }
 
-        const filename = 'Localization.json';
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        const asset = {
-            name: filename,
-            type: 'json',
-            source: false,
-            parent: editor.call('assets:panel:currentFolder'),
-            filename: filename,
-            file: new Blob([content], { type: 'application/json' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
-
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createI18n({
+            name: 'localization.json',
+            localizationData: DEFAULT_LOCALIZATION_DATA,
+            folder
+        }).catch((err) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/editor/assets/assets-create-json.ts
+++ b/src/editor/assets/assets-create-json.ts
@@ -4,19 +4,31 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: args.name ?? 'New Json',
-            type: 'json',
-            source: false,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            filename: 'asset.json',
-            file: new Blob([args.json ?? '{ }'], { type: 'application/json' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset, args.callback, args.noSelect);
+        let json: object | undefined;
+        if (args.json !== undefined) {
+            json = typeof args.json === 'string' ? JSON.parse(args.json) : args.json;
+        }
+
+        editor.api.globals.assets.createJson({
+            name: args.name,
+            json,
+            spaces: args.spaces,
+            folder
+        }).then((asset) => {
+            if (!args.noSelect) {
+                editor.api.globals.selection.set([asset]);
+            }
+            if (args.callback) {
+                args.callback(null, asset.get('id'));
+            }
+        }).catch((err) => {
+            editor.call('status:error', err);
+            if (args.callback) {
+                args.callback(err);
+            }
+        });
     });
 });

--- a/src/editor/assets/assets-create-script.ts
+++ b/src/editor/assets/assets-create-script.ts
@@ -13,23 +13,23 @@ editor.once('load', () => {
             text
         } = args;
 
-        const isEsmScript = filename.endsWith('.mjs');
         const parentId = parent ? parent.get('id') : null;
 
-
-        // We need to ensure that the target folder does not already contain an asset with the same name
-        const hasExistingEsmScript = isEsmScript && editor.call('assets:list').some((asset) => {
-            // get the containing folder of the asset
-            const path = asset.get('path').pop();
-
-            const isSameFolder = (path ?? null) === (parentId ?? null);
+        // a script's filename stem becomes a JS class name and the pc.createScript
+        // argument, so we never auto-suffix on collision; user must pick a unique name
+        const hasExistingScript = editor.call('assets:list').some((asset) => {
+            if (asset.get('type') !== 'script') {
+                return false;
+            }
+            const path = asset.get('path');
+            const folder = path && path.length ? path[path.length - 1] : null;
+            const isSameFolder = (folder ?? null) === (parentId ?? null);
             const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
-
-            return isSameFile && isSameFolder;
+            return isSameFolder && isSameFile;
         });
 
-        if (hasExistingEsmScript) {
-            editor.call('status:error', `The asset "${filename}" already exists in this location. Please use another name.`);
+        if (hasExistingScript) {
+            editor.call('status:error', `A script named "${filename}" already exists in this folder. Please use another name.`);
             return;
         }
 

--- a/src/editor/assets/assets-create-script.ts
+++ b/src/editor/assets/assets-create-script.ts
@@ -1,4 +1,21 @@
 editor.once('load', () => {
+    // a script's filename stem becomes a JS class name and the pc.createScript
+    // argument, so we never auto-suffix on collision; user must pick a unique name
+    editor.method('assets:script:checkCollision', (filename, parent) => {
+        const parentId = parent ? parent.get('id') : null;
+        const collision = editor.call('assets:list').some((asset) => {
+            if (asset.get('type') !== 'script') {
+                return false;
+            }
+            const path = asset.get('path');
+            const folder = path && path.length ? path[path.length - 1] : null;
+            const isSameFolder = (folder ?? null) === (parentId ?? null);
+            const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
+            return isSameFolder && isSameFile;
+        });
+        return collision ? `A script named "${filename}" already exists in this folder. Please use another name.` : null;
+    });
+
     editor.method('assets:create:script', (args = {}, callback = (asset) => {}) => {
 
         editor.call('status:clear');
@@ -13,23 +30,9 @@ editor.once('load', () => {
             text
         } = args;
 
-        const parentId = parent ? parent.get('id') : null;
-
-        // a script's filename stem becomes a JS class name and the pc.createScript
-        // argument, so we never auto-suffix on collision; user must pick a unique name
-        const hasExistingScript = editor.call('assets:list').some((asset) => {
-            if (asset.get('type') !== 'script') {
-                return false;
-            }
-            const path = asset.get('path');
-            const folder = path && path.length ? path[path.length - 1] : null;
-            const isSameFolder = (folder ?? null) === (parentId ?? null);
-            const isSameFile = asset.get('name').toLowerCase() === filename.toLowerCase();
-            return isSameFolder && isSameFile;
-        });
-
-        if (hasExistingScript) {
-            editor.call('status:error', `A script named "${filename}" already exists in this folder. Please use another name.`);
+        const collisionError = editor.call('assets:script:checkCollision', filename, parent);
+        if (collisionError) {
+            editor.call('status:error', collisionError);
             return;
         }
 

--- a/src/editor/assets/assets-create-shader.ts
+++ b/src/editor/assets/assets-create-shader.ts
@@ -4,19 +4,13 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: 'New Shader',
-            type: 'shader',
-            source: false,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            filename: 'asset.glsl',
-            file: new Blob(['\n'], { type: 'text/x-glsl' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createShader({
+            folder
+        }).catch((err) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/editor/assets/assets-create-text.ts
+++ b/src/editor/assets/assets-create-text.ts
@@ -4,19 +4,13 @@ editor.once('load', () => {
             return;
         }
 
-        const asset = {
-            name: 'New Text',
-            type: 'text',
-            source: false,
-            parent: (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder'),
-            filename: 'asset.txt',
-            file: new Blob(['\n'], { type: 'text/plain' }),
-            scope: {
-                type: 'project',
-                id: config.project.id
-            }
-        };
+        const parent = (args.parent !== undefined) ? args.parent : editor.call('assets:panel:currentFolder');
+        const folder = parent?.apiAsset ?? parent ?? undefined;
 
-        editor.call('assets:create', asset);
+        editor.api.globals.assets.createText({
+            folder
+        }).catch((err) => {
+            editor.call('status:error', err);
+        });
     });
 });

--- a/src/editor/assets/assets-duplicate.ts
+++ b/src/editor/assets/assets-duplicate.ts
@@ -103,13 +103,14 @@ editor.once('load', () => {
             )
             .on('load', (_status: number, data: unknown) => {
                 const text = typeof data === 'string' ? data.replace(/\r\n?/g, '\n') : '';
+                const validate = (name: string) => editor.call('assets:script:checkCollision', name, parentObserver);
                 editor.call('picker:script-create', (newFilename: string) => {
                     editor.call('assets:create:script', {
                         filename: newFilename,
                         parent: parentObserver,
                         text
                     });
-                }, sourceFilename);
+                }, sourceFilename, validate);
             })
             .on('error', (_status: number, errData: unknown) => {
                 editor.call('status:error', errData ?? 'Could not duplicate script asset');

--- a/src/editor/assets/assets-duplicate.ts
+++ b/src/editor/assets/assets-duplicate.ts
@@ -1,27 +1,119 @@
+import { getUniqueName } from '@/editor-api/assets/unique-name';
+
+const TEXT_CREATE_METHOD: Record<string, 'createCss' | 'createHtml' | 'createJson' | 'createText' | 'createShader'> = {
+    css: 'createCss',
+    html: 'createHtml',
+    json: 'createJson',
+    text: 'createText',
+    shader: 'createShader'
+};
+
 editor.once('load', () => {
-    editor.method('assets:duplicate', (asset) => {
-        if (asset.get('type') !== 'material' && asset.get('type') !== 'sprite') {
+    editor.method('assets:duplicate', (asset: any) => {
+        if (!editor.call('permissions:write')) {
             return;
         }
 
+        const type = asset.get('type');
         const path = asset.get('path');
-        const parent = path.length ? path[path.length - 1] : null;
+        const parentId = path && path.length ? path[path.length - 1] : null;
+        const parentObserver = parentId ? editor.call('assets:get', parentId) : null;
+        const parentApi = parentObserver?.apiAsset ?? undefined;
 
-        const raw = {
-            // only materials can be duplicated at the moment
-            type: asset.get('type'),
-            name: `${asset.get('name')} Copy`,
-            tags: asset.get('tags'),
-            source: false,
-            data: asset.get('data'),
-            preload: asset.get('preload'),
-            parent: parent ? editor.call('assets:get', parent) : null,
-            scope: {
-                type: 'project',
-                id: config.project.id
+        // collect sibling names for unique-name lookup
+        const siblings = new Set<string>();
+        editor.call('assets:list').forEach((a: any) => {
+            const p = a.get('path');
+            const par = p && p.length ? p[p.length - 1] : null;
+            if ((par ?? null) === (parentId ?? null)) {
+                siblings.add(a.get('name'));
             }
-        };
+        });
 
-        editor.call('assets:create', raw);
+        // material / sprite — duplicate via assets:create with cloned data
+        if (type === 'material' || type === 'sprite') {
+            const newName = getUniqueName(asset.get('name'), siblings);
+            const raw = {
+                type,
+                name: newName,
+                tags: asset.get('tags'),
+                source: false,
+                data: asset.get('data'),
+                preload: asset.get('preload'),
+                parent: parentObserver,
+                scope: {
+                    type: 'project',
+                    id: config.project.id
+                }
+            };
+            editor.call('assets:create', raw);
+            return;
+        }
+
+        // text-based file types — fetch source content, then call createX
+        if (TEXT_CREATE_METHOD[type]) {
+            const filename = asset.get('file.filename');
+            if (!filename) {
+                return;
+            }
+            editor.api.globals.rest.assets.assetGetFile(
+                asset.get('id'),
+                filename,
+                { branchId: config.self.branch.id }
+            )
+            .on('load', (_status: number, data: unknown) => {
+                const text = typeof data === 'string' ? data.replace(/\r\n?/g, '\n') : '';
+                const sourceName = asset.get('name');
+                if (type === 'json') {
+                    let parsed: object;
+                    try {
+                        parsed = text ? JSON.parse(text) : {};
+                    } catch (e) {
+                        parsed = {};
+                    }
+                    editor.api.globals.assets.createJson({
+                        name: sourceName,
+                        json: parsed,
+                        folder: parentApi
+                    }).catch((err: unknown) => editor.call('status:error', err));
+                    return;
+                }
+                editor.api.globals.assets[TEXT_CREATE_METHOD[type]]({
+                    name: sourceName,
+                    text,
+                    folder: parentApi
+                }).catch((err: unknown) => editor.call('status:error', err));
+            })
+            .on('error', (_status: number, errData: unknown) => {
+                editor.call('status:error', errData ?? `Could not duplicate ${type} asset`);
+            });
+            return;
+        }
+
+        // script — open the picker so user types a unique filename, then create
+        if (type === 'script') {
+            const sourceFilename = asset.get('file.filename');
+            if (!sourceFilename) {
+                return;
+            }
+            editor.api.globals.rest.assets.assetGetFile(
+                asset.get('id'),
+                sourceFilename,
+                { branchId: config.self.branch.id }
+            )
+            .on('load', (_status: number, data: unknown) => {
+                const text = typeof data === 'string' ? data.replace(/\r\n?/g, '\n') : '';
+                editor.call('picker:script-create', (newFilename: string) => {
+                    editor.call('assets:create:script', {
+                        filename: newFilename,
+                        parent: parentObserver,
+                        text
+                    });
+                }, sourceFilename);
+            })
+            .on('error', (_status: number, errData: unknown) => {
+                editor.call('status:error', errData ?? 'Could not duplicate script asset');
+            });
+        }
     });
 });

--- a/src/editor/assets/assets-paste.ts
+++ b/src/editor/assets/assets-paste.ts
@@ -1,4 +1,157 @@
+import { getUniqueName } from '@/editor-api/assets/unique-name';
+
+const TEXT_TYPES = new Set(['css', 'html', 'json', 'text', 'shader']);
+// types we can recreate client-side without re-uploading file blobs
+const CLIENT_PASTE_TYPES = new Set([...TEXT_TYPES, 'folder']);
+
 editor.once('load', () => {
+    // get direct children of a folder (or root when folderId === null)
+    const childrenOf = (folderId: string | number | null) => {
+        return editor.call('assets:list').filter((a: any) => {
+            const p = a.get('path');
+            const par = p && p.length ? p[p.length - 1] : null;
+            return (par ?? null) === (folderId ?? null);
+        });
+    };
+
+    // build the set of names already in use within a folder (sans optional self)
+    const takenIn = (folderId: string | number | null, exceptId?: string | number) => {
+        const taken = new Set<string>();
+        for (const a of childrenOf(folderId)) {
+            if (exceptId !== undefined && a.get('id') === exceptId) {
+                continue;
+            }
+            taken.add(a.get('name'));
+        }
+        return taken;
+    };
+
+    // fetch a text asset's file contents via REST
+    const fetchTextContent = (asset: any) => new Promise<string>((resolve, reject) => {
+        const filename = asset.get('file.filename');
+        if (!filename) {
+            resolve('');
+            return;
+        }
+        editor.api.globals.rest.assets.assetGetFile(
+            asset.get('id'),
+            filename,
+            { branchId: config.self.branch.id }
+        )
+        .on('load', (_status: number, data: unknown) => {
+            resolve(typeof data === 'string' ? data.replace(/\r\n?/g, '\n') : '');
+        })
+        .on('error', (_status: number, err: unknown) => reject(err));
+    });
+
+    // create one asset under targetFolder mirroring source. returns the newly
+    // created Asset (editor-api object) so callers can recurse into folders.
+    const pasteOne = async (source: any, targetFolderApi: any, targetFolderId: string | number | null): Promise<any> => {
+        const type = source.get('type');
+        const desired = source.get('name');
+        const taken = takenIn(targetFolderId);
+        const uniqueName = getUniqueName(desired, taken);
+
+        if (TEXT_TYPES.has(type)) {
+            const text = await fetchTextContent(source);
+            if (type === 'json') {
+                let parsed: object;
+                try {
+                    parsed = text ? JSON.parse(text) : {};
+                } catch (_) {
+                    parsed = {};
+                }
+                return editor.api.globals.assets.createJson({
+                    name: uniqueName,
+                    json: parsed,
+                    folder: targetFolderApi
+                });
+            }
+            const method = `create${type[0].toUpperCase()}${type.slice(1)}` as
+                'createCss' | 'createHtml' | 'createText' | 'createShader';
+            return editor.api.globals.assets[method]({
+                name: uniqueName,
+                text,
+                folder: targetFolderApi
+            });
+        }
+
+        if (type === 'folder') {
+            return editor.api.globals.assets.createFolder({
+                name: uniqueName,
+                folder: targetFolderApi
+            });
+        }
+
+        return null;
+    };
+
+    // recursively paste a folder's children into the new folder. siblings
+    // share a target folder, so resolve them sequentially — otherwise two
+    // children with identical names could both win the same getUniqueName slot.
+    const pasteFolderChildren = async (sourceFolder: any, newFolder: any) => {
+        const sourceId = sourceFolder.get('id');
+        const newFolderId = newFolder.get('id');
+        const newFolderObserver = editor.call('assets:get', newFolderId);
+        const newFolderApi = newFolderObserver?.apiAsset ?? newFolder;
+
+        for (const child of childrenOf(sourceId)) {
+            if (!CLIENT_PASTE_TYPES.has(child.get('type'))) {
+                continue;
+            }
+            // eslint-disable-next-line no-await-in-loop
+            const created = await pasteOne(child, newFolderApi, newFolderId);
+            if (created && child.get('type') === 'folder') {
+                // eslint-disable-next-line no-await-in-loop
+                await pasteFolderChildren(child, created);
+            }
+        }
+    };
+
+    // wait for the asset to land in the local registry, then suffix its name (and
+    // file.filename for text-based files) if a sibling already uses it. used as
+    // a fallback when we delegate to the server-side REST paste (cross-project,
+    // binary types, etc.)
+    const ensureUniqueOnPaste = (assetId: string, targetFolderId: string | number | null) => {
+        const apply = () => {
+            const asset = editor.call('assets:get', assetId);
+            if (!asset) {
+                return;
+            }
+            const path = asset.get('path');
+            const parentId = path && path.length ? path[path.length - 1] : null;
+            if ((parentId ?? null) !== (targetFolderId ?? null)) {
+                return;
+            }
+            const type = asset.get('type');
+            const enforce = TEXT_TYPES.has(type) || type === 'folder' || type === 'script';
+            if (!enforce) {
+                return;
+            }
+
+            const taken = takenIn(targetFolderId, assetId);
+            const currentName = asset.get('name');
+            if (!taken.has(currentName)) {
+                return;
+            }
+            const newName = getUniqueName(currentName, taken);
+            const update: { name: string; filename?: string } = { name: newName };
+            if (asset.get('file.filename')) {
+                update.filename = newName;
+            }
+            editor.api.globals.rest.assets.assetUpdate(assetId, update)
+            .on('error', (_status: number, errData: unknown) => {
+                console.warn(`paste rename error: ${errData}`);
+            });
+        };
+
+        if (editor.call('assets:get', assetId)) {
+            apply();
+        } else {
+            editor.once(`assets:add[${assetId}]`, apply);
+        }
+    };
+
     editor.method('assets:paste', (parentFolder, keepFolderStructure, callback) => {
         if (!editor.call('permissions:write')) {
             return;
@@ -6,52 +159,104 @@ editor.once('load', () => {
 
         const clipboard = editor.call('clipboard');
         const value = clipboard.value;
-        if (!value) {
-            return;
-        }
-        if (value.type !== 'asset') {
+        if (!value || value.type !== 'asset') {
             return;
         }
 
-        const data = {
-            projectId: value.projectId,
-            branchId: value.branchId,
-            targetProjectId: config.project.id,
-            targetBranchId: config.self.branch.id,
-            keepFolderStructure: !!keepFolderStructure,
-            assets: value.assets.slice()
-        };
+        const targetFolderObserver = parentFolder ?? null;
+        const targetFolderId = targetFolderObserver ? targetFolderObserver.get('id') : null;
+        const targetFolderApi = targetFolderObserver?.apiAsset ?? undefined;
+        const sameProject = value.projectId === config.project.id &&
+                            value.branchId === config.self.branch.id;
 
-        if (parentFolder) {
-            data.targetFolderId = parentFolder.get('id');
+        // partition source asset IDs into client-side and server-side groups
+        const clientIds: string[] = [];
+        const serverIds: string[] = [];
+
+        if (sameProject) {
+            for (const id of value.assets) {
+                const source = editor.call('assets:get', id);
+                if (source && CLIENT_PASTE_TYPES.has(source.get('type'))) {
+                    clientIds.push(id);
+                } else {
+                    serverIds.push(id);
+                }
+            }
+        } else {
+            serverIds.push(...value.assets);
         }
 
         const now = Date.now();
         editor.call('status:text', 'Pasting assets...');
         editor.call('status:job', `asset-paste:${now}`, 1);
 
-        editor.api.globals.rest.assets.assetPaste(data)
-        .on('load', (status, data) => {
-            if (status === 201) {
-                editor.call('status:text', `${data.result.length} asset${data.result.length > 1 ? 's' : ''} created`);
+        const finishJob = () => editor.call('status:job', `asset-paste:${now}`);
+
+        const runClientSide = async () => {
+            for (const id of clientIds) {
+                const source = editor.call('assets:get', id);
+                if (!source) {
+                    continue;
+                }
+                // eslint-disable-next-line no-await-in-loop
+                const created = await pasteOne(source, targetFolderApi, targetFolderId);
+                if (created && source.get('type') === 'folder' && keepFolderStructure !== false) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await pasteFolderChildren(source, created);
+                }
+            }
+        };
+
+        const runServerSide = () => new Promise<any>((resolve, reject) => {
+            if (serverIds.length === 0) {
+                resolve(null);
+                return;
+            }
+            const data: any = {
+                projectId: value.projectId,
+                branchId: value.branchId,
+                targetProjectId: config.project.id,
+                targetBranchId: config.self.branch.id,
+                keepFolderStructure: !!keepFolderStructure,
+                assets: serverIds.slice()
+            };
+            if (parentFolder) {
+                data.targetFolderId = parentFolder.get('id');
+            }
+            editor.api.globals.rest.assets.assetPaste(data)
+            .on('load', (status: number, response: any) => {
+                if (status === 201 && Array.isArray(response.result)) {
+                    for (const item of response.result) {
+                        const id = item?.id ?? item;
+                        if (id !== undefined && id !== null) {
+                            ensureUniqueOnPaste(String(id), targetFolderId);
+                        }
+                    }
+                }
+                resolve(response);
+            })
+            .on('error', (_status: number, err: unknown) => reject(err));
+        });
+
+        runClientSide()
+        .then(() => runServerSide())
+        .then((response) => {
+            const total = clientIds.length + (response?.result?.length ?? 0);
+            if (total > 0) {
+                editor.call('status:text', `${total} asset${total > 1 ? 's' : ''} created`);
             } else {
                 editor.call('status:clear');
             }
-            editor.call('status:job', `asset-paste:${now}`);
+            finishJob();
             if (callback) {
-                callback(null, data);
+                callback(null, response);
             }
-
-            // TODO: should we clear the clipboard?
-            // if (clipboard.value === value) {
-            //     clipboard.value = null;
-            // }
         })
-        .on('error', (status, data) => {
-            editor.call('status:error', data ?? 'Error while pasting assets');
-            editor.call('status:job', `asset-paste:${now}`);
+        .catch((err) => {
+            editor.call('status:error', err ?? 'Error while pasting assets');
+            finishJob();
             if (callback) {
-                callback(data);
+                callback(err);
             }
         });
     });

--- a/src/editor/assets/assets-rename.ts
+++ b/src/editor/assets/assets-rename.ts
@@ -1,3 +1,5 @@
+const TEXT_TYPES = new Set(['css', 'html', 'json', 'script', 'shader', 'text']);
+
 editor.once('load', () => {
     const changeName = function (assetId: string | number, assetName: string) {
         editor.api.globals.rest.assets.assetUpdate(assetId, { name: assetName })
@@ -10,19 +12,30 @@ editor.once('load', () => {
     editor.method('assets:rename', (asset, newName) => {
         const oldName = asset.get('name');
         const id = asset.get('id');
-        const assetPath = asset.get('path').join('/');
-        const isEsmScript = editor.call('assets:isModule', asset);
+        const type = asset.get('type');
+        const path = asset.get('path');
+        const parentId = path && path.length ? path[path.length - 1] : null;
+        const enforceUnique = TEXT_TYPES.has(type) || type === 'folder';
 
-        // For ES Modules, check if the target name is already taken
-        const nameMatchesExistingAsset = isEsmScript && editor.call('assets:list').some((item) => {
-            const itemPath = item.get('path').join('/');
-            return item.get('name') === newName && itemPath === assetPath && id;
-        });
+        // reject if a sibling already has the new name (case-insensitive)
+        if (enforceUnique) {
+            const collision = editor.call('assets:list').some((item: any) => {
+                if (item.get('id') === id) {
+                    return false;
+                }
+                const itemPath = item.get('path');
+                const itemParent = itemPath && itemPath.length ? itemPath[itemPath.length - 1] : null;
+                if ((itemParent ?? null) !== (parentId ?? null)) {
+                    return false;
+                }
+                return item.get('name').toLowerCase() === newName.toLowerCase();
+            });
 
-        // If the target name is already taken, show an error message and return early
-        if (nameMatchesExistingAsset) {
-            editor.call('status:error', `The name "${newName}” with extension “.mjs” is already taken. Please choose a different name.`);
-            return;
+            if (collision) {
+                const message = `An asset named "${newName}" already exists in this folder. Please choose a different name.`;
+                editor.call('status:error', message);
+                return message;
+            }
         }
 
         editor.api.globals.history?.add({
@@ -41,5 +54,6 @@ editor.once('load', () => {
         });
 
         changeName(id, newName);
+        return null;
     });
 });

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -360,6 +360,8 @@ class AssetInspector extends Container {
 
     private _assetEvents: EventHandle[] = [];
 
+    private _renameInFlight = false;
+
     constructor(args: Record<string, unknown> = {}) {
         args.flex = true;
 
@@ -694,10 +696,19 @@ class AssetInspector extends Container {
     }
 
     _updateAssetName(value: string) {
+        // ignore the change event fired by our own programmatic field revert below
+        if (this._renameInFlight) {
+            return;
+        }
         if (!value) {
             return;
         }
-        editor.call('assets:rename', this._assets[0], value);
+        const error = editor.call('assets:rename', this._assets[0], value);
+        if (error) {
+            this._renameInFlight = true;
+            this._attributesInspector.getField('name').value = this._assets[0].get('name');
+            this._renameInFlight = false;
+        }
     }
 
     link(assets: Observer[]) {

--- a/src/editor/inspector/components/script.ts
+++ b/src/editor/inspector/components/script.ts
@@ -1332,7 +1332,8 @@ class ScriptComponentInspector extends ComponentInspector {
         if (filename) {
             onFilename(filename);
         } else {
-            editor.call('picker:script-create', onFilename, script);
+            const validate = (name: string) => editor.call('assets:script:checkCollision', name, folder && folder.apiAsset);
+            editor.call('picker:script-create', onFilename, script, validate);
         }
     }
 

--- a/src/editor/inspector/settings-panels/loading-screen.ts
+++ b/src/editor/inspector/settings-panels/loading-screen.ts
@@ -144,6 +144,7 @@ class LoadingScreenSettingsPanel extends BaseSettingsPanel {
 
     _clickCreateDefault() {
         const folder = editor.call('sourcefiles:loadingScreen:skeleton');
+        const validate = (name: string) => editor.call('assets:script:checkCollision', name, folder && folder.apiAsset);
         editor.call('picker:script-create', (filename) => {
             editor.call('assets:create:script', {
                 filename: filename,
@@ -152,7 +153,7 @@ class LoadingScreenSettingsPanel extends BaseSettingsPanel {
             }, (asset: Asset) => {
                 this._setLoadingScreen(asset.observer);
             });
-        });
+        }, undefined, validate);
     }
 }
 

--- a/src/editor/inspector/settings-panels/localization.ts
+++ b/src/editor/inspector/settings-panels/localization.ts
@@ -40,7 +40,7 @@ class LocalizationSettingsPanel extends BaseSettingsPanel {
         const createNewAssetEvt = this._attributesInspector.getField('createAsset').on('click', () => {
             const folder = editor.call('assets:panel:currentFolder');
             editor.api.globals.assets.createI18n({
-                name: 'Localization',
+                name: 'localization.json',
                 folder: folder && folder.apiAsset
             })
             .catch((err) => {

--- a/src/editor/pickers/picker-script-create.ts
+++ b/src/editor/pickers/picker-script-create.ts
@@ -2,8 +2,11 @@ import { Label, Overlay, TextInput } from '@playcanvas/pcui';
 
 import { normalizeScriptName } from '@/common/script-names';
 
+const INVALID_FILENAME = 'Invalid filename';
+
 editor.once('load', () => {
     let callback: ((name: string) => void) | null = null;
+    let extraValidate: ((filename: string) => string | null) | null = null;
 
     const overlay = new Overlay({
         class: 'picker-script-create',
@@ -18,7 +21,7 @@ editor.once('load', () => {
 
     const validate = new Label({
         class: 'validate',
-        text: 'Invalid filename',
+        text: INVALID_FILENAME,
         hidden: true
     });
     overlay.append(validate);
@@ -29,15 +32,44 @@ editor.once('load', () => {
     });
     overlay.append(input);
 
+    // run the two checks in order; return the resolved name or an error message
+    const evaluate = (raw: string): { name: string | null; error: string | null } => {
+        const name = normalizeScriptName(raw);
+        if (name === null) {
+            return { name: null, error: INVALID_FILENAME };
+        }
+        const extra = extraValidate?.(name) ?? null;
+        return { name, error: extra };
+    };
+
     const onInputChange = () => {
-        validate.hidden = normalizeScriptName(input.value) !== null;
+        // empty input is the "neutral" state — show no error until the user types
+        if (!input.value) {
+            validate.hidden = true;
+            return;
+        }
+        const { error } = evaluate(input.value);
+        if (error) {
+            validate.text = error;
+            validate.hidden = false;
+        } else {
+            validate.hidden = true;
+        }
     };
 
     const onInputKeyDown = (evt: KeyboardEvent) => {
         if (evt.key === 'Enter') {
-            const normalizedScriptName = normalizeScriptName(input.value);
-            if (normalizedScriptName !== null) {
-                callback?.(normalizedScriptName);
+            if (!input.value) {
+                return;
+            }
+            const { name, error } = evaluate(input.value);
+            if (error) {
+                validate.text = error;
+                validate.hidden = false;
+                return;
+            }
+            if (name !== null) {
+                callback?.(name);
                 overlay.hidden = true;
             }
         }
@@ -63,16 +95,25 @@ editor.once('load', () => {
         input.unbind('change', onInputChange);
         input.unbind('keydown', onInputKeyDown);
         window.removeEventListener('keydown', onWindowKeyDown, true);
+        extraValidate = null;
+        validate.text = INVALID_FILENAME;
+        validate.hidden = true;
         editor.emit('picker:script-create:close');
     });
 
     editor.method('picker:script-create:validate', normalizeScriptName);
 
-    editor.method('picker:script-create', (fn, string) => {
+    editor.method('picker:script-create', (fn, string, validator) => {
         callback = fn ?? null;
+        extraValidate = validator ?? null;
         overlay.hidden = false;
+        validate.text = INVALID_FILENAME;
         validate.hidden = true;
         input.value = string ?? '';
+        // surface validation immediately for any seeded value so the user sees a colliding seed
+        if (input.value) {
+            onInputChange();
+        }
         input.focus(true);
     });
 

--- a/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
@@ -89,7 +89,11 @@ editor.once('load', () => {
             rootPanel.headerText = `SPRITE ASSET - ${value}`;
             if (value !== spriteAsset.get('name') && !suspendRenameEvt) {
                 suspendRenameEvt = true;
-                editor.call('assets:rename', spriteAsset, value);
+                const error = editor.call('assets:rename', spriteAsset, value);
+                if (error) {
+                    fieldName.value = spriteAsset.get('name');
+                    rootPanel.headerText = `SPRITE ASSET - ${spriteAsset.get('name')}`;
+                }
                 suspendRenameEvt = false;
             }
         }));

--- a/test/editor-api/api/test-assets.js
+++ b/test/editor-api/api/test-assets.js
@@ -301,13 +301,54 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.css');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal('text');
         expect(data.get('type')).to.equal('css');
         expect(data.get('name')).to.equal('name');
         expect(data.get('parent')).to.equal('10');
         expect(data.get('preload')).to.equal('true');
+    });
+
+    it('uses default name new.css when none supplied', function () {
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
+
+        api.globals.branchId = 'branch';
+        api.globals.projectId = 1;
+
+        api.globals.assets.createCss({});
+
+        expect(requests.length).to.equal(1);
+        const data = requests[0].requestBody;
+        expect(data.get('name')).to.equal('new.css');
+        expect(data.get('filename')).to.equal('new.css');
+    });
+
+    it('suffixes css name when sibling exists', function () {
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
+
+        api.globals.branchId = 'branch';
+        api.globals.projectId = 1;
+
+        const folder = new api.Asset({ id: 10 });
+        const sibling = new api.Asset({ id: 11, type: 'css', name: 'new.css', path: [10] });
+        api.globals.assets.add(folder);
+        api.globals.assets.add(sibling);
+
+        api.globals.assets.createCss({ folder });
+
+        expect(requests.length).to.equal(1);
+        const data = requests[0].requestBody;
+        expect(data.get('name')).to.equal('new (1).css');
+        expect(data.get('filename')).to.equal('new (1).css');
     });
 
     it('creates cubemap asset', function () {
@@ -406,7 +447,7 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.html');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal('text');
         expect(data.get('type')).to.equal('html');
@@ -437,7 +478,7 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.json');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal('{"test":1}');
         expect(data.get('type')).to.equal('json');
@@ -467,7 +508,7 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.json');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal(JSON.stringify({
             "header": {
@@ -542,7 +583,7 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.glsl');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal('text');
         expect(data.get('type')).to.equal('shader');
@@ -608,7 +649,7 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
-        expect(data.get('filename')).to.equal('asset.txt');
+        expect(data.get('filename')).to.equal('name');
         expect(data.get('file') instanceof Blob).to.equal(true);
         expect(await data.get('file').text()).to.equal('text');
         expect(data.get('type')).to.equal('text');

--- a/test/editor-api/api/test-unique-name.js
+++ b/test/editor-api/api/test-unique-name.js
@@ -1,0 +1,80 @@
+describe('getUniqueName', function () {
+    it('returns the desired name when no collision', function () {
+        expect(api.getUniqueName('foo.css', new Set())).to.equal('foo.css');
+        expect(api.getUniqueName('foo.css', new Set(['bar.css']))).to.equal('foo.css');
+    });
+
+    it('appends (1) on first collision', function () {
+        expect(api.getUniqueName('foo.css', new Set(['foo.css']))).to.equal('foo (1).css');
+    });
+
+    it('increments to next free slot', function () {
+        const taken = new Set(['foo.css', 'foo (1).css', 'foo (2).css']);
+        expect(api.getUniqueName('foo.css', taken)).to.equal('foo (3).css');
+    });
+
+    it('skips gaps in suffix sequence', function () {
+        const taken = new Set(['foo.css', 'foo (2).css']);
+        expect(api.getUniqueName('foo.css', taken)).to.equal('foo (1).css');
+    });
+
+    it('continues from existing suffix on input', function () {
+        const taken = new Set(['foo (3).css']);
+        expect(api.getUniqueName('foo (3).css', taken)).to.equal('foo (4).css');
+    });
+
+    it('handles names without extension', function () {
+        expect(api.getUniqueName('folder', new Set(['folder']))).to.equal('folder (1)');
+        expect(api.getUniqueName('folder (1)', new Set(['folder', 'folder (1)']))).to.equal('folder (2)');
+    });
+
+    it('handles multiple dots in name', function () {
+        expect(api.getUniqueName('archive.tar.gz', new Set(['archive.tar.gz'])))
+            .to.equal('archive.tar (1).gz');
+    });
+
+    it('comparison is case-insensitive', function () {
+        expect(api.getUniqueName('foo.css', new Set(['FOO.CSS']))).to.equal('foo (1).css');
+        expect(api.getUniqueName('Foo.css', new Set(['foo.css']))).to.equal('Foo (1).css');
+    });
+});
+
+describe('siblingNames', function () {
+    let assets;
+
+    beforeEach(function () {
+        api.globals.schema = null;
+        api.globals.realtime = null;
+        api.globals.assets = new api.Assets();
+        assets = api.globals.assets;
+    });
+
+    it('returns names for direct siblings only', function () {
+        const folder = new api.Asset({ id: 10 });
+        const direct = new api.Asset({ id: 11, name: 'a.css', path: [10] });
+        const nested = new api.Asset({ id: 12, name: 'b.css', path: [10, 99] });
+        const root = new api.Asset({ id: 13, name: 'c.css' });
+
+        assets.add(folder);
+        assets.add(direct);
+        assets.add(nested);
+        assets.add(root);
+
+        const names = api.siblingNames(assets.list(), folder);
+        expect(names.has('a.css')).to.equal(true);
+        expect(names.has('b.css')).to.equal(false);
+        expect(names.has('c.css')).to.equal(false);
+    });
+
+    it('treats null folder as project root', function () {
+        const root = new api.Asset({ id: 11, name: 'a.css' });
+        const inFolder = new api.Asset({ id: 12, name: 'b.css', path: [10] });
+
+        assets.add(root);
+        assets.add(inFolder);
+
+        const names = api.siblingNames(assets.list(), null);
+        expect(names.has('a.css')).to.equal(true);
+        expect(names.has('b.css')).to.equal(false);
+    });
+});


### PR DESCRIPTION
Newly created, duplicated, and pasted assets now get a unique name within their folder.

**New behavior**
- Default names are lowercase: `new.css`, `new.html`, `new.json`, `new.txt`, `new.glsl`, `folder`. Display name and filename match.
- Create / duplicate / paste in the same folder auto-suffixes: `foo (1).css`, `foo (2).css`, …
- Duplicate now works for css / html / json / text / shader (was a no-op).
- Material / sprite duplicate names go from `Foo Copy` to `Foo (1)`.
- The script-create picker now validates as you type and stays open on rejection — the inline error shows the reason (invalid filename, reserved name, or sibling collision) and the typed value is preserved so you can correct it. Previously the picker dismissed on any rejection and a status toast fired after the fact.

**Now rejected with an error**
- Renaming a text-based asset or folder to a name a sibling already uses (was previously only blocked for `.mjs`).
- Creating a `.js` or `.ts` script with a name already used in the folder (was previously only blocked for `.mjs`).
- Duplicating a script opens the create dialog seeded with the source filename so the user picks a unique name.

**Existing projects**
Pre-existing duplicates aren't migrated; they keep their names and load fine. Creating, renaming, or duplicating around them follows the new rules.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)