### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.19.4",
+        "playcanvas": "2.19.5",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8593,9 +8593,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.4.tgz",
-      "integrity": "sha512-+gaYLH4p1Xw8djamI7Drkjq7WOMb1AFB5lmf5pHs0ssQhVvzR+PzUMRHJzWqjFbmt380wZw3HsuJXRe3N7/imw==",
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.5.tgz",
+      "integrity": "sha512-oc97+uMc2GZ7CuogQAhpXLhCXY0QDFMFUChSuOIxIplIabSUc72URLKc1ppev2qHslmPjze3E0YrMrknDSi10A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.19.4",
+    "playcanvas": "2.19.5",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
Bumps the `playcanvas` engine dependency from `2.19.4` to `2.19.5` (patch update).

Release notes: https://github.com/playcanvas/engine/releases/tag/v2.19.5