### PR TITLE
fix: wait for async checkpoint creation

### DIFF
--- a/src/editor-api/rest/checkpoints.ts
+++ b/src/editor-api/rest/checkpoints.ts
@@ -1,6 +1,6 @@
 import { Ajax } from '../ajax';
 import { globals as api } from '../globals';
-import type { Checkpoint, User } from '../models';
+import type { Checkpoint, Job, User } from '../models';
 
 // args
 export type CheckpointCreateArgs = {
@@ -55,12 +55,21 @@ export type CheckpointResponse = Pick<Checkpoint, 'id' | 'createdAt' | 'descript
 export type CheckpointUserResponse = Pick<Checkpoint, 'id' | 'createdAt' | 'description'> & {
     user: Pick<User, 'id' | 'fullName' | 'username'>;
 };
+export type CheckpointCreateJobData = Partial<CheckpointUserResponse> & {
+    type?: 'checkpoint_create';
+    project_id?: number;
+    branch_id?: string;
+    user_id?: number;
+    all_new_immutable?: string;
+    description: string;
+    user?: Pick<User, 'id' | 'fullName' | 'username'>;
+};
 
 /**
  * Creates a new checkpoint
  */
 export const checkpointCreate = (args: CheckpointCreateArgs) => {
-    return Ajax.post<CheckpointUserResponse>({
+    return Ajax.post<Job<CheckpointCreateJobData>>({
         url: `${api.apiUrl}/checkpoints`,
         auth: true,
         data: {

--- a/src/editor/messenger/jobs.ts
+++ b/src/editor/messenger/jobs.ts
@@ -2,32 +2,47 @@ import { Defer } from '@/common/defer';
 
 const { rest } = editor.api.globals;
 
-export const diffCreate = (args: Parameters<typeof rest.diff.diffCreate>[0]) => {
-    const defer = new Defer<Awaited<ReturnType<ReturnType<typeof rest.diff.diffCreate>['promisify']>>>();
-    const promise = new Promise((resolve, reject) => {
-        const jobUpdate = editor.on('messenger:job.update', async ({ job: jobData }) => {
-            const job = await defer.promise;
-            if (jobData.id !== job.id) {
-                return;
-            }
-            jobUpdate.unbind();
+type JobStart = {
+    promisify: () => Promise<{ id: number }>;
+};
 
-            try {
-                // Verify the job completed successfully
-                const completedJob = await rest.jobs.jobGet({ jobId: job.id }).promisify();
-                if (completedJob.status === 'error') {
-                    throw new Error(completedJob.messages?.[0] ?? 'Checkpoint diff failed');
+type DiffJob = Awaited<ReturnType<ReturnType<typeof rest.diff.diffCreate>['promisify']>>;
+type Checkpoint = Awaited<ReturnType<ReturnType<typeof rest.checkpoints.checkpointGet>['promisify']>>;
+
+const waitForJob = <T extends object>(request: JobStart, message: string) => {
+    const defer = new Defer<{ id: number }>();
+    const promise = new Promise<T>((resolve, reject) => {
+        const jobUpdate = editor.on('messenger:job.update', ({ job: jobData }: { job: { id: number } }) => {
+            defer.promise.then((job) => {
+                if (jobData.id !== job.id) {
+                    return;
                 }
+                jobUpdate.unbind();
 
-                // Fetch the full diff payload from S3 (the job document only
-                // stores summary metadata to stay under the MongoDB 16MB limit).
-                const diff = await rest.diff.diffGet({ id: job.data.merge_id }).promisify();
-                resolve(diff);
-            } catch (err) {
-                reject(err);
-            }
+                rest.jobs.jobGet({ jobId: job.id }).promisify().then((completedJob) => {
+                    if (completedJob.status === 'error') {
+                        reject(new Error(completedJob.messages?.[0] ?? message));
+                        return;
+                    }
+                    resolve(completedJob.data as T);
+                }).catch(reject);
+            }).catch(reject);
+        });
+
+        request.promisify().then(defer.resolve).catch((err) => {
+            jobUpdate.unbind();
+            reject(err);
         });
     });
-    rest.diff.diffCreate(args).promisify().then(defer.resolve).catch(defer.reject);
     return promise;
+};
+
+export const checkpointCreate = (args: Parameters<typeof rest.checkpoints.checkpointCreate>[0]) => {
+    return waitForJob<Checkpoint>(rest.checkpoints.checkpointCreate(args), 'Checkpoint create failed');
+};
+
+export const diffCreate = (args: Parameters<typeof rest.diff.diffCreate>[0]) => {
+    return waitForJob<DiffJob['data']>(rest.diff.diffCreate(args), 'Checkpoint diff failed').then((data) => {
+        return rest.diff.diffGet({ id: data.merge_id }).promisify();
+    });
 };

--- a/src/editor/pickers/picker-fix-corrupted-templates.ts
+++ b/src/editor/pickers/picker-fix-corrupted-templates.ts
@@ -1,5 +1,7 @@
 import { Overlay, Container, Label, Button, Spinner } from '@playcanvas/pcui';
 
+import { checkpointCreate } from '../messenger/jobs';
+
 editor.once('load', () => {
     if (!editor.call('users:hasFlag', 'hasFixCorruptedTemplates')) {
         return;
@@ -121,7 +123,7 @@ editor.once('load', () => {
     content.append(progressButtons);
 
     let currentState = null;
-    function setState(state: number, data?: Record<string, unknown>) {
+    function setState(state: number, data?: unknown) {
         if (currentState === state) {
             return;
         }
@@ -199,15 +201,15 @@ editor.once('load', () => {
 
         // take checkpoint
         progressText.text = 'Creating checkpoint...';
-        editor.api.globals.rest.checkpoints.checkpointCreate({
+        checkpointCreate({
             projectId: config.project.id,
             branchId: config.self.branch.id,
             description: `Checkpoint before executing corrupted templates migration in branch '${config.self.branch.name}'`
-        }).on('load', (status, data) => {
+        }).then(() => {
             progressText.text = 'Migrating...';
             editor.emit('picker:fixCorruptedTemplates:confirm');
-        }).on('error', (status, err) => {
-            setState(STATE_ERROR, err);
+        }).catch((err) => {
+            setState(STATE_ERROR, err instanceof Error ? err.message : `${err}`);
         });
     });
 

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -5,7 +5,7 @@ import { LegacyListItem } from '@/common/ui/list-item';
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
-import { diffCreate } from '../../messenger/jobs';
+import { checkpointCreate as checkpointCreateJob, diffCreate } from '../../messenger/jobs';
 
 editor.once('load', () => {
     if (config.project.settings.useLegacyScripts) {
@@ -20,8 +20,6 @@ editor.once('load', () => {
     let branchesSkip = null;
     let selectedBranch = null;
     let showNewCheckpointOnLoad = false;
-
-    let currentCheckpointId = null;
 
     // main panel
     const panel = new Container({
@@ -294,20 +292,20 @@ editor.once('load', () => {
         panelBranchesFilter.enabled = enabled;
     };
 
-    const checkpointCallbackQueue = [];
-    const createCheckpoint = function (branchId: string, description: string, callback: () => void) {
+    const createCheckpoint = function (branchId: string, description: string, callback: (checkpoint?: Record<string, unknown>) => void) {
         togglePanels(false);
         showRightSidePanel(panelCreateCheckpointProgress);
 
-        // push callback to queue
-        checkpointCallbackQueue.push(callback);
-
-        // NOTE: do not handle callback here in case checkpoint takes a while to create
-        // and request times out. Callback is handled through messenger event
-        editor.api.globals.rest.checkpoints.checkpointCreate({
+        checkpointCreateJob({
             projectId: config.project.id,
             branchId,
             description
+        }).then((checkpoint) => {
+            panelCreateCheckpointProgress.finish(null);
+            callback(checkpoint as Record<string, unknown>);
+        }).catch((err) => {
+            panelCreateCheckpointProgress.finish(err instanceof Error ? err.message : `${err}`);
+            togglePanels(true);
         });
     };
 
@@ -1159,24 +1157,8 @@ editor.once('load', () => {
             });
         }));
 
-        events.push(editor.on('messenger:checkpoint.createStarted', (data: Record<string, unknown>) => {
-            currentCheckpointId = data.checkpoint_id;
-        }));
-
         // when a checkpoint is created add it to the list
         events.push(editor.on('messenger:checkpoint.createEnded', (data: Record<string, unknown>) => {
-
-            if (currentCheckpointId === data.checkpoint_id) {
-                const err = data.status === 'error' ? data.message : null;
-                panelCreateCheckpointProgress.finish(err);
-                if (err) {
-                    return togglePanels(true);
-                }
-
-                // shift callback from front of queue and call it
-                checkpointCallbackQueue.shift()?.();
-            }
-
             if (data.status === 'error') {
                 return;
             }

--- a/test-suite/globals.d.ts
+++ b/test-suite/globals.d.ts
@@ -11,11 +11,11 @@ interface DiffJobData {
     dst_branch_id: string;
 }
 
-interface DiffJob {
+interface Job<T = any> {
     id: number;
     status: 'complete' | 'running' | 'error';
     messages?: string[];
-    data: DiffJobData;
+    data: T;
 }
 
 interface DiffResult {
@@ -29,11 +29,11 @@ interface CheckpointListResponse {
 
 interface EditorRest extends Omit<OriginalRest, 'diff' | 'jobs' | 'branches'> {
     diff: Omit<OriginalRest['diff'], 'diffCreate'> & {
-        diffCreate(args: OriginalRest['diff']['DiffCreateArgs']): Promisifiable<DiffJob>;
+        diffCreate(args: OriginalRest['diff']['DiffCreateArgs']): Promisifiable<Job<DiffJobData>>;
         diffGet(args: { id: string }): Promisifiable<DiffResult>;
     };
     jobs: Omit<OriginalRest['jobs'], 'jobGet'> & {
-        jobGet(args: { jobId: number }): Promisifiable<DiffJob>;
+        jobGet(args: { jobId: number }): Promisifiable<Job>;
     };
     branches: Omit<OriginalRest['branches'], 'branchCheckpoints'> & {
         branchCheckpoints(args: OriginalRest['branches']['BranchCheckpointArgs']): Promisifiable<CheckpointListResponse>;

--- a/test-suite/test/api/version-control.test.ts
+++ b/test-suite/test/api/version-control.test.ts
@@ -55,15 +55,38 @@ test.describe('branch/checkpoint/diff/merge', () => {
             await page.goto(editorUrl(projectId), { waitUntil: 'networkidle' });
 
             [materialId, mainBranchId, mainCheckpointId] = await page.evaluate(async () => {
+                const createCheckpoint = async (description: string) => {
+                    const jobDeferred: PromiseWithResolvers<any> = Promise.withResolvers();
+                    const checkpointPromise = new Promise<any>((resolve, reject) => {
+                        const handle = window.editor.api.globals.messenger.on('message', async (name: string, data: any) => {
+                            const job = await jobDeferred.promise;
+                            if (name !== 'job.update' || data.job.id !== job.id) {
+                                return;
+                            }
+                            handle.unbind();
+                            const completed = await window.editor.api.globals.rest.jobs.jobGet({ jobId: job.id }).promisify();
+                            if (completed.status === 'error') {
+                                reject(new Error(completed.messages?.[0] ?? 'Checkpoint create failed'));
+                                return;
+                            }
+                            resolve(completed.data);
+                        });
+                    });
+
+                    const job = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
+                        projectId: window.editor.api.globals.projectId,
+                        branchId: window.editor.api.globals.branchId,
+                        description
+                    }).promisify();
+                    jobDeferred.resolve(job);
+                    return checkpointPromise;
+                };
+
                 // setup material
                 const material = await window.editor.api.globals.assets.createMaterial({ name: 'TEST_MATERIAL' });
 
                 // create checkpoint
-                const checkpoint = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
-                    projectId: window.editor.api.globals.projectId,
-                    branchId: window.editor.api.globals.branchId,
-                    description: 'BASE'
-                }).promisify();
+                const checkpoint = await createCheckpoint('BASE');
 
                 return [
                     material.get('id'),
@@ -95,16 +118,39 @@ test.describe('branch/checkpoint/diff/merge', () => {
             await page.waitForLoadState('networkidle');
 
             await page.evaluate(async (materialId) => {
+                const createCheckpoint = async (description: string) => {
+                    const jobDeferred: PromiseWithResolvers<any> = Promise.withResolvers();
+                    const checkpointPromise = new Promise<void>((resolve, reject) => {
+                        const handle = window.editor.api.globals.messenger.on('message', async (name: string, data: any) => {
+                            const job = await jobDeferred.promise;
+                            if (name !== 'job.update' || data.job.id !== job.id) {
+                                return;
+                            }
+                            handle.unbind();
+                            const completed = await window.editor.api.globals.rest.jobs.jobGet({ jobId: job.id }).promisify();
+                            if (completed.status === 'error') {
+                                reject(new Error(completed.messages?.[0] ?? 'Checkpoint create failed'));
+                                return;
+                            }
+                            resolve();
+                        });
+                    });
+
+                    const job = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
+                        projectId: window.editor.api.globals.projectId,
+                        branchId: window.editor.api.globals.branchId,
+                        description
+                    }).promisify();
+                    jobDeferred.resolve(job);
+                    return checkpointPromise;
+                };
+
                 // set material color RED
                 const material = await window.editor.api.globals.assets.findOne((asset: Observer) => asset.get('id') === materialId);
                 material.set('data.diffuse', [1, 0, 0]);
 
                 // create checkpoint
-                await window.editor.api.globals.rest.checkpoints.checkpointCreate({
-                    projectId: window.editor.api.globals.projectId,
-                    branchId: window.editor.api.globals.branchId,
-                    description: 'RED'
-                }).promisify();
+                await createCheckpoint('RED');
             }, materialId);
         })).toStrictEqual([]);
     });
@@ -130,16 +176,39 @@ test.describe('branch/checkpoint/diff/merge', () => {
             await page.waitForLoadState('networkidle');
 
             await page.evaluate(async (materialId) => {
+                const createCheckpoint = async (description: string) => {
+                    const jobDeferred: PromiseWithResolvers<any> = Promise.withResolvers();
+                    const checkpointPromise = new Promise<void>((resolve, reject) => {
+                        const handle = window.editor.api.globals.messenger.on('message', async (name: string, data: any) => {
+                            const job = await jobDeferred.promise;
+                            if (name !== 'job.update' || data.job.id !== job.id) {
+                                return;
+                            }
+                            handle.unbind();
+                            const completed = await window.editor.api.globals.rest.jobs.jobGet({ jobId: job.id }).promisify();
+                            if (completed.status === 'error') {
+                                reject(new Error(completed.messages?.[0] ?? 'Checkpoint create failed'));
+                                return;
+                            }
+                            resolve();
+                        });
+                    });
+
+                    const job = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
+                        projectId: window.editor.api.globals.projectId,
+                        branchId: window.editor.api.globals.branchId,
+                        description
+                    }).promisify();
+                    jobDeferred.resolve(job);
+                    return checkpointPromise;
+                };
+
                 // set material color GREEN
                 const material = await window.editor.api.globals.assets.findOne((asset: Observer) => asset.get('id') === materialId);
                 material.set('data.diffuse', [0, 1, 0]);
 
                 // create checkpoint
-                await window.editor.api.globals.rest.checkpoints.checkpointCreate({
-                    projectId: window.editor.api.globals.projectId,
-                    branchId: window.editor.api.globals.branchId,
-                    description: 'GREEN'
-                }).promisify();
+                await createCheckpoint('GREEN');
             }, materialId);
         })).toStrictEqual([]);
     });

--- a/test-suite/test/ui/version-control.test.ts
+++ b/test-suite/test/ui/version-control.test.ts
@@ -56,15 +56,38 @@ test.describe('branch/checkpoint/diff/merge', () => {
             await page.goto(editorUrl(projectId), { waitUntil: 'networkidle' });
 
             [materialId, mainBranchId, mainCheckpointId] = await page.evaluate(async () => {
+                const createCheckpoint = async (description: string) => {
+                    const jobDeferred: PromiseWithResolvers<any> = Promise.withResolvers();
+                    const checkpointPromise = new Promise<any>((resolve, reject) => {
+                        const handle = window.editor.api.globals.messenger.on('message', async (name: string, data: any) => {
+                            const job = await jobDeferred.promise;
+                            if (name !== 'job.update' || data.job.id !== job.id) {
+                                return;
+                            }
+                            handle.unbind();
+                            const completed = await window.editor.api.globals.rest.jobs.jobGet({ jobId: job.id }).promisify();
+                            if (completed.status === 'error') {
+                                reject(new Error(completed.messages?.[0] ?? 'Checkpoint create failed'));
+                                return;
+                            }
+                            resolve(completed.data);
+                        });
+                    });
+
+                    const job = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
+                        projectId: window.editor.api.globals.projectId,
+                        branchId: window.editor.api.globals.branchId,
+                        description
+                    }).promisify();
+                    jobDeferred.resolve(job);
+                    return checkpointPromise;
+                };
+
                 // setup material
                 const material = await window.editor.api.globals.assets.createMaterial({ name: 'TEST_MATERIAL' });
 
                 // create checkpoint
-                const checkpoint = await window.editor.api.globals.rest.checkpoints.checkpointCreate({
-                    projectId: window.editor.api.globals.projectId,
-                    branchId: window.editor.api.globals.branchId,
-                    description: 'BASE'
-                }).promisify();
+                const checkpoint = await createCheckpoint('BASE');
 
                 return [
                     material.get('id'),


### PR DESCRIPTION
### What's Changed
- Update checkpoint creation REST typing to return a job.
- Add a checkpoint job waiter and use it in version control flows.
- Update version-control tests to wait for completed checkpoint jobs.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- Manual tests: not run