### PR TITLE
fix: improve asset rename conflict feedback

### DIFF
--- a/sass/code-editor.scss
+++ b/sass/code-editor.scss
@@ -351,6 +351,12 @@ strong {
         font-size: 16px;
     }
 
+    .pcui-treeview-item.pcui-treeview-item-rename {
+        .files-rename-input.pcui-error {
+            border-bottom: 2px solid $status-error !important;
+        }
+    }
+
     .pcui-treeview-item.dirty {
         .pcui-treeview-item-contents:not(.pcui-treeview-item-selected) {
             color: color.adjust($muted-yellow, $alpha: -0.15);
@@ -359,6 +365,32 @@ strong {
         .pcui-treeview-item-contents.pcui-treeview-item-selected {
             color: $muted-yellow;
         }
+    }
+}
+
+.files-rename-error-popup {
+    position: absolute;
+    z-index: 10002;
+    max-width: 320px;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    background: $status-error;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 35%);
+    color: white;
+    font-size: 12px;
+    line-height: 16px;
+    pointer-events: none;
+    white-space: normal;
+    word-break: break-word;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: 12px;
+        border-right: 4px solid transparent;
+        border-bottom: 4px solid $status-error;
+        border-left: 4px solid transparent;
     }
 }
 

--- a/sass/pcui/_pcui-inspector.scss
+++ b/sass/pcui/_pcui-inspector.scss
@@ -13,6 +13,21 @@
 
             min-width: 0;
         }
