### PR TITLE
fix: allow asset path modification from observer sync

### DIFF
--- a/src/editor/assets/assets-sync.ts
+++ b/src/editor/assets/assets-sync.ts
@@ -4,6 +4,7 @@ editor.once('load', () => {
     const legacyScripts = editor.call('settings:project').get('useLegacyScripts');
     const syncPaths = [
         'name',
+        'path',
         'exclude',
         'preload',
         'tags',


### PR DESCRIPTION
### What's Changed
- Allow asset path changes to sync through the asset observer whitelist.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)