### PR TITLE
fix: show material opacity intensity slider when dithering is enabled

### DIFF
--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1424,6 +1424,8 @@ class MaterialAssetInspector extends Container {
         this._opacityInspector.getField('data.blendType').on('change', toggleFields);
         this._opacityInspector.getField('data.opacityVertexColor').on('change', toggleFields);
         this._opacityInspector.getField('data.opacityFadesSpecular').on('change', toggleFields);
+        this._opacityInspector.getField('data.opacityDither').on('change', toggleFields);
+        this._opacityInspector.getField('data.opacityShadowDither').on('change', toggleFields);
 
         this._clearCoatFactorInspector.getField('data.clearCoat').on('change', toggleFields);
 
@@ -1572,7 +1574,10 @@ class MaterialAssetInspector extends Container {
         this._clearCoatNormalInspector.hidden = clearCoat === 0.0;
 
         const blendType = this._opacityInspector.getField('data.blendType').value;
-        this._opacityInspector.getField('data.opacity').parent.hidden = ([2, 4, 6].indexOf(blendType) === -1);
+        const opacityDither = this._opacityInspector.getField('data.opacityDither').value;
+        const opacityShadowDither = this._opacityInspector.getField('data.opacityShadowDither').value;
+        const dithered = opacityDither !== 'none' || opacityShadowDither !== 'none';
+        this._opacityInspector.getField('data.opacity').parent.hidden = ([2, 4, 6].indexOf(blendType) === -1) && !dithered;
 
         const opacityMapField = this._opacityInspector.getField('data.opacityMap');
         const opacityVertexColorField = this._opacityInspector.getField('data.opacityVertexColor');

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1574,8 +1574,8 @@ class MaterialAssetInspector extends Container {
         this._clearCoatNormalInspector.hidden = clearCoat === 0.0;
 
         const blendType = this._opacityInspector.getField('data.blendType').value;
-        const opacityDither = this._opacityInspector.getField('data.opacityDither').value;
-        const opacityShadowDither = this._opacityInspector.getField('data.opacityShadowDither').value;
+        const opacityDither = this._opacityInspector.getField('data.opacityDither').value ?? 'none';
+        const opacityShadowDither = this._opacityInspector.getField('data.opacityShadowDither').value ?? 'none';
         const dithered = opacityDither !== 'none' || opacityShadowDither !== 'none';
         this._opacityInspector.getField('data.opacity').parent.hidden = ([2, 4, 6].indexOf(blendType) === -1) && !dithered;
 


### PR DESCRIPTION
## Summary
Show the material opacity slider when opacity dithering or shadow dithering is enabled, in addition to the existing blend-type-based visibility.

## Problem
The opacity intensity slider in the material inspector was only shown when `blendType` was one of `[2, 4, 6]`. However, opacity intensity also has a visible effect when `opacityDither` or `opacityShadowDither` is set to anything other than `none` — meaning users could enable dithering but had no way to adjust the opacity value driving it.

## What's Changed
- Hook `toggleFields` into change events for `data.opacityDither` and `data.opacityShadowDither` so visibility updates when the user toggles dithering.
- Update the opacity field visibility check: the slider is now shown if the blend type matches **or** if either dither mode is not `none`.

## Test plan
- [x] With a non-blended blend type and both dither modes set to `none`, confirm the opacity slider is hidden.
- [x] Set `Opacity Dither` to a value other than `none` → slider becomes visible.
- [x] Reset to `none`, then set `Opacity Shadow Dither` to a non-`none` value → slider becomes visible.
- [x] Switch back to a blended blend type → slider remains visible regardless of dither settings.
- [x] Toggle dither values back and forth and confirm the slider shows/hides immediately without needing to re-open the inspector.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
