### PR TITLE
docs: clarify spotlight cone angles are half-angles

### DIFF
--- a/src/editor/attributes/reference/components/light.ts
+++ b/src/editor/attributes/reference/components/light.ts
@@ -38,13 +38,13 @@ export const fields: AttributeReference[]  = [{
     name: 'light:innerConeAngle',
     title: 'innerConeAngle',
     subTitle: '{Number}',
-    description: 'The angle at which the spotlight cone starts to fade off. The angle is specified in degrees. Affects spot lights only.',
+    description: 'The half-angle (measured in degrees from the light\'s direction axis to the cone edge) at which the spotlight cone starts to fade off. The full inner beam angle is twice this value. Affects spot lights only.',
     url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#innerconeangle'
 }, {
     name: 'light:outerConeAngle',
     title: 'outerConeAngle',
     subTitle: '{Number}',
-    description: 'The angle at which the spotlight cone has faded to nothing. The angle is specified in degrees. Affects spot lights only.',
+    description: 'The half-angle (measured in degrees from the light\'s direction axis to the cone edge) at which the spotlight cone has faded to nothing. The full outer beam angle is twice this value. Affects spot lights only.',
     url: 'https://api.playcanvas.com/engine/classes/LightComponent.html#outerconeangle'
 }, {
     name: 'light:shape',


### PR DESCRIPTION
## Summary

- Updates the attribute reference tooltips for `light:innerConeAngle` and `light:outerConeAngle` to state explicitly that these are **half-angles** (measured from the light's direction axis to the cone edge), and calls out the resulting full beam angle.
- No behavior change — tooltip text only.

## Motivation

The current tooltip matches the engine's JSDoc verbatim: "The angle at which the spotlight cone has faded to nothing." That reads naturally as the full beam angle — the convention used in Unity, Maya, 3ds Max, Unreal, Blender and essentially every DCC tool. PlayCanvas actually stores the half-angle (which is what the shader math needs and what glTF `KHR_lights_punctual` uses), so a user setting `outerConeAngle` to 45 gets a **90° cone**, not a 45° one. The default value of `45` compounds the confusion.

This PR doesn't change the convention — it just stops the inspector tooltip from quietly misleading users. It pairs with [playcanvas/engine#8665](https://github.com/playcanvas/engine/pull/8665), which applies the equivalent fix to the JSDoc source.

## Before / After

Before:

> The angle at which the spotlight cone has faded to nothing. The angle is specified in degrees. Affects spot lights only.

After:

> The half-angle (measured in degrees from the light's direction axis to the cone edge) at which the spotlight cone has faded to nothing. The full outer beam angle is twice this value. Affects spot lights only.

`light:innerConeAngle` gets the equivalent treatment.

## Test plan

- [x] `npm run lint` clean on changed file
- Hover the `Outer Cone Angle` / `Inner Cone Angle` fields in the Spot Light inspector and confirm the tooltip wording.
