### PR TITLE
feat: use owner-prefixed vercel redirects

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -447,8 +447,11 @@ const esbuildBundlePlugin = () => {
                 // deployment URL sends users to the editor with the correct
                 // use_local_frontend query parameter for this branch.
                 if (process.env.VERCEL) {
+                    const owner = (process.env.VERCEL_GIT_REPO_OWNER || 'playcanvas').toLowerCase();
                     const branch = process.env.VERCEL_GIT_COMMIT_REF || 'main';
-                    const redirectUrl = `https://playcanvas.com/editor?use_local_frontend=branch:${branch}`;
+                    const source = owner === 'playcanvas' ? 'main' : owner;
+                    const query = new URLSearchParams({ use_local_frontend: `${source}:${branch}` });
+                    const redirectUrl = `https://playcanvas.com/editor?${query}`;
                     const html = [
                         '<!DOCTYPE html>',
                         '<html><head>',

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -449,8 +449,7 @@ const esbuildBundlePlugin = () => {
                 if (process.env.VERCEL) {
                     const owner = (process.env.VERCEL_GIT_REPO_OWNER || 'playcanvas').toLowerCase();
                     const branch = process.env.VERCEL_GIT_COMMIT_REF || 'main';
-                    const source = owner === 'playcanvas' ? 'main' : owner;
-                    const query = new URLSearchParams({ use_local_frontend: `${source}:${branch}` });
+                    const query = new URLSearchParams({ use_local_frontend: `${owner}:${branch}` });
                     const redirectUrl = `https://playcanvas.com/editor?${query}`;
                     const html = [
                         '<!DOCTYPE html>',


### PR DESCRIPTION
### Changes
- Generate Vercel redirects with `playcanvas:<branch>` for upstream PlayCanvas deployments.
- Generate owner-prefixed redirects for fork deployments.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- Manual validation: inspected generated Vercel redirect HTML for upstream and fork owners.