### PR TITLE
feat: expose gsplat rendering/LOD properties in component inspector

### DIFF
--- a/src/editor/attributes/reference/components/gsplat.ts
+++ b/src/editor/attributes/reference/components/gsplat.ts
@@ -4,15 +4,36 @@ export const fields: AttributeReference[]  = [{
     name: 'gsplat:component',
     title: 'pc.GSplatComponent',
     subTitle: '{pc.Component}',
-    description: 'Enables an Entity to render a gaussian splat. This component attaches the gaussian splat asset to the Entity.'
+    description: 'Enables an Entity to render a gaussian splat. This component attaches the gaussian splat asset to the Entity.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html'
 }, {
     name: 'gsplat:asset',
     title: 'asset',
     subTitle: '{pc.Asset}',
-    description: 'The GSplat Asset.'
+    description: 'The GSplat Asset.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#asset'
 }, {
     name: 'gsplat:layers',
     title: 'layers',
     subTitle: '{Number[]}',
-    description: 'The layers to which the gaussian splats should belong.'
+    description: 'The layers to which the gaussian splats should belong.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#layers'
+}, {
+    name: 'gsplat:castShadows',
+    title: 'castShadows',
+    subTitle: '{Boolean}',
+    description: 'Cast shadows for lights that have shadow casting enabled.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#castshadows'
+}, {
+    name: 'gsplat:lodBaseDistance',
+    title: 'lodBaseDistance',
+    subTitle: '{Number}',
+    description: 'Distance of the first LOD transition (LOD 0 to LOD 1). Closer objects use the highest quality LOD.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodbasedistance'
+}, {
+    name: 'gsplat:lodMultiplier',
+    title: 'lodMultiplier',
+    subTitle: '{Number}',
+    description: 'Geometric multiplier between successive LOD distance thresholds.',
+    url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodmultiplier'
 }];

--- a/src/editor/inspector/components/gsplat.ts
+++ b/src/editor/inspector/components/gsplat.ts
@@ -14,6 +14,31 @@ const ATTRIBUTES: Attribute[] = [{
         assetType: 'gsplat'
     }
 }, {
+    label: 'Cast Shadows',
+    path: 'components.gsplat.castShadows',
+    reference: 'gsplat:castShadows',
+    type: 'boolean'
+}, {
+    label: 'LOD Base Distance',
+    path: 'components.gsplat.lodBaseDistance',
+    reference: 'gsplat:lodBaseDistance',
+    type: 'number',
+    args: {
+        min: 0.1,
+        step: 0.1,
+        precision: 2
+    }
+}, {
+    label: 'LOD Multiplier',
+    path: 'components.gsplat.lodMultiplier',
+    reference: 'gsplat:lodMultiplier',
+    type: 'number',
+    args: {
+        min: 1.2,
+        step: 0.1,
+        precision: 2
+    }
+}, {
     label: 'Layers',
     path: 'components.gsplat.layers',
     reference: 'gsplat:layers',


### PR DESCRIPTION
### What's Changed
- Expose `castShadows`, `lodBaseDistance` (min `0.1`, default `5`), and `lodMultiplier` (min `1.2`, default `3`) in the gsplat component inspector.
- Add reference tooltips with API reference links for the new fields, and backfill API reference links on the existing `asset`, `layers`, and component entries.

Requires the backend scene schema to include these gsplat properties so they receive defaults and persist; until that lands the fields drive the live engine entity in-session but won't serialize.

### Preview
<img width="876" height="506" alt="image" src="https://github.com/user-attachments/assets/e49a385d-caf0-4c19-b9b2-ad3ccc215c2d" />

### Checks
- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