+
+        &.asset-rename-error-group {
+            flex-wrap: wrap;
+            align-items: flex-start;
+
+            > .pcui-label.asset-rename-error:not(:first-child) {
+                flex-basis: calc(65% - #{$element-margin});
+                margin: 3px 0 0 calc(35% + #{$element-margin});
+                color: #f30;
+                font-size: 12px;
+                line-height: 16px;
+                white-space: normal;
+                word-break: break-word;
+            }
+        }
     }
 
     > .pcui-asset-input {

--- a/src/code-editor/files-panel/files-panel.ts
+++ b/src/code-editor/files-panel/files-panel.ts
@@ -1,5 +1,13 @@
-import type { Observer } from '@playcanvas/observer';
-import { Progress, TreeView, TreeViewItem, Panel } from '@playcanvas/pcui';
+import type { EventHandle, Observer } from '@playcanvas/observer';
+import { Progress, TextInput, TreeView, TreeViewItem, Panel } from '@playcanvas/pcui';
+
+const TEXT_TYPES = new Set(['css', 'html', 'json', 'script', 'shader', 'text']);
+const RENAME_CLASS = 'pcui-treeview-item-rename';
+const POPUP_GAP = 4;
+
+type FileTreeItem = TreeViewItem & {
+    _assetId: string;
+};
 
 editor.once('load', () => {
     const icons: Map<string, string> = new Map();
@@ -21,9 +29,73 @@ editor.once('load', () => {
     });
     panel.append(tree);
 
+    const root = editor.call('layout.root');
+    const renamePopup = document.createElement('div');
+    renamePopup.className = 'files-rename-error-popup';
+    renamePopup.hidden = true;
+    root.dom.appendChild(renamePopup);
+
+    let activeRename: (() => void) | null = null;
+    let suspendRename = false;
+
+    const hideRenameError = () => {
+        renamePopup.hidden = true;
+        renamePopup.textContent = '';
+    };
+
+    const positionRenameError = (input: TextInput) => {
+        const rootRect = root.dom.getBoundingClientRect();
+        const inputRect = input.dom.getBoundingClientRect();
+        const popupRect = renamePopup.getBoundingClientRect();
+        const x = Math.max(4, Math.min(rootRect.width - popupRect.width - 4, inputRect.left - rootRect.left));
+        const y = Math.max(4, Math.min(rootRect.height - popupRect.height - 4, inputRect.bottom - rootRect.top + POPUP_GAP));
+
+        renamePopup.style.left = `${x}px`;
+        renamePopup.style.top = `${y}px`;
+    };
+
+    const showRenameError = (input: TextInput, text: string) => {
+        renamePopup.textContent = text;
+        renamePopup.hidden = false;
+        requestAnimationFrame(() => positionRenameError(input));
+    };
+
+    const getParent = (asset: Observer) => {
+        const path = asset.get('path');
+        return path && path.length ? path[path.length - 1] : null;
+    };
+
+    const getRenameError = (asset: Observer, name: string) => {
+        const type = asset.get('type');
+        if (!TEXT_TYPES.has(type) && type !== 'folder') {
+            return null;
+        }
+
+        const id = asset.get('id');
+        const parent = getParent(asset);
+        const target = name.toLowerCase();
+        const collision = (editor.call('assets:list') || []).some((item: Observer) => {
+            if (item.get('id') === id) {
+                return false;
+            }
+
+            return getParent(item) === parent && item.get('name').toLowerCase() === target;
+        });
+
+        return collision ? `An asset named "${name}" already exists in this folder. Please choose a different name.` : null;
+    };
+
+    const getItemAsset = (item: TreeViewItem) => {
+        return editor.call('assets:get', (item as FileTreeItem)._assetId);
+    };
+
     // Handle tree item renaming via the context menu
     tree.on('rename', (item: TreeViewItem, name: string) => {
-        const asset = editor.call('assets:get', item._assetId);
+        if (suspendRename) {
+            return;
+        }
+
+        const asset = getItemAsset(item);
         const error = editor.call('assets:rename', asset, name);
         if (error) {
             item.text = asset.get('name');
@@ -54,6 +126,126 @@ editor.once('load', () => {
     editor.on('permissions:writeState', refreshTreePermissions);
     editor.on('realtime:authenticated', refreshTreePermissions);
     editor.on('realtime:disconnected', refreshTreePermissions);
+
+    editor.method('files:rename:start', (item: TreeViewItem) => {
+        if (!editor.call('permissions:write')) {
+            return;
+        }
+
+        const asset = getItemAsset(item);
+        if (!asset) {
+            return;
+        }
+
+        if (activeRename) {
+            activeRename();
+        }
+
+        const contents = item.dom.childNodes[0] as HTMLElement & { ui: { append: (element: TextInput) => void } };
+        const input = new TextInput({
+            blurOnEnter: false,
+            blurOnEscape: false,
+            class: 'files-rename-input',
+            renderChanges: false,
+            value: asset.get('name')
+        });
+
+        let closing = false;
+        let destroyed = false;
+        let destroyEvt: EventHandle | null = null;
+
+        const close = () => {
+            if (closing) {
+                return;
+            }
+
+            closing = true;
+            if (activeRename === close) {
+                activeRename = null;
+            }
+
+            hideRenameError();
+            destroyEvt?.unbind();
+            if (!destroyed) {
+                input.input.removeEventListener('input', clearError);
+                item.class.remove(RENAME_CLASS);
+                input.destroy();
+                item.focus();
+            }
+        };
+
+        const fail = (text: string) => {
+            input.error = true;
+            showRenameError(input, text);
+            requestAnimationFrame(() => {
+                if (!closing) {
+                    input.focus();
+                }
+            });
+        };
+
+        const commit = () => {
+            const name = input.value.trim();
+            if (!name || name === asset.get('name')) {
+                close();
+                return true;
+            }
+
+            const error = getRenameError(asset, name) || editor.call('assets:rename', asset, name);
+            if (error) {
+                fail(error);
+                return false;
+            }
+
+            suspendRename = true;
+            item.text = name;
+            suspendRename = false;
+            close();
+            return true;
+        };
+
+        function clearError() {
+            input.error = false;
+            hideRenameError();
+        }
+
+        input.on('keydown', (evt: KeyboardEvent) => {
+            if (evt.key === 'Enter') {
+                evt.preventDefault();
+                evt.stopPropagation();
+                commit();
+            } else if (evt.key === 'Escape') {
+                evt.preventDefault();
+                evt.stopPropagation();
+                close();
+            }
+        });
+
+        input.on('blur', () => {
+            if (!closing && !commit()) {
+                requestAnimationFrame(() => {
+                    if (!closing) {
+                        input.focus();
+                    }
+                });
+            }
+        });
+
+        input.input.addEventListener('input', clearError);
+        destroyEvt = item.once('destroy', () => {
+            destroyed = true;
+            closing = true;
+            if (activeRename === close) {
+                activeRename = null;
+            }
+            hideRenameError();
+        });
+        activeRename = close;
+
+        item.class.add(RENAME_CLASS);
+        contents.ui.append(input);
+        input.focus(true);
+    });
 
     const treeRoot = new TreeViewItem({
         allowSelect: false,

--- a/src/code-editor/menu-panel/file/rename.ts
+++ b/src/code-editor/menu-panel/file/rename.ts
@@ -24,7 +24,7 @@ editor.once('load', () => {
 
             const treeItem = editor.call('files:getTreeItem', selected[0].get('id'));
             if (treeItem) {
-                treeItem.rename();
+                editor.call('files:rename:start', treeItem);
             }
         }
     }));

--- a/src/editor/assets/assets-rename.ts
+++ b/src/editor/assets/assets-rename.ts
@@ -33,7 +33,6 @@ editor.once('load', () => {
 
             if (collision) {
                 const message = `An asset named "${newName}" already exists in this folder. Please choose a different name.`;
-                editor.call('status:error', message);
                 return message;
             }
         }

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -360,8 +360,6 @@ class AssetInspector extends Container {
 
     private _assetEvents: EventHandle[] = [];
 
-    private _renameInFlight = false;
-
     private _renameError: Label | null = null;
 
     constructor(args: Record<string, unknown> = {}) {
@@ -705,19 +703,12 @@ class AssetInspector extends Container {
     }
 
     _updateAssetName(value: string) {
-        // ignore the change event fired by our own programmatic field revert below
-        if (this._renameInFlight) {
-            return;
-        }
         if (!value) {
             this._setRenameError();
             return;
         }
         const error = editor.call('assets:rename', this._assets[0], value);
         if (error) {
-            this._renameInFlight = true;
-            this._attributesInspector.getField('name').value = this._assets[0].get('name');
-            this._renameInFlight = false;
             this._setRenameError(error);
         } else {
             this._setRenameError();

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -1,5 +1,5 @@
 import type { EventHandle, Observer, ObserverList } from '@playcanvas/observer';
-import { Container, Button, Menu, BindingObserversToElement } from '@playcanvas/pcui';
+import { Container, Button, Menu, BindingObserversToElement, Label } from '@playcanvas/pcui';
 
 
 import { bytesToHuman, convertDatetime } from '@/common/utils';
@@ -362,6 +362,8 @@ class AssetInspector extends Container {
 
     private _renameInFlight = false;
 
+    private _renameError: Label | null = null;
+
     constructor(args: Record<string, unknown> = {}) {
         args.flex = true;
 
@@ -474,9 +476,16 @@ class AssetInspector extends Container {
 
         // one way binding from observers to element for name field
         // because the other way is handled by calling assets:rename
-        this._attributesInspector.getField('name').binding = new BindingObserversToElement({
+        const nameField = this._attributesInspector.getField('name');
+        nameField.binding = new BindingObserversToElement({
             history: args.history
         });
+        this._renameError = new Label({
+            class: 'asset-rename-error',
+            hidden: true
+        });
+        nameField.parent.class.add('asset-rename-error-group');
+        nameField.parent.append(this._renameError);
 
         this._assetTypes.forEach((assetType) => {
             // check if class exists
@@ -701,6 +710,7 @@ class AssetInspector extends Container {
             return;
         }
         if (!value) {
+            this._setRenameError();
             return;
         }
         const error = editor.call('assets:rename', this._assets[0], value);
@@ -708,6 +718,18 @@ class AssetInspector extends Container {
             this._renameInFlight = true;
             this._attributesInspector.getField('name').value = this._assets[0].get('name');
             this._renameInFlight = false;
+            this._setRenameError(error);
+        } else {
+            this._setRenameError();
+        }
+    }
+
+    _setRenameError(text: string = '') {
+        const field = this._attributesInspector.getField('name');
+        field.error = !!text;
+        if (this._renameError) {
+            this._renameError.text = text;
+            this._renameError.hidden = !text;
         }
     }
 
@@ -721,6 +743,7 @@ class AssetInspector extends Container {
         this._assets = assets;
 
         this._containerButtons.hidden = false;
+        this._setRenameError();
 
         const legacyScripts = this._projectSettings.get('useLegacyScripts');
 
@@ -745,6 +768,7 @@ class AssetInspector extends Container {
 
         assets.forEach((asset) => {
             this._assetEvents.push(asset.on('file.size:set', this._updateFileSize.bind(this)));
+            this._assetEvents.push(asset.on('name:set', () => this._setRenameError()));
         });
 
         this._attributesInspector.getField('source_asset_id').values = assets.map((asset) => {
@@ -897,6 +921,7 @@ class AssetInspector extends Container {
 
     unlink() {
         super.unlink();
+        this._setRenameError();
 
         if (!this._assets) {
             return;

--- a/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
@@ -102,8 +102,6 @@ editor.once('load', () => {
                 suspendRenameEvt = true;
                 const error = editor.call('assets:rename', spriteAsset, value);
                 if (error) {
-                    fieldName.value = spriteAsset.get('name');
-                    rootPanel.headerText = `SPRITE ASSET - ${spriteAsset.get('name')}`;
                     setRenameError(error);
                 } else {
                     setRenameError();

--- a/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
+++ b/src/editor/pickers/sprite-editor/sprite-editor-sprite-panel.ts
@@ -83,6 +83,17 @@ editor.once('load', () => {
         // Custom handling for Name field (rename asset)
         let suspendRenameEvt = false;
         const fieldName = inspector.getField('name') as TextInput;
+        const renameError = new Label({
+            class: 'asset-rename-error',
+            hidden: true
+        });
+        fieldName.parent.class.add('asset-rename-error-group');
+        fieldName.parent.append(renameError);
+        const setRenameError = (text = '') => {
+            fieldName.error = !!text;
+            renameError.text = text;
+            renameError.hidden = !text;
+        };
         fieldName.value = spriteAsset.get('name');
 
         events.push(fieldName.on('change', (value: string) => {
@@ -93,14 +104,20 @@ editor.once('load', () => {
                 if (error) {
                     fieldName.value = spriteAsset.get('name');
                     rootPanel.headerText = `SPRITE ASSET - ${spriteAsset.get('name')}`;
+                    setRenameError(error);
+                } else {
+                    setRenameError();
                 }
                 suspendRenameEvt = false;
+            } else if (!value) {
+                setRenameError();
             }
         }));
 
         events.push(spriteAsset.on('name:set', (value: string) => {
             suspendRenameEvt = true;
             fieldName.value = value;
+            setRenameError();
             suspendRenameEvt = false;
         }));
 


### PR DESCRIPTION
Fixes #2044

### What's Changed
- Add duplicate-name validation for text and folder asset renames.
- Show inline asset inspector rename errors for existing editor rename surfaces.
- Show a code editor file-tree rename conflict popup instead of relying on the status bar.
- Keep expected duplicate rename conflicts in the rename UI instead of also emitting status-bar errors.

### Preview
**Editor**
<img width="546" height="162" alt="image" src="https://github.com/user-attachments/assets/af136f6b-3f2f-4c7c-8d76-307c45ac1a37" />

**Code Editor**
<img width="454" height="213" alt="image" src="https://github.com/user-attachments/assets/b8f7e0b2-7ada-4751-a35f-6120a2890c21" />

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)