### PR TITLE
feat: surface use_local_engine in the editor

### DIFF
--- a/src/editor/console/console.ts
+++ b/src/editor/console/console.ts
@@ -181,4 +181,9 @@ editor.on('load', () => {
     if (!config.url.frontend.startsWith('/editor/scene')) {
         editor.call('console:log', 'Using local frontend');
     }
+
+    // log engine usage
+    if (!config.url.engine.startsWith('https://code.playcanvas.com/playcanvas-')) {
+        editor.call('console:log', 'Using local engine');
+    }
 });

--- a/src/editor/inspector/settings-panels/engine.ts
+++ b/src/editor/inspector/settings-panels/engine.ts
@@ -1,7 +1,11 @@
+import { SelectInput } from '@playcanvas/pcui';
+
 import { config } from '@/editor/config';
 
 import { BaseSettingsPanel, type BaseSettingsPanelArgs } from './base';
 import type { Attribute } from '../attribute.type.d';
+
+const DEFAULT_ENGINE_URL_PREFIX = 'https://code.playcanvas.com/playcanvas-';
 
 const ATTRIBUTES: Attribute[] = [
     {
@@ -45,6 +49,19 @@ class EngineSettingsPanel extends BaseSettingsPanel {
         args._tooltipReference = 'settings:engine';
 
         super(args);
+
+        // when use_local_engine overrides the engine, the version select is forced by the URL,
+        // so show the actual engine version (read-only) instead of the selectable options
+        if (!config.url.engine.startsWith(DEFAULT_ENGINE_URL_PREFIX)) {
+            const versionField = this._attributesInspector.getField<SelectInput>('engineVersion');
+            if (versionField) {
+                const match = config.url.engine.match(/playcanvas-(\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?)/);
+                const label = match ? `${match[1]} (local engine)` : 'Local';
+                // keep the currently bound value so disabling does not write back to settings
+                versionField.options = [{ t: label, v: versionField.value }];
+                versionField.enabled = false;
+            }
+        }
 
         const switchEngine = this._attributesInspector.getField('switchEngine');
 


### PR DESCRIPTION
## Summary

Surfaces the `use_local_engine` URL param in the editor UI, mirroring how `use_local_frontend` is already surfaced.

When the editor is loaded with `?use_local_engine` (empty → local dev server at `localhost:51000`, or a valid custom `code.playcanvas.com`/`localhost` engine URL), the editor-server resolves it into `config.url.engine`. Previously the editor gave no indication this override was active, and the **Settings → Engine → Engine Version** dropdown still showed the selectable `previous`/`current`/`releaseCandidate` options even though the engine is forced by the URL.

## Changes

- **`src/editor/console/console.ts`** — log `Using local engine` to the in-app console when `config.url.engine` is not the default `https://code.playcanvas.com/playcanvas-…` build. Added directly below the existing `Using local frontend` log, same placement/behavior.
- **`src/editor/inspector/settings-panels/engine.ts`** — when a custom engine is active, replace the Engine Version select with a **disabled** field showing the version parsed from `config.url.engine` (e.g. `2.5.0 (local engine)`), falling back to `Local` when the URL carries no version (e.g. the `localhost:51000/playcanvas.js` dev server). The field keeps its currently bound value so disabling never writes back to `sessionSettings.engineVersion`.

## Notes

- Both changes are editor-page only. The launch page already swaps the engine via its `<script src="{{locals.url.engine}}">` tag.
- Detection uses `config.url.engine` (what's actually loaded) as the single source of truth, mirroring the existing `use_local_frontend` console check.
- A custom `code.playcanvas.com/playcanvas-X.js` URL is treated as "default" (it's effectively just a version pick); only genuinely different builds (local dev server, differently-named builds) trigger the new behavior.

## Testing

- `npx eslint` on both changed files — clean
- `npm run type:check` — no new errors in the changed files (pre-existing `src/workers/*` errors are unrelated and present on `main`)
