### PR TITLE
perf: only re-render the viewport when necessary (gsplat cost)

### DIFF
--- a/src/editor/viewport/camera/camera-orbit.ts
+++ b/src/editor/viewport/camera/camera-orbit.ts
@@ -7,6 +7,7 @@ editor.once('viewport:load', (app: Application) => {
     // Zooming / Flying will not move virtual point forward/backwards
 
     let orbiting = false;
+    let orbitDirty = false;
     let orbitCamera;
     const pivot = new Vec3();
     let distance = 1;
@@ -28,7 +29,11 @@ editor.once('viewport:load', (app: Application) => {
         distance = Math.max(0.01, vecA.copy(pivot).sub(camera.getPosition()).length());
         pivot.copy(camera.forward).mulScalar(distance).add(camera.getPosition());
 
-        if (orbiting) {
+        // only apply + render when the orientation actually changed (set in tap:move),
+        // so holding the button without moving does not re-render every frame
+        if (orbiting && orbitDirty) {
+            orbitDirty = false;
+
             quat.setFromEulerAngles(pitch, yaw, 0);
             vecA.set(0, 0, distance);
             quat.transformVector(vecA, vecA);
@@ -36,8 +41,6 @@ editor.once('viewport:load', (app: Application) => {
 
             camera.setPosition(vecA);
             camera.setRotation(quat);
-
-            editor.call('viewport:render');
         }
 
         if (camera.focus) {
@@ -125,6 +128,7 @@ editor.once('viewport:load', (app: Application) => {
         pitch = Math.max(-89.99, Math.min(89.99, pitch - (tap.y - tap.ly) * sensitivity));
         yaw += (tap.lx - tap.x) * sensitivity;
 
+        orbitDirty = true;
         editor.call('viewport:render');
     });
 

--- a/src/editor/viewport/camera/camera-pan.ts
+++ b/src/editor/viewport/camera/camera-pan.ts
@@ -6,6 +6,7 @@ editor.once('viewport:load', (app: Application) => {
     // Panning with left mouse button while shift key is down
 
     let panning = false;
+    let panDirty = false;
     let panCamera;
     let shiftKey = false;
     const vecA = new Vec2();
@@ -21,9 +22,12 @@ editor.once('viewport:load', (app: Application) => {
     });
 
     editor.on('viewport:update', (dt: number) => {
-        if (!panning) {
+        // only recompute + render when the pointer moved (set in tap:move / pan start),
+        // so holding the pan button without moving does not re-render every frame
+        if (!panning || !panDirty) {
             return;
         }
+        panDirty = false;
 
         const camera = editor.call('camera:current');
 
@@ -51,8 +55,6 @@ editor.once('viewport:load', (app: Application) => {
                 camera.setPosition(camera.getPosition().add(vecB));
             }
         }
-
-        editor.call('viewport:render');
     });
 
     const onPanStart = function (tap: ViewportTap): void {
@@ -106,6 +108,7 @@ editor.once('viewport:load', (app: Application) => {
             }
         }
 
+        panDirty = true;
         editor.call('viewport:render');
     };
     editor.method('camera:pan:start', onPanStart);
@@ -135,6 +138,7 @@ editor.once('viewport:load', (app: Application) => {
         vecA.x = tap.x;
         vecA.y = tap.y;
 
+        panDirty = true;
         editor.call('viewport:render');
     });
 

--- a/src/editor/viewport/gizmo/gizmo-point.ts
+++ b/src/editor/viewport/gizmo/gizmo-point.ts
@@ -283,7 +283,8 @@ editor.once('viewport:load', (app) => {
 
             dragPoint.emit('dragMove', length);
         }
-
-        editor.call('viewport:render');
+        // no viewport:render here: this runs every rendered frame while dragging, so
+        // it would loop forever when the mouse is held still. the active-drag render
+        // in viewport-tap drives the redraw as the mouse actually moves.
     });
 });

--- a/src/editor/viewport/gizmo/gizmo-transform.ts
+++ b/src/editor/viewport/gizmo/gizmo-transform.ts
@@ -203,16 +203,27 @@ const initGizmo = <T extends TransformGizmo>(gizmo: T) => {
 
     // track hover state and cursor position
     let hovering = false;
+    let hoverMesh: MeshInstance | null = null;
     gizmo.on(Gizmo.EVENT_POINTERMOVE, (x: number, y: number, meshInstance: MeshInstance) => {
         cursor[0] = x;
         cursor[1] = y;
-        if (hovering === !!meshInstance) {
+        const mesh = meshInstance || null;
+        if (hoverMesh === mesh) {
             return;
         }
-        hovering = !!meshInstance;
-        editor.emit('gizmo:transform:hover', hovering);
+        hoverMesh = mesh;
+        const nowHovering = !!mesh;
+        if (hovering !== nowHovering) {
+            hovering = nowHovering;
+            editor.emit('gizmo:transform:hover', hovering);
+        }
+        // the hovered handle changed: re-render so the highlight updates. the engine
+        // marks the gizmo dirty on hover but only repaints on a rendered frame, and
+        // nothing else renders on plain mouse movement now.
+        editor.call('viewport:render');
     });
     gizmo.on(Gizmo.EVENT_NODESDETACH, () => {
+        hoverMesh = null;
         if (hovering) {
             hovering = false;
             editor.emit('gizmo:transform:hover', false);

--- a/src/editor/viewport/viewport-outline.ts
+++ b/src/editor/viewport/viewport-outline.ts
@@ -51,7 +51,7 @@ editor.once('load', () => {
     };
 
     // request rendering of entities for a user
-    const setUserSelection = (id: number | string, entities: Entity[]): void => {
+    const setUserSelection = (id: number | string, entities: Entity[], render = true): void => {
 
         // remove existing entities
         const existingEntities = userSelections.get(id);
@@ -68,7 +68,9 @@ editor.once('load', () => {
             outlineRenderer.addEntity(entities[i], color, false);
         }
 
-        editor.call('viewport:render');
+        if (render) {
+            editor.call('viewport:render');
+        }
     };
 
     // local user selection changed
@@ -126,7 +128,11 @@ editor.once('load', () => {
         outlineRenderer.removeAllEntities();
         const entities = userSelections.get(config.self.id);
         if (entities) {
-            setUserSelection(config.self.id, entities);
+            // re-add without forcing a render: this runs on every rendered frame,
+            // so requesting a render here would loop the viewport forever while a
+            // selection exists (the frameUpdate below draws the outline into the
+            // frame that is already rendering)
+            setUserSelection(config.self.id, entities, false);
         }
 
         // request outline rendering, which is then added to the scene at the start of the Immediate layer

--- a/src/editor/viewport/viewport-pick.ts
+++ b/src/editor/viewport/viewport-pick.ts
@@ -1,5 +1,6 @@
 import { Entity, GraphNode, Picker, Vec2 } from 'playcanvas';
 
+import { frameLimiter } from '@/common/utils';
 import { FORCE_PICK_TAG } from '@/core/constants';
 
 import type { ViewportTap } from './viewport-tap';
@@ -51,7 +52,7 @@ editor.once('load', () => {
         picking = state;
     });
 
-    editor.on('viewport:update', () => {
+    const runPick = () => {
         if (!mouseDown && !inViewport && pickedData.node) {
             pickedData.node = null;
             pickedData.picked = null;
@@ -75,7 +76,14 @@ editor.once('load', () => {
                 editor.emit('viewport:pick:hover', pickedData.node, pickedData.picked);
             }
         });
-    });
+    };
+
+    // run hover-picking on pointer movement, coalesced to once per frame; the picker
+    // renders to its own buffer, so this is decoupled from the main viewport render —
+    // hovering no longer forces a full (splat) re-render
+    const requestPick = frameLimiter(runPick);
+    editor.on('viewport:mouse:move', () => requestPick());
+    editor.on('viewport:hover', () => requestPick());
 
     editor.on('viewport:hover', (hover: boolean) => {
         inViewport = hover;

--- a/src/editor/viewport/viewport-tap.ts
+++ b/src/editor/viewport/viewport-tap.ts
@@ -97,16 +97,21 @@ editor.once('load', () => {
             down: taps.length !== 0
         });
 
-        // render if mouse moved within viewport
+        // track hover state as the mouse moves
         if (evt.clientX >= rect.left && evt.clientX <= rect.right && evt.clientY >= rect.top && evt.clientY <= rect.bottom) {
             if (!inViewport) {
                 inViewport = true;
                 editor.emit('viewport:hover', true);
             }
-            editor.call('viewport:render');
         } else if (inViewport) {
             inViewport = false;
             editor.emit('viewport:hover', false);
+        }
+
+        // render only while actively dragging (a pointer is down): drags drive
+        // per-frame handlers (camera, gizmos) that must redraw as the mouse moves.
+        // plain hovering with no button must NOT render — costly for splats.
+        if (taps.length) {
             editor.call('viewport:render');
         }
     };
@@ -179,7 +184,6 @@ editor.once('load', () => {
 
     canvas.dom.addEventListener('mouseover', () => {
         editor.emit('viewport:hover', true);
-        editor.call('viewport:render');
     }, false);
 
     canvas.dom.addEventListener('mouseleave', (evt) => {
@@ -190,7 +194,6 @@ editor.once('load', () => {
         }
 
         editor.emit('viewport:hover', false);
-        editor.call('viewport:render');
     }, false);
 
     window.addEventListener('mousemove', evtMouseMove, false);

--- a/src/editor/viewport/viewport.ts
+++ b/src/editor/viewport/viewport.ts
@@ -92,6 +92,13 @@ editor.once('load', () => {
         return keepRendering;
     });
 
+    // gsplat depth-sorting runs async on a worker; the sort for the resting camera
+    // can land just after the last frame. re-render once when a sort settles so the
+    // splat order is correct. self-terminating: a static camera skips the sort.
+    app.scene.on('gsplat:sorted', () => {
+        editor.call('viewport:render');
+    });
+
     app.start();
 
     editor.emit('viewport:load', app);


### PR DESCRIPTION
## Problem

Every viewport render redraws and re-sorts `gsplat` components (expensive). The viewport was re-rendering on every mouse move, continuously while a button was held, and continuously whenever anything was selected. This makes rendering strictly on-demand.

## Changes

| File | Change |
|------|--------|
| `viewport-pick` | Drive hover-picking via `frameLimiter` on pointer move instead of per-frame `viewport:update`; the picker uses its own render target, so hovering no longer forces a full render |
| `viewport-tap` | Render on mouse move only during an active drag — never on plain hover |
| `camera-orbit` / `camera-pan` | Render only while the camera actually moves (dirty flag on drag), not every frame a button is held still |
| `viewport-outline` | Stop the per-frame `gizmoUpdate` re-add from forcing a render — it looped forever whenever an entity or asset was selected |
| `gizmo-point` | Remove the unconditional render in its per-frame `postUpdate` (self-sustaining loop while dragging) |
| `gizmo-transform` | Render once when the hovered handle changes, so the axis highlight still updates |
| `viewport` | Re-render once when an async gsplat sort completes, so the resting splat order is correct (self-terminating) |

## Result

Renders occur only on real change: drag movement, camera animation (until convergence), gizmo-handle hover, selection (once), splat-sort completion (once), and active previews. Idle, hovering, and holding a button still all produce **zero** renders.

## Testing

`lint`, `tsc` (no new errors), `npm test` (157 passing). Manual: orbit/pan a gsplat scene renders during motion, silent at rest; select an item renders once; idle is silent.

_Known minor items left as-is: rect-select (Ctrl+drag) renders per move though only its DOM rect changes; hovering a draggable point handle may not highlight until the next render._