### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.19.2",
+        "playcanvas": "2.19.3",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8593,9 +8593,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.2.tgz",
-      "integrity": "sha512-mnO2wfE08/JyCxjGWU9ZIbYUcAFfdRFTfnuKm87Ym2IEUu8kX7mMm3UHIGYgSGJ7juS5Eg+hu8pQYzQB7ktwug==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.3.tgz",
+      "integrity": "sha512-a48S0kHsFxqZu1MA9tvr5alRE2y+ND5Tv3mhnh7AUxGD9mKQmdUZWnvVR5700ERqrHwL6ojg8ZLRy2+aeC0FnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.19.2",
+    "playcanvas": "2.19.3",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
Updates the PlayCanvas engine dependency from `2.19.2` to `2.19.3` (latest release).

Changes are limited to `package.json` and `package-lock.json` — a straight patch bump with no transitive dependency changes.