### PR TITLE
feat: add download format selector

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3886,8 +3886,13 @@ strong {
         }
     }
 
-    .pcui-select-input.engine-version-dropdown {
+    .pcui-select-input.engine-version-dropdown,
+    .pcui-select-input.download-format-dropdown {
         margin: 0;
+    }
+
+    .pcui-select-input.download-format-dropdown {
+        width: 100%;
     }
 
     > .options > .pcui-container.field {

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -20,8 +20,7 @@ editor.once('load', () => {
     // holds events that need to be destroyed
     let events: EventHandle[] = [];
 
-    let containerOptionsWebLens: Container | null = null;
-    let containerOptionsNpmProject: Container | null = null;
+    let containerDownloadOptions: Container | null = null;
 
     // root container
     const container = new Container({
@@ -41,14 +40,11 @@ editor.once('load', () => {
         mode = 'publish';
         editor.call('picker:project', 'publish-new');
         container.class.remove('download-mode');
-        if (containerOptionsWebLens) {
-            containerOptionsWebLens.hidden = true;
+        if (containerDownloadOptions) {
+            containerDownloadOptions.hidden = true;
         }
-        if (containerOptionsNpmProject) {
-            containerOptionsNpmProject.hidden = true;
-        }
-        if (fieldOptionsNpmProject) {
-            fieldOptionsNpmProject.value = false;
+        if (fieldDownloadFormat) {
+            fieldDownloadFormat.value = DOWNLOAD_FORMAT_STATIC;
         }
         refreshDownloadFormatOptions();
     });
@@ -57,11 +53,8 @@ editor.once('load', () => {
         mode = 'download';
         editor.call('picker:project', 'publish-download');
         container.class.add('download-mode');
-        if (config.self.flags.superUser && containerOptionsWebLens) {
-            containerOptionsWebLens.hidden = false;
-        }
-        if (containerOptionsNpmProject) {
-            containerOptionsNpmProject.hidden = false;
+        if (containerDownloadOptions) {
+            containerDownloadOptions.hidden = false;
         }
         refreshDownloadFormatOptions();
     });
@@ -277,8 +270,7 @@ editor.once('load', () => {
     let fieldOptionsMinify: BooleanInput | null = null;
     let fieldOptionsSourcemaps: BooleanInput | null = null;
     let fieldOptionsOptimizeSceneFormat: BooleanInput | null = null;
-    let fieldOptionsWebLens: BooleanInput | null = null;
-    let fieldOptionsNpmProject: BooleanInput | null = null;
+    let fieldDownloadFormat: SelectInput | null = null;
     let containerBuildOptions: Container | null = null;
     let rowOptionsMinify: Container | null = null;
     let rowOptionsSourcemaps: Container | null = null;
@@ -286,8 +278,7 @@ editor.once('load', () => {
         concatenate: boolean,
         minify: boolean,
         sourcemaps: boolean,
-        optimizeSceneFormat: boolean,
-        webLens: boolean
+        optimizeSceneFormat: boolean
     } | null = null;
     let refreshingDownloadFormatOptions = false;
 
@@ -328,18 +319,13 @@ editor.once('load', () => {
         const optMinify = createOption('Minify Scripts', true);
         const optSourcemaps = createOption('Generate Source Maps', false);
         const optOptimizeFormat = createOption('Optimize Scene Format', false);
-        const optWebLens = createOption('Export to WebLens Format', false);
 
         fieldOptionsConcat = optConcat.input;
         fieldOptionsMinify = optMinify.input;
         fieldOptionsSourcemaps = optSourcemaps.input;
         fieldOptionsOptimizeSceneFormat = optOptimizeFormat.input;
-        fieldOptionsWebLens = optWebLens.input;
         rowOptionsMinify = optMinify.row;
         rowOptionsSourcemaps = optSourcemaps.row;
-
-        containerOptionsWebLens = optWebLens.row;
-        containerOptionsWebLens.hidden = true;
 
         fieldOptionsConcat.on('change', () => {
             refreshDownloadFormatOptions();
@@ -350,12 +336,11 @@ editor.once('load', () => {
         });
     }
 
-    const containerDownloadOptions = new Container({
+    containerDownloadOptions = new Container({
         class: 'options'
     });
     container.append(containerDownloadOptions);
-    containerOptionsNpmProject = containerDownloadOptions;
-    containerOptionsNpmProject.hidden = true;
+    containerDownloadOptions.hidden = true;
 
     const labelDownloadOptions = new Label({
         text: 'Download Options',
@@ -363,31 +348,29 @@ editor.once('load', () => {
     });
     containerDownloadOptions.append(labelDownloadOptions);
 
-    const rowNpmProject = new Container({
-        class: 'field'
-    });
-    containerDownloadOptions.append(rowNpmProject);
+    const downloadFormatOptions = [{
+        t: 'Static Website',
+        v: DOWNLOAD_FORMAT_STATIC
+    }, {
+        t: 'NPM + Vite Project (WIP)',
+        v: DOWNLOAD_FORMAT_NPM
+    }];
 
-    fieldOptionsNpmProject = new BooleanInput({
-        value: false
-    });
-    rowNpmProject.append(fieldOptionsNpmProject);
-
-    const labelNpmProject = new Label({
-        text: 'Export as NPM Project'
-    });
-    rowNpmProject.append(labelNpmProject);
-
-    if (fieldOptionsWebLens) {
-        fieldOptionsWebLens.on('change', (value: boolean) => {
-            if (value && fieldOptionsNpmProject) {
-                fieldOptionsNpmProject.value = false;
-            }
-            refreshDownloadFormatOptions();
+    if (config.self.flags.superUser) {
+        downloadFormatOptions.splice(1, 0, {
+            t: 'Snapchat Web Lens',
+            v: DOWNLOAD_FORMAT_WEB_LENS
         });
     }
 
-    fieldOptionsNpmProject.on('change', () => {
+    fieldDownloadFormat = new SelectInput({
+        class: 'download-format-dropdown',
+        value: DOWNLOAD_FORMAT_STATIC,
+        options: downloadFormatOptions
+    });
+    containerDownloadOptions.append(fieldDownloadFormat);
+
+    fieldDownloadFormat.on('change', () => {
         refreshDownloadFormatOptions();
     });
 
@@ -398,7 +381,7 @@ editor.once('load', () => {
 
         refreshingDownloadFormatOptions = true;
 
-        const npmProject = !!(fieldOptionsNpmProject && fieldOptionsNpmProject.value);
+        const npmProject = fieldDownloadFormat?.value === DOWNLOAD_FORMAT_NPM;
         if (fieldOptionsConcat && fieldOptionsMinify && fieldOptionsSourcemaps && fieldOptionsOptimizeSceneFormat) {
             if (npmProject) {
                 if (!optionsBeforeNpmProject) {
@@ -406,8 +389,7 @@ editor.once('load', () => {
                         concatenate: fieldOptionsConcat.value,
                         minify: fieldOptionsMinify.value,
                         sourcemaps: fieldOptionsSourcemaps.value,
-                        optimizeSceneFormat: fieldOptionsOptimizeSceneFormat.value,
-                        webLens: fieldOptionsWebLens ? fieldOptionsWebLens.value : false
+                        optimizeSceneFormat: fieldOptionsOptimizeSceneFormat.value
                     };
                 }
 
@@ -415,17 +397,11 @@ editor.once('load', () => {
                 fieldOptionsMinify.value = false;
                 fieldOptionsSourcemaps.value = false;
                 fieldOptionsOptimizeSceneFormat.value = false;
-                if (fieldOptionsWebLens) {
-                    fieldOptionsWebLens.value = false;
-                }
             } else if (optionsBeforeNpmProject) {
                 fieldOptionsConcat.value = optionsBeforeNpmProject.concatenate;
                 fieldOptionsMinify.value = optionsBeforeNpmProject.minify;
                 fieldOptionsSourcemaps.value = optionsBeforeNpmProject.sourcemaps;
                 fieldOptionsOptimizeSceneFormat.value = optionsBeforeNpmProject.optimizeSceneFormat;
-                if (fieldOptionsWebLens) {
-                    fieldOptionsWebLens.value = optionsBeforeNpmProject.webLens;
-                }
                 optionsBeforeNpmProject = null;
             }
 
@@ -433,9 +409,6 @@ editor.once('load', () => {
             fieldOptionsMinify.disabled = npmProject;
             fieldOptionsSourcemaps.disabled = npmProject;
             fieldOptionsOptimizeSceneFormat.disabled = npmProject;
-            if (fieldOptionsWebLens) {
-                fieldOptionsWebLens.disabled = npmProject;
-            }
         }
 
         if (containerBuildOptions) {
@@ -449,9 +422,6 @@ editor.once('load', () => {
             }
             if (rowOptionsSourcemaps) {
                 rowOptionsSourcemaps.hidden = !fieldOptionsMinify.value || !fieldOptionsConcat.value;
-            }
-            if (containerOptionsWebLens) {
-                containerOptionsWebLens.hidden = mode !== 'download' || !config.self.flags.superUser;
             }
         }
 
@@ -594,10 +564,6 @@ editor.once('load', () => {
             data.optimize_scene_format = fieldOptionsOptimizeSceneFormat.value;
         }
 
-        if (fieldOptionsWebLens) {
-            data.web_lens = fieldOptionsWebLens.value;
-        }
-
         data.engine_version = config.engineVersions[engineVersionDropdown.value].version;
 
         editor.api.globals.rest.apps.appCreate(data).on('load', () => {
@@ -625,8 +591,8 @@ editor.once('load', () => {
 
         refreshButtonsState();
 
-        const npmProject = fieldOptionsNpmProject ? fieldOptionsNpmProject.value : false;
-        const format = npmProject ? DOWNLOAD_FORMAT_NPM : fieldOptionsWebLens?.value ? DOWNLOAD_FORMAT_WEB_LENS : DOWNLOAD_FORMAT_STATIC;
+        const format = fieldDownloadFormat?.value ?? DOWNLOAD_FORMAT_STATIC;
+        const npmProject = format === DOWNLOAD_FORMAT_NPM;
 
         // post data
         const data = {

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -343,7 +343,7 @@ editor.once('load', () => {
     containerDownloadOptions.hidden = true;
 
     const labelDownloadOptions = new Label({
-        text: 'Download Options',
+        text: 'Download Format',
         class: 'field-label'
     });
     containerDownloadOptions.append(labelDownloadOptions);

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -9,6 +9,7 @@ import { config } from '@/editor/config';
 
 const DOWNLOAD_FORMAT_STATIC = 'static';
 const DOWNLOAD_FORMAT_WEB_LENS = 'web_lens';
+const DOWNLOAD_FORMAT_NPM = 'npm';
 
 editor.once('load', () => {
     const legacyScripts = editor.call('settings:project').get('useLegacyScripts');
@@ -20,6 +21,7 @@ editor.once('load', () => {
     let events: EventHandle[] = [];
 
     let containerOptionsWebLens: Container | null = null;
+    let containerOptionsNpmProject: Container | null = null;
 
     // root container
     const container = new Container({
@@ -39,16 +41,29 @@ editor.once('load', () => {
         mode = 'publish';
         editor.call('picker:project', 'publish-new');
         container.class.remove('download-mode');
-        containerOptionsWebLens.hidden = true;
+        if (containerOptionsWebLens) {
+            containerOptionsWebLens.hidden = true;
+        }
+        if (containerOptionsNpmProject) {
+            containerOptionsNpmProject.hidden = true;
+        }
+        if (fieldOptionsNpmProject) {
+            fieldOptionsNpmProject.value = false;
+        }
+        refreshDownloadFormatOptions();
     });
 
     editor.method('picker:publish:download', () => {
         mode = 'download';
         editor.call('picker:project', 'publish-download');
         container.class.add('download-mode');
-        if (config.self.flags.superUser) {
+        if (config.self.flags.superUser && containerOptionsWebLens) {
             containerOptionsWebLens.hidden = false;
         }
+        if (containerOptionsNpmProject) {
+            containerOptionsNpmProject.hidden = false;
+        }
+        refreshDownloadFormatOptions();
     });
 
     // info panel
@@ -258,16 +273,29 @@ editor.once('load', () => {
     containerEngineVersion.append(engineVersionDropdown);
     container.append(containerEngineVersion);
 
-    let fieldOptionsConcat: BooleanInput;
-    let fieldOptionsMinify: BooleanInput;
-    let fieldOptionsSourcemaps: BooleanInput;
-    let fieldOptionsOptimizeSceneFormat: BooleanInput;
-    let fieldOptionsWebLens: BooleanInput;
+    let fieldOptionsConcat: BooleanInput | null = null;
+    let fieldOptionsMinify: BooleanInput | null = null;
+    let fieldOptionsSourcemaps: BooleanInput | null = null;
+    let fieldOptionsOptimizeSceneFormat: BooleanInput | null = null;
+    let fieldOptionsWebLens: BooleanInput | null = null;
+    let fieldOptionsNpmProject: BooleanInput | null = null;
+    let containerBuildOptions: Container | null = null;
+    let rowOptionsMinify: Container | null = null;
+    let rowOptionsSourcemaps: Container | null = null;
+    let optionsBeforeNpmProject: {
+        concatenate: boolean,
+        minify: boolean,
+        sourcemaps: boolean,
+        optimizeSceneFormat: boolean,
+        webLens: boolean
+    } | null = null;
+    let refreshingDownloadFormatOptions = false;
 
     if (!legacyScripts) {
         const containerOptions = new Container({
             class: 'options'
         });
+        containerBuildOptions = containerOptions;
         container.append(containerOptions);
 
         const labelOptions = new Label({
@@ -307,18 +335,127 @@ editor.once('load', () => {
         fieldOptionsSourcemaps = optSourcemaps.input;
         fieldOptionsOptimizeSceneFormat = optOptimizeFormat.input;
         fieldOptionsWebLens = optWebLens.input;
+        rowOptionsMinify = optMinify.row;
+        rowOptionsSourcemaps = optSourcemaps.row;
 
         containerOptionsWebLens = optWebLens.row;
         containerOptionsWebLens.hidden = true;
 
-        fieldOptionsConcat.on('change', (value: boolean) => {
-            optMinify.row.hidden = !value;
-            optSourcemaps.row.hidden = !fieldOptionsMinify.value || !value;
+        fieldOptionsConcat.on('change', () => {
+            refreshDownloadFormatOptions();
         });
 
-        fieldOptionsMinify.on('change', (value: boolean) => {
-            optSourcemaps.row.hidden = !value;
+        fieldOptionsMinify.on('change', () => {
+            refreshDownloadFormatOptions();
         });
+    }
+
+    const containerDownloadOptions = new Container({
+        class: 'options'
+    });
+    container.append(containerDownloadOptions);
+    containerOptionsNpmProject = containerDownloadOptions;
+    containerOptionsNpmProject.hidden = true;
+
+    const labelDownloadOptions = new Label({
+        text: 'Download Options',
+        class: 'field-label'
+    });
+    containerDownloadOptions.append(labelDownloadOptions);
+
+    const rowNpmProject = new Container({
+        class: 'field'
+    });
+    containerDownloadOptions.append(rowNpmProject);
+
+    fieldOptionsNpmProject = new BooleanInput({
+        value: false
+    });
+    rowNpmProject.append(fieldOptionsNpmProject);
+
+    const labelNpmProject = new Label({
+        text: 'Export as NPM Project'
+    });
+    rowNpmProject.append(labelNpmProject);
+
+    if (fieldOptionsWebLens) {
+        fieldOptionsWebLens.on('change', (value: boolean) => {
+            if (value && fieldOptionsNpmProject) {
+                fieldOptionsNpmProject.value = false;
+            }
+            refreshDownloadFormatOptions();
+        });
+    }
+
+    fieldOptionsNpmProject.on('change', () => {
+        refreshDownloadFormatOptions();
+    });
+
+    function refreshDownloadFormatOptions() {
+        if (refreshingDownloadFormatOptions) {
+            return;
+        }
+
+        refreshingDownloadFormatOptions = true;
+
+        const npmProject = !!(fieldOptionsNpmProject && fieldOptionsNpmProject.value);
+        if (fieldOptionsConcat && fieldOptionsMinify && fieldOptionsSourcemaps && fieldOptionsOptimizeSceneFormat) {
+            if (npmProject) {
+                if (!optionsBeforeNpmProject) {
+                    optionsBeforeNpmProject = {
+                        concatenate: fieldOptionsConcat.value,
+                        minify: fieldOptionsMinify.value,
+                        sourcemaps: fieldOptionsSourcemaps.value,
+                        optimizeSceneFormat: fieldOptionsOptimizeSceneFormat.value,
+                        webLens: fieldOptionsWebLens ? fieldOptionsWebLens.value : false
+                    };
+                }
+
+                fieldOptionsConcat.value = false;
+                fieldOptionsMinify.value = false;
+                fieldOptionsSourcemaps.value = false;
+                fieldOptionsOptimizeSceneFormat.value = false;
+                if (fieldOptionsWebLens) {
+                    fieldOptionsWebLens.value = false;
+                }
+            } else if (optionsBeforeNpmProject) {
+                fieldOptionsConcat.value = optionsBeforeNpmProject.concatenate;
+                fieldOptionsMinify.value = optionsBeforeNpmProject.minify;
+                fieldOptionsSourcemaps.value = optionsBeforeNpmProject.sourcemaps;
+                fieldOptionsOptimizeSceneFormat.value = optionsBeforeNpmProject.optimizeSceneFormat;
+                if (fieldOptionsWebLens) {
+                    fieldOptionsWebLens.value = optionsBeforeNpmProject.webLens;
+                }
+                optionsBeforeNpmProject = null;
+            }
+
+            fieldOptionsConcat.disabled = npmProject;
+            fieldOptionsMinify.disabled = npmProject;
+            fieldOptionsSourcemaps.disabled = npmProject;
+            fieldOptionsOptimizeSceneFormat.disabled = npmProject;
+            if (fieldOptionsWebLens) {
+                fieldOptionsWebLens.disabled = npmProject;
+            }
+        }
+
+        if (containerBuildOptions) {
+            containerBuildOptions.disabled = npmProject;
+            containerBuildOptions.hidden = npmProject;
+        }
+
+        if (!npmProject && fieldOptionsConcat && fieldOptionsMinify) {
+            if (rowOptionsMinify) {
+                rowOptionsMinify.hidden = !fieldOptionsConcat.value;
+            }
+            if (rowOptionsSourcemaps) {
+                rowOptionsSourcemaps.hidden = !fieldOptionsMinify.value || !fieldOptionsConcat.value;
+            }
+            if (containerOptionsWebLens) {
+                containerOptionsWebLens.hidden = mode !== 'download' || !config.self.flags.superUser;
+            }
+        }
+
+        refreshingDownloadFormatOptions = false;
     }
 
     // scenes
@@ -448,7 +585,7 @@ editor.once('load', () => {
         if (fieldOptionsMinify) {
             data.scripts_minify = fieldOptionsMinify.value;
 
-            if (fieldOptionsConcat.value && fieldOptionsMinify.value && fieldOptionsSourcemaps.value) {
+            if (fieldOptionsConcat?.value && fieldOptionsMinify.value && fieldOptionsSourcemaps?.value) {
                 data.scripts_sourcemaps = true;
             }
         }
@@ -488,17 +625,20 @@ editor.once('load', () => {
 
         refreshButtonsState();
 
+        const npmProject = fieldOptionsNpmProject ? fieldOptionsNpmProject.value : false;
+        const format = npmProject ? DOWNLOAD_FORMAT_NPM : fieldOptionsWebLens?.value ? DOWNLOAD_FORMAT_WEB_LENS : DOWNLOAD_FORMAT_STATIC;
+
         // post data
         const data = {
             name: inputName.value,
             project_id: config.project.id,
             branch_id: config.self.branch.id,
             scenes: getSelectedScenes(),
-            scripts_concatenate: fieldOptionsConcat ? fieldOptionsConcat.value : false,
-            scripts_minify: fieldOptionsMinify ? fieldOptionsMinify.value : false,
-            scripts_sourcemaps: fieldOptionsMinify && fieldOptionsMinify.value && fieldOptionsSourcemaps.value,
-            optimize_scene_format: fieldOptionsOptimizeSceneFormat ? fieldOptionsOptimizeSceneFormat.value : false,
-            format: fieldOptionsWebLens?.value ? DOWNLOAD_FORMAT_WEB_LENS : DOWNLOAD_FORMAT_STATIC
+            scripts_concatenate: !npmProject && !!fieldOptionsConcat?.value,
+            scripts_minify: !npmProject && !!fieldOptionsMinify?.value,
+            scripts_sourcemaps: !npmProject && !!fieldOptionsMinify?.value && !!fieldOptionsSourcemaps?.value,
+            optimize_scene_format: !npmProject && !!fieldOptionsOptimizeSceneFormat?.value,
+            format
         };
 
         data.engine_version = config.engineVersions[engineVersionDropdown.value].version;


### PR DESCRIPTION
### What's Changed
- Add a download format selector for the REST `format` values: Static Website (`static`) and NPM + Vite Project (`npm`).
- Label the selector as `Download Format` so the UI matches the app download API field.
- Hide build options for NPM + Vite exports and restore previous build option values when switching back.

### Preview
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/21f57cf9-445f-4f37-b798-450c63c59c8d" />
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/f62d478a-6d71-4322-af7e-37bfa82cbf80" />

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- Manual tests: not run
