### PR TITLE
fix: re-render viewport when gizmo type changes

### DIFF
--- a/src/editor/viewport/gizmo/gizmo.ts
+++ b/src/editor/viewport/gizmo/gizmo.ts
@@ -18,6 +18,9 @@ editor.once('load', () => {
         gizmoType = type;
 
         editor.emit('gizmo:type', type);
+
+        // render-on-demand viewport: request a frame so the new gizmo is drawn
+        editor.call('viewport:render');
     });
 
     editor.method('gizmo:coordSystem', (system?: string) => {


### PR DESCRIPTION
## Problem

Switching the active gizmo type — via the keyboard shortcuts **1/2/3/4** or the **toolbar gizmo buttons** — did not visually update the viewport. The new gizmo (translate/rotate/scale/resize) only appeared after some *unrelated* interaction triggered a frame, e.g. moving the mouse over the viewport or changing the selection.

## Root cause

The viewport renders **on demand**: `ViewportApplication`'s tick loop only renders when `app.redraw === true` and otherwise goes idle (`src/editor/viewport/viewport-application.ts`). Anything that changes what's on screen is expected to call `editor.call('viewport:render')` to request a frame — a pattern used in dozens of places across the viewport modules.

Both input paths funnel through the `gizmo:type` method in `src/editor/viewport/gizmo/gizmo.ts`:

- keybinds → `gizmoButtons.<op>.emit('click')` → `editor.call('gizmo:type', op)`
- toolbar buttons → `editor.call('gizmo:type', op)`

That method updated state and emitted the `gizmo:type` event (whose listener `reflow` in `gizmo-transform.ts` attaches/detaches the gizmo objects), but **nothing requested a render**, so `app.redraw` stayed `false` and the change wasn't drawn. Selection changes *appeared* to work only because the outline handler requests a render as a side effect — a pure type switch has no such side effect.

## Fix

Request a single `viewport:render` right after the gizmo type actually changes, at the central funnel. This covers **both** input paths and **every** `gizmo:type` listener (including the `resize`/element-size gizmo) in one place, and the early-return on an unchanged type means no redundant frames.

```diff
         gizmoType = type;

         editor.emit('gizmo:type', type);
+
+        // render-on-demand viewport: request a frame so the new gizmo is drawn
+        editor.call('viewport:render');
     });
```

## Verification

- `eslint` on the changed file: clean (exit 0)
- `npm run build`: succeeds
- Manual: select an entity, then press **1/2/3/4** (or click the toolbar gizmo buttons) **without moving the mouse** — the gizmo now switches immediately instead of on the next unrelated frame.

No automated test is added: this behavior depends on a live PlayCanvas `Application` + the rAF render loop, which the repo's unit tests (pure-logic only) don't bootstrap, and the change follows the established `viewport:render`-on-change pattern.