### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.18.1",
+        "playcanvas": "2.19.2",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -3890,9 +3890,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvas": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.1.tgz",
-      "integrity": "sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8146,9 +8146,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.88.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
-      "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8593,9 +8593,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.1.tgz",
-      "integrity": "sha512-R+60EWFgPwgwqvnzP81sZbRfwJdL8EG5MLV+vJ+aeG6+Djt4IvpfJAHzYKRHak0I4oYtCCZwdLBygFboLBMCWQ==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.2.tgz",
+      "integrity": "sha512-mnO2wfE08/JyCxjGWU9ZIbYUcAFfdRFTfnuKm87Ym2IEUu8kX7mMm3UHIGYgSGJ7juS5Eg+hu8pQYzQB7ktwug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8603,10 +8603,10 @@
         "@webgpu/types": "^0.1.66"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.3.0"
       },
       "optionalDependencies": {
-        "canvas": "3.2.1"
+        "canvas": "3.2.3"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.18.1",
+    "playcanvas": "2.19.2",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
### What's Changed
- Update the PlayCanvas engine dependency from 2.18.1 to 2.19.2.
- Refresh the npm lockfile entries for the engine package and its optional canvas dependency.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

Manual tests: not run