### PR TITLE
refactor: drop `const self = this` aliases in legacy code

### DIFF
--- a/src/common/unwrap.ts
+++ b/src/common/unwrap.ts
@@ -907,7 +907,6 @@ class Unwrap {
         const vertCount = [];
         let ibOffset = 0;
         let objectScale;
-        const self = this;
         let meshId, nodeId, vbId, attribs;
         const _uvs = [];
         const _scales = [];
@@ -961,7 +960,7 @@ class Unwrap {
 
             let unwrappedData = { uv: _uv, append: [] };
             if (!_uv) {
-                unwrappedData = self.boxUnwrap(_ib, _positions);
+                unwrappedData = this.boxUnwrap(_ib, _positions);
                 _uv = unwrappedData.uv;
             }
             const append = unwrappedData.append;
@@ -1024,15 +1023,15 @@ class Unwrap {
         }
 
 
-        const charts = self.findCharts(ib);
-        const areasObj = self.calculateChartArea(ib, charts, positions, uv);
-        const scales = self.normalizeCharts(ib, charts, areasObj, uv);
+        const charts = this.findCharts(ib);
+        const areasObj = this.calculateChartArea(ib, charts, positions, uv);
+        const scales = this.normalizeCharts(ib, charts, areasObj, uv);
         globalScale = 1;
 
         if (this.cancel) {
             return;
         }
-        packResult = self.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
+        packResult = this.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
 
         if (this.progress) {
             this.progress(30);
@@ -1043,7 +1042,7 @@ class Unwrap {
                 return;
             }
             globalScale /= 1 + areasObj.notFitted;
-            packResult = self.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
+            packResult = this.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
         }
         packedScaleOffset = packResult.scaleOffset;
 
@@ -1063,7 +1062,7 @@ class Unwrap {
                 break;
             } // float precision
 
-            packResult = self.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
+            packResult = this.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
             if (!packResult.fit) {
                 break;
             }
@@ -1074,10 +1073,10 @@ class Unwrap {
         }
 
         globalScale -= step;
-        packResult = self.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
+        packResult = this.packCharts(ib, charts, areasObj.aabbs, areasObj, uv, scales, globalScale);
         packedScaleOffset = packResult.scaleOffset;
 
-        self.finalTransformUv(ib, charts, uv, scales, globalScale, packedScaleOffset);
+        this.finalTransformUv(ib, charts, uv, scales, globalScale, packedScaleOffset);
 
 
         for (i = 0; i < data.model.vertices.length; i++) {

--- a/src/editor/entities/entities-scripts.ts
+++ b/src/editor/entities/entities-scripts.ts
@@ -69,21 +69,19 @@ editor.once('load', () => {
         // Called when a new entity is added. Adds the entity to the index
         // and subscribes to component script events
         onEntityAdd(entity: Observer) {
-            const self = this;
-
             const scripts = entity.get('components.script.order');
             if (scripts) {
                 for (let i = 0; i < scripts.length; i++) {
-                    self.add(entity, scripts[i]);
+                    this.add(entity, scripts[i]);
                 }
             }
 
             entity.on('components.script.order:insert', (script, index, remote) => {
-                self.add(entity, script);
+                this.add(entity, script);
             });
 
             entity.on('components.script.order:remove', (script) => {
-                self.remove(entity, script);
+                this.remove(entity, script);
             });
 
             entity.on('components.script:unset', (scriptComponent) => {
@@ -91,7 +89,7 @@ editor.once('load', () => {
                 if (scriptOrder) {
                     let i = scriptOrder.length;
                     while (i--) {
-                        self.remove(entity, scriptOrder[i]);
+                        this.remove(entity, scriptOrder[i]);
                     }
                 }
             });

--- a/src/editor/store/assetsStore.ts
+++ b/src/editor/store/assetsStore.ts
@@ -177,9 +177,8 @@ class AssetsStore extends BaseStore {
             return newItems;
         }
 
-        const self = this;
-        const load = async function (item: { id: string }) {
-            return self._prepareItem(await editor.api.globals.rest.store.storeGet(item.id).promisify());
+        const load = async (item: { id: string }) => {
+            return this._prepareItem(await editor.api.globals.rest.store.storeGet(item.id).promisify());
         };
 
         for (const item of items) {

--- a/src/editor/store/myAssetsStore.ts
+++ b/src/editor/store/myAssetsStore.ts
@@ -72,9 +72,8 @@ class MyAssetsStore extends BaseStore {
             return newItems;
         }
 
-        const self = this;
-        const load = async function (item: { id: string }) {
-            return self._prepareItem(await editor.api.globals.rest.assets.assetGet(item.id).promisify());
+        const load = async (item: { id: string }) => {
+            return this._prepareItem(await editor.api.globals.rest.assets.assetGet(item.id).promisify());
         };
 
         for (const item of items) {

--- a/src/editor/store/sketchFabStore.ts
+++ b/src/editor/store/sketchFabStore.ts
@@ -140,15 +140,14 @@ class SketchFabStore extends BaseStore {
             return newItems;
         }
 
-        const self = this;
-        const load = async function (item: { id: string; thumbnails: { images: { url: string }[] }; assets?: unknown }) {
+        const load = async (item: { id: string; thumbnails: { images: { url: string }[] }; assets?: unknown }) => {
             const url = `https://api.sketchfab.com/v3/models/${item.id}`;
             const response = await fetch(url);
             if (!response.ok) {
                 log.error`sketchfab fetch failed ${response.status}: ${response.statusText}`;
                 return null;
             }
-            return self._prepareItem(await response.json(), item.assets);
+            return this._prepareItem(await response.json(), item.assets);
         };
 
         for (const item of items) {

--- a/src/editor/viewport/gizmo/gizmo-camera.ts
+++ b/src/editor/viewport/gizmo/gizmo-camera.ts
@@ -134,10 +134,8 @@ editor.once('load', () => {
             this.unlink();
             this._link = obj;
 
-            const self = this;
-
             this.events.push(this._link.once('destroy', () => {
-                self.unlink();
+                this.unlink();
             }));
         }
 

--- a/src/editor/viewport/gizmo/gizmo-light.ts
+++ b/src/editor/viewport/gizmo/gizmo-light.ts
@@ -190,10 +190,8 @@ editor.once('load', () => {
             this.unlink();
             this._link = obj;
 
-            const self = this;
-
             this.events.push(this._link.once('destroy', () => {
-                self.unlink();
+                this.unlink();
             }));
 
             this.entity = new Entity();

--- a/src/editor/viewport/gizmo/gizmo-particles.ts
+++ b/src/editor/viewport/gizmo/gizmo-particles.ts
@@ -153,10 +153,8 @@ editor.once('load', () => {
             this.unlink();
             this._link = obj;
 
-            const self = this;
-
             this.events.push(this._link.once('destroy', () => {
-                self.unlink();
+                this.unlink();
             }));
 
             this.entity = new Entity();

--- a/src/editor/viewport/gizmo/gizmo-zone.ts
+++ b/src/editor/viewport/gizmo/gizmo-zone.ts
@@ -372,10 +372,8 @@ editor.once('load', () => {
                 this.unlink();
                 this._link = obj;
 
-                const self = this;
-
                 this.events.push(this._link.once('destroy', () => {
-                    self.unlink();
+                    this.unlink();
                 }));
 
                 this.entity = new Entity();
@@ -386,9 +384,7 @@ editor.once('load', () => {
                     layers: [layerBack.id, layerFront.id]
                 });
                 this.entity.model.addModelToLayers = addModelToLayers;
-                this.entity._getEntity = function () {
-                    return self._link.entity;
-                };
+                this.entity._getEntity = () => this._link.entity;
                 this.entity.setLocalScale(1, 1, 1);
                 this.entity.__editor = true;
 


### PR DESCRIPTION
## Summary

Removes redundant `const self = this` aliases across several legacy files. These were originally needed to preserve the enclosing `this` inside `function` expressions; with class methods and arrow callbacks, `this` is already lexically bound and the alias is dead weight.

Follows the pattern established in #2038.

## Changes

**Category A** — drop the alias, replace `self` with `this` (`self` was only used inside arrow callbacks or directly in the method body):

- `src/editor/entities/entities-scripts.ts` (`onEntityAdd`)
- `src/editor/viewport/gizmo/gizmo-camera.ts` (`link()`)
- `src/editor/viewport/gizmo/gizmo-light.ts` (`link()`)
- `src/editor/viewport/gizmo/gizmo-particles.ts` (`link()`)
- `src/common/unwrap.ts` (direct method-body use, no nested functions)

**Category B** — also convert a nearby `function` expression to an arrow, then drop the alias:

- `src/editor/viewport/gizmo/gizmo-zone.ts` (`link()`) — converted `this.entity._getEntity = function () {...}` to an arrow.
- `src/editor/store/sketchFabStore.ts` (`prepareItems()`) — converted inner `const load = async function (item) {...}` to an async arrow.
- `src/editor/store/myAssetsStore.ts` (`prepareItems()`) — same.
- `src/editor/store/assetsStore.ts` (`prepareItems()`) — same.

**Out of scope (intentionally)**:

- `src/common/ui/element.ts` — legacy pattern with many `function` handlers, higher churn; deferred.
- `src/common/ui/color-field.ts` — `self` there is a local type-cast alias (`this as LegacyColorField & { ui: { disabled: boolean } }`), a different kind of cleanup.

## Public API changes

None. Pure refactor; no behavior change.

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run type:check` reports the same number of errors as `main` (no new TS errors).
- [x] Smoke-test the editor: open a scene, confirm gizmos render (camera, light, particles, zone), confirm script-component entity tracking works, confirm the asset/sketchfab stores list items correctly.
