### PR TITLE
fix: use format for app downloads

### DIFF
--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -7,6 +7,9 @@ import { LegacyListItem } from '@/common/ui/list-item';
 import { convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
+const DOWNLOAD_FORMAT_STATIC = 'static';
+const DOWNLOAD_FORMAT_WEB_LENS = 'web_lens';
+
 editor.once('load', () => {
     const legacyScripts = editor.call('settings:project').get('useLegacyScripts');
 
@@ -495,7 +498,7 @@ editor.once('load', () => {
             scripts_minify: fieldOptionsMinify ? fieldOptionsMinify.value : false,
             scripts_sourcemaps: fieldOptionsMinify && fieldOptionsMinify.value && fieldOptionsSourcemaps.value,
             optimize_scene_format: fieldOptionsOptimizeSceneFormat ? fieldOptionsOptimizeSceneFormat.value : false,
-            web_lens: fieldOptionsWebLens ? fieldOptionsWebLens.value : false
+            format: fieldOptionsWebLens?.value ? DOWNLOAD_FORMAT_WEB_LENS : DOWNLOAD_FORMAT_STATIC
         };
 
         data.engine_version = config.engineVersions[engineVersionDropdown.value].version;

--- a/test-suite/lib/common.ts
+++ b/test-suite/lib/common.ts
@@ -5,6 +5,7 @@ export interface EsmBuildOptions {
     scripts_minify?: boolean;
     scripts_sourcemaps?: boolean;
     optimize_scene_format?: boolean;
+    format?: 'static' | 'npm' | 'web_lens';
 }
 
 /**


### PR DESCRIPTION
### What changed
- Send app downloads with the format field instead of the legacy request flag.
- Type download helper options with supported format values.

### Checks
- [x] I confirm I have read the contributing guidelines.
- Manual tests: not run
