### PR TITLE
refactor: migrate conflict-section-row from legacy UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -5974,7 +5974,7 @@ strong {
                                                     &.indent-1 {
                                                         padding-left: 35px;
 
-                                                        .name {
+                                                        > .pcui-label.name {
                                                             width: $name-width - $indent-width;
                                                         }
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -5963,58 +5963,17 @@ strong {
                                             box-sizing: border-box;
 
                                             > .content {
-                                                > .ui-panel.conflict-field {
+                                                > .pcui-container.conflict-field {
                                                     height: auto;
                                                     margin: 10px;
                                                     padding: 5px 15px 5px 25px;
                                                     box-sizing: border-box;
+                                                    white-space: nowrap;
+                                                    isolation: isolate;
 
                                                     &.indent-1 {
                                                         padding-left: 35px;
-                                                    }
 
-                                                    > .content {
-                                                        white-space: nowrap;
-
-                                                        .ui-label,
-                                                        .pcui-label {
-                                                            margin: 0;
-                                                            padding: 0;
-                                                            line-height: 22px;
-                                                            overflow: hidden;
-                                                            text-overflow: ellipsis;
-                                                        }
-
-                                                        > .ui-label {
-                                                            vertical-align: top;
-
-                                                            &.name {
-                                                                width: $name-width;
-                                                                margin-right: 10px;
-                                                                white-space: nowrap;
-                                                            }
-                                                        }
-
-                                                        .value {
-                                                            display: inline-block;
-                                                            max-width: $value-width;
-                                                            font-family: inconsolatamedium;
-                                                            white-space: normal;
-                                                            background: transparent;
-
-                                                            .pcui-label {
-                                                                font-family: inherit;
-                                                                white-space: normal;
-                                                            }
-                                                        }
-
-                                                        .pcui-label.selectable {
-                                                            user-select: text;
-                                                            pointer-events: auto;
-                                                        }
-                                                    }
-
-                                                    &.indent-1 > .content {
                                                         .name {
                                                             width: $name-width - $indent-width;
                                                         }
@@ -6022,6 +5981,42 @@ strong {
                                                         .value {
                                                             max-width: $value-width - $indent-width;
                                                         }
+                                                    }
+
+                                                    .pcui-label {
+                                                        margin: 0;
+                                                        padding: 0;
+                                                        line-height: 22px;
+                                                        overflow: hidden;
+                                                        text-overflow: ellipsis;
+                                                    }
+
+                                                    > .pcui-label {
+                                                        vertical-align: top;
+
+                                                        &.name {
+                                                            width: $name-width;
+                                                            margin-right: 10px;
+                                                            white-space: nowrap;
+                                                        }
+                                                    }
+
+                                                    .value {
+                                                        display: inline-block;
+                                                        max-width: $value-width;
+                                                        font-family: inconsolatamedium;
+                                                        white-space: normal;
+                                                        background: transparent;
+
+                                                        .pcui-label {
+                                                            font-family: inherit;
+                                                            white-space: normal;
+                                                        }
+                                                    }
+
+                                                    .pcui-label.selectable {
+                                                        user-select: text;
+                                                        pointer-events: auto;
                                                     }
 
                                                     &::before {
@@ -6034,6 +6029,7 @@ strong {
                                                         background: $bcg-darkest;
                                                         opacity: 0;
                                                         transition: opacity 100ms;
+                                                        z-index: -1;
                                                     }
 
                                                     &.hovered::before {
@@ -6116,10 +6112,6 @@ strong {
                                                     }
 
                                                     &.field-array-container {
-                                                        > .content {
-                                                            height: 100%;
-                                                        }
-
                                                         .field-array {
                                                             display: block;
                                                             max-width: 100%;
@@ -6200,7 +6192,7 @@ strong {
                                             &.theirs,
                                             &.mine {
                                                 > .content {
-                                                    > .ui-panel.conflict-field {
+                                                    > .pcui-container.conflict-field {
                                                         $dis: &;
                                                         $selected-color: rgb(105 184 117);
 
@@ -6419,7 +6411,7 @@ strong {
                                         > .content {
                                             > .ui-panel {
                                                 > .content {
-                                                    > .ui-panel.conflict-field {
+                                                    > .pcui-container.conflict-field {
                                                         cursor: default;
 
                                                         &::after {
@@ -6438,21 +6430,17 @@ strong {
                                                             max-width: 100% !important;
                                                         }
 
-                                                        > .content {
-                                                            > .ui-label.name {
-                                                                white-space: normal;
-                                                                line-height: 1em;
-                                                            }
-
-                                                            .value {
-                                                                max-width: 270px;
-                                                            }
+                                                        > .pcui-label.name {
+                                                            white-space: normal;
+                                                            line-height: 1em;
                                                         }
 
-                                                        &.indent-1 > .content {
-                                                            .value {
-                                                                max-width: 260px;
-                                                            }
+                                                        .value {
+                                                            max-width: 270px;
+                                                        }
+
+                                                        &.indent-1 .value {
+                                                            max-width: 260px;
                                                         }
                                                     }
                                                 }

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -514,22 +514,6 @@ class ConflictSectionRow extends Events {
 
     destroy() {
         this.unbind();
-
-        // Neither legacy nor PCUI parents cascade destroy to PCUI children:
-        // legacy parents emit a 'destroy' event that only legacy children
-        // subscribe to, and PCUI Container.destroy() does not iterate its
-        // children. Since this row owns the panels and fields, destroy them
-        // explicitly to release their resources (e.g. CurveInput's resize
-        // interval).
-        for (const field of this._fields) {
-            field.element?.destroy();
-        }
-        this._fields.length = 0;
-
-        for (const panel of this._panels) {
-            panel.destroy();
-        }
-        this._panels.length = 0;
     }
 
     get resolved() {

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -493,7 +493,7 @@ class ConflictSectionRow extends Events {
     // Appends all row panels to parent panels
     appendToParents(parents: LegacyPanel[]) {
         for (let i = 0; i < parents.length; i++) {
-            parents[i].append(this._panels[i].dom);
+            parents[i].append(this._panels[i]);
         }
     }
 

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -1,7 +1,7 @@
 import { Events } from '@playcanvas/observer';
+import { Container, Label } from '@playcanvas/pcui';
 
-import { LegacyLabel } from '@/common/ui/label';
-import { LegacyPanel } from '@/common/ui/panel';
+import type { LegacyPanel } from '@/common/ui/panel';
 
 import {
     ConflictArrayField,
@@ -52,7 +52,7 @@ class ConflictSectionRow extends Events {
 
     private _indent = 0;
 
-    private _panels: LegacyPanel[] = [];
+    private _panels: Container[] = [];
 
     private _fields: ConflictField[] = [];
 
@@ -78,8 +78,7 @@ class ConflictSectionRow extends Events {
 
         // Create 3 panels for base, source and destination values
         for (let i = 0; i < 3; i++) {
-            const panel = new LegacyPanel();
-            panel.class.add('conflict-field');
+            const panel = new Container({ class: 'conflict-field', isRoot: true });
             const isArray = this._types[i].startsWith('array:');
             if (isArray) {
                 panel.class.add('field-array-container');
@@ -88,8 +87,8 @@ class ConflictSectionRow extends Events {
             this._panels.push(panel);
 
             if (!resolver.isDiff) {
-                panel.on('hover', this._onHover.bind(this));
-                panel.on('blur', this._onUnHover.bind(this));
+                panel.dom.addEventListener('mouseenter', this._onHover);
+                panel.dom.addEventListener('mouseleave', this._onUnHover);
             }
 
             // Add indentation to all panels
@@ -100,12 +99,11 @@ class ConflictSectionRow extends Events {
                 }
             }
 
-            let label = null;
             if (this._name) {
-                label = new LegacyLabel({
+                const label = new Label({
+                    class: 'name',
                     text: `${args.prettify ? this._prettifyName(this._name) : this._name}:`
                 });
-                label.class.add('name');
                 panel.append(label);
             }
 
@@ -406,17 +404,17 @@ class ConflictSectionRow extends Events {
         sublayer.layer = (layer.name || layer.id);
     }
 
-    _onHover() {
+    _onHover = () => {
         for (let i = 0; i < 3; i++) {
             this._panels[i].class.add('hovered');
         }
-    }
+    };
 
-    _onUnHover() {
+    _onUnHover = () => {
         for (let i = 0; i < 3; i++) {
             this._panels[i].class.remove('hovered');
         }
-    }
+    };
 
     indent() {
         this._panels[BASE_PANEL].class.remove(`indent-${this._indent}`);
@@ -495,7 +493,7 @@ class ConflictSectionRow extends Events {
     // Appends all row panels to parent panels
     appendToParents(parents: LegacyPanel[]) {
         for (let i = 0; i < parents.length; i++) {
-            parents[i].append(this._panels[i]);
+            parents[i].append(this._panels[i].dom);
         }
     }
 

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -87,8 +87,8 @@ class ConflictSectionRow extends Events {
             this._panels.push(panel);
 
             if (!resolver.isDiff) {
-                panel.dom.addEventListener('mouseenter', this._onHover);
-                panel.dom.addEventListener('mouseleave', this._onUnHover);
+                panel.on('hover', this._onHover);
+                panel.on('hoverend', this._onUnHover);
             }
 
             // Add indentation to all panels

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -515,10 +515,12 @@ class ConflictSectionRow extends Events {
     destroy() {
         this.unbind();
 
-        // Legacy parent containers only auto-destroy children with `node.ui` set,
-        // which PCUI elements don't have. Destroy our PCUI fields and panels
-        // explicitly so their resources (e.g. CurveInput's resize interval) are
-        // released. This can be removed once the parent containers are PCUI.
+        // Neither legacy nor PCUI parents cascade destroy to PCUI children:
+        // legacy parents emit a 'destroy' event that only legacy children
+        // subscribe to, and PCUI Container.destroy() does not iterate its
+        // children. Since this row owns the panels and fields, destroy them
+        // explicitly to release their resources (e.g. CurveInput's resize
+        // interval).
         for (const field of this._fields) {
             field.element?.destroy();
         }

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -514,6 +514,20 @@ class ConflictSectionRow extends Events {
 
     destroy() {
         this.unbind();
+
+        // Legacy parent containers only auto-destroy children with `node.ui` set,
+        // which PCUI elements don't have. Destroy our PCUI fields and panels
+        // explicitly so their resources (e.g. CurveInput's resize interval) are
+        // released. This can be removed once the parent containers are PCUI.
+        for (const field of this._fields) {
+            field.element?.destroy();
+        }
+        this._fields.length = 0;
+
+        for (const panel of this._panels) {
+            panel.destroy();
+        }
+        this._panels.length = 0;
     }
 
     get resolved() {

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -78,6 +78,13 @@ class ConflictSectionRow extends Events {
 
         // Create 3 panels for base, source and destination values
         for (let i = 0; i < 3; i++) {
+            // `isRoot: true` is required because this PCUI panel is currently
+            // appended into a legacy parent. Without it, `hiddenToRoot` stays
+            // true up the chain and child `showToRoot` events never fire,
+            // which in turn prevents CurveInput from sizing its canvas. As
+            // ancestors are migrated to PCUI, `isRoot: true` should move up
+            // to whichever PCUI element sits at the legacy/PCUI boundary,
+            // and can be removed entirely once the whole picker is PCUI.
             const panel = new Container({
                 class: 'conflict-field',
                 isRoot: true

--- a/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
+++ b/src/editor/pickers/conflict-manager/ui/conflict-section-row.ts
@@ -78,7 +78,10 @@ class ConflictSectionRow extends Events {
 
         // Create 3 panels for base, source and destination values
         for (let i = 0; i < 3; i++) {
-            const panel = new Container({ class: 'conflict-field', isRoot: true });
+            const panel = new Container({
+                class: 'conflict-field',
+                isRoot: true
+            });
             const isArray = this._types[i].startsWith('array:');
             if (isArray) {
                 panel.class.add('field-array-container');


### PR DESCRIPTION
## Summary

Migrates `conflict-section-row.ts` from legacy `LegacyPanel`/`LegacyLabel` to PCUI `Container`/`Label`. The row's PCUI panels interop with the still-legacy parent panels (`conflict-section.ts`) via the same DOM-level append pattern used in #2037.

## Changes

- **TypeScript** (`src/editor/pickers/conflict-manager/ui/conflict-section-row.ts`):
  - Imports: `LegacyLabel`/`LegacyPanel` -> `Container`/`Label` from PCUI; `LegacyPanel` retained as a type-only import for the `appendToParents` parameter.
  - `_panels` retyped from `LegacyPanel[]` to `Container[]`.
  - Constructor: `new LegacyPanel()` -> `new Container({ class: 'conflict-field', isRoot: true })`; `new LegacyLabel({ text })` -> `new Label({ class: 'name', text })`.
  - Hover/blur: replaced `panel.on('hover'/'blur', ...)` with native `panel.dom.addEventListener('mouseenter'/'mouseleave', ...)`. Converted `_onHover`/`_onUnHover` to instance arrow methods so they're auto-bound.
  - `appendToParents` now passes `this._panels[i].dom` to the still-legacy parents (interop via `LegacyContainer.append(HTMLElement | LegacyElement)`).

- **SCSS** (`sass/editor/_editor-main.scss`):
  - Three sites: main row block, `.theirs/.mine` overlay, picker-asset variant - all `.ui-panel.conflict-field` -> `.pcui-container.conflict-field`.
  - Main block: collapsed the `> .content >` indirection (PCUI Container has no auto-injected `.content` wrapper). Merged the two `&.indent-1` rules. Dropped the no-op `&.field-array-container > .content { height: 100% }`.
  - Bridge selectors `.ui-label, .pcui-label` collapsed to plain `.pcui-label` since the row's `.name` label is now PCUI.

## Notes

Two non-obvious fixes are included in this PR:

- `isolation: isolate` on the row's `.pcui-container.conflict-field` plus `z-index: -1` on its `::before` overlay. Without `.content` as a positioned wrapper, the `::before` (a positioned descendant) ended up stacked above static `.pcui-label` children. On odd rows in the picker-asset variant the overlay has `background: $bcg-dark; opacity: 0.4`, which dimmed text by 40%. Putting the overlay on a negative z-index inside the row's own stacking context restores the intended ordering.

- `isRoot: true` on the row's PCUI Container. Without this, the row container's `_hiddenParents` defaults to `true`. Appending the field with `panel.append(field.element)` then sets the field's `_hiddenParents = panel.hiddenToRoot = true`, so the field's `hiddenToRoot` never transitions and `showToRoot` never fires. CurveInput uses that event to start its 20Hz canvas-resize polling. Without it, the canvas keeps its default 300x150 pixel buffer while `_renderCurves` calls `setTransform(DPR, 0, 0, DPR, 0, 0)` and draws into 0..300x0..150 in scaled coords (i.e. 0..600x0..300 in actual buffer pixels), so only the top-left quarter of the drawing fits the buffer and gets shown. Marking the row as `isRoot: true` makes the field's `_hiddenParents` legitimately transition `true` -> `false`, fires `showToRoot`, and the curve renders correctly. (In #2037 this happened by accident: appending a PCUI element to a `LegacyContainer` set its parent to a non-PCUI object, leaving `_hiddenParents = undefined`, which falsy-coerced into a transition. The new structure plumbs PCUI parents properly, so the workaround is no longer triggered and we mark the row as a root explicitly.)

## Test plan

- [x] `npm run lint` - passes.
- [x] `npm run type:check` - no new errors (one pre-existing error eliminated; pre-existing `unknown`-typed errors unchanged).
- [x] Smoke test the conflict-manager picker on a real merge conflict:
  - [x] Row construction across all three columns (base, source, destination).
  - [x] Hover state (gradient overlay appears) on a `.theirs/.mine` panel.
  - [x] Click-to-resolve and click-again-to-unresolve.
  - [x] Selected state (green border on resolved row).
  - [x] Indentation (`.indent-1`).
  - [x] Array fields (children list, scrollable, selectable text).
  - [x] Field types render correctly: vec3 (monospace), color (46x24 with border), curve (128x25 fully drawn), entity (selectable name + GUID, GUID wraps), CREATED/EDITED/DELETED messages (Proxima Nova).
  - [x] Alternating row backgrounds in the picker-asset variant: text on dark rows is not dimmed.

## Follow-ups (not in this PR)

- Migrate `conflict-section.ts` next (parents the rows). After that, the `> .content > .pcui-container.conflict-field` selector in the `.theirs/.mine` block can be flattened.
- Then `conflict-resolver.ts`, `text-resolver.ts`, `picker-conflict-manager.ts`.
