### PR TITLE
fix: create default import map as json

### DIFF
--- a/src/editor/inspector/settings-panels/import-map.ts
+++ b/src/editor/inspector/settings-panels/import-map.ts
@@ -144,7 +144,7 @@ class ImportMapSettingsPanel extends BaseSettingsPanel {
     _clickCreateDefault() {
         this._createDefaultButton.enabled = false;
         editor.call('assets:create:json', {
-            name: 'Import Map',
+            name: 'import-map.json',
             json: JSON.stringify({ imports: {} }, null, 2),
             spaces: 2,
             noSelect: true,


### PR DESCRIPTION
Fixes #2043

### What's Changed
- Rename the default import map asset to `import-map.json` so the upload filename keeps a JSON extension.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- [x] `npx eslint src/editor/inspector/settings-panels/import-map.ts`