### PR TITLE
Modernize builds panel, publish and download flows

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4972,18 +4972,24 @@ strong {
             align-items: center;
             line-height: normal;
             padding: 11px 0;
-            border-bottom: 1px solid $border-primary;
             background: transparent;
             cursor: default;
             transition: background-color 100ms ease;
 
+            // author display: grid beats the UA [hidden] rule; restore it for filtering
+            &[hidden] {
+                display: none;
+            }
+
+            // separator only between visible rows; border-bottom + :last-child
+            // breaks when filtering hides the actual last child
+            &:not([hidden]) ~ .build-item:not([hidden]) {
+                border-top: 1px solid $border-primary;
+            }
+
             &:hover {
                 background-color: #354144;
                 cursor: pointer;
-            }
-
-            &:last-child {
-                border-bottom: none;
             }
 
             > .build-row {

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3793,11 +3793,33 @@ strong {
         visibility: hidden;
     }
 
+    // round + border the menu to match the build list box
+    .pcui-menu-items {
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
     .pcui-menu-item-content {
-        > .pcui-label {
-            line-height: 32px;
-            margin: 0 0 0 8px;
+        font-size: 13px;
+
+        &:hover {
+            background-color: #354144;
         }
+
+        > .pcui-label {
+            line-height: 30px;
+            margin: 0 0 0 10px;
+        }
+    }
+
+    .pcui-menu-item.open > .pcui-menu-item-content > .pcui-label,
+    .pcui-menu-item.download > .pcui-menu-item-content > .pcui-label {
+        color: $text-primary;
+    }
+
+    .pcui-menu-item.delete > .pcui-menu-item-content > .pcui-label {
+        color: $error-secondary;
     }
 }
 
@@ -4271,84 +4293,52 @@ strong {
         width: 100%;
     }
 
-    > .publish-buttons-container {
+    > .builds-toolbar {
         display: flex;
         flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        margin: 20px 0 8px;
 
-        & > .buttons {
-            border-left: 1px solid $border-primary;
-            border-right: 1px solid $border-primary;
-            border-top: 1px solid $border-primary;
-            margin: 15px;
-            text-align: center;
-            flex-grow: 1;
-            flex-basis: 0;
+        > .pcui-button {
+            @extend .font-bold;
 
-            &.collapsed { border: unset; }
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 32px;
+            margin: 0;
+            padding: 0 16px;
+            border-radius: 6px;
+            font-size: 13px;
+            box-shadow: none;
+            cursor: pointer;
 
-            > .pcui-label {
-                text-align: center;
-                opacity: 0.8;
+            &.download {
                 color: $text-primary;
+                background-color: transparent;
+                border: 1px solid $border-primary;
 
-                &.icon {
-                    @extend .font-icon;
-
-                    font-size: 70px;
-                    margin: 30px 0 0;
-                }
-
-                &.desc {
-                    color: $text-primary;
-                    font-size: 13px;
-                    padding: 13px;
+                &:not(.disabled):hover {
+                    background-color: $bcg-darkest;
+                    border-color: $text-dark;
                 }
             }
 
-            > .pcui-button {
-                display: flex;
-                justify-content: center;
-                margin: 0;
-                padding: 0;
-                width: 100%;
-                height: 34px;
-                line-height: 34px;
-                font-size: 12px;
-                text-transform: uppercase;
-                text-align: center;
-                box-shadow: unset;
+            &.publish {
+                color: $text-primary;
+                background-color: $text-active;
+                border: 1px solid $text-active;
 
-                @extend .font-bold;
-
-                &::before {
-                    @extend .font-icon;
-
-                    display: block;
-                    margin-right: 10px;
+                &:not(.disabled):hover {
+                    filter: brightness(1.08);
                 }
-
-                &.publish.collapsed { &::before { content: '\E268'; } }
-                &.download.collapsed { &::before { content: '\E245'; } }
             }
 
-            &:hover {
-                cursor: pointer;
-                background: $bcg-dark;
-
-                > .pcui-label {
-                    opacity: 1;
-                }
-
-                > .pcui-button {
-                    &:not(.disabled) {
-                        background: $bcg-darkest;
-                        color: $text-primary;
-
-                        &::before {
-                            color: $text-active;
-                        }
-                    }
-                }
+            &.disabled {
+                opacity: 0.5;
+                cursor: not-allowed;
             }
         }
     }
@@ -4476,30 +4466,36 @@ strong {
         }
     }
 
-    > ul {
+    > .builds-list {
         margin: 0;
         padding: 0;
-        border: none;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        overflow: hidden;
         background: transparent;
+
+        // each column sizes to its widest cell across all rows: status | name | branch | date | kebab
+        display: grid;
+        grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) max-content max-content;
+        column-gap: 14px;
 
         &.primary-build-summary {
             margin-bottom: 12px;
         }
 
-        > li {
+        > .build-item {
             @extend .font-regular;
 
-            height: auto;
-            min-height: 72px;
+            grid-column: 1 / -1;
+            display: grid;
+            grid-template-columns: subgrid;
+            column-gap: 14px;
+            align-items: center;
             line-height: normal;
-            padding: 0;
-            position: relative;
+            padding: 11px 0;
             border-bottom: 1px solid $border-primary;
             background: transparent;
             cursor: default;
-            overflow: visible;
-            text-overflow: clip;
-            white-space: normal;
             transition: background-color 100ms ease;
 
             &:hover {
@@ -4507,21 +4503,19 @@ strong {
                 cursor: pointer;
             }
 
-            // list is non-selectable; clicking to expand adds .selected, so neutralize the leaked theme background
-            &.selected:not(:hover) {
-                background-color: transparent;
+            &:last-child {
+                border-bottom: none;
             }
 
             > .build-row {
-                display: flex;
-                align-items: center;
-                gap: 14px;
-                min-height: 72px;
-                padding: 12px 14px;
+                display: contents;
+
+                > .status {
+                    margin-left: 14px;
+                }
 
                 > .body {
                     min-width: 0;
-                    flex: 1 1 0;
 
                     > .sub {
                         margin-top: 4px;
@@ -4534,7 +4528,6 @@ strong {
                 }
 
                 > .branch {
-                    flex: 1 1 0;
                     min-width: 0;
                     display: flex;
                     justify-content: flex-start;
@@ -4554,16 +4547,72 @@ strong {
                 }
 
                 > .right-meta {
-                    flex: 1 1 0;
                     display: flex;
                     flex-direction: column;
-                    align-items: flex-end;
+                    align-items: flex-start;
                     gap: 2px;
                     color: $text-dark;
                     font-size: 12px;
 
+                    > .date,
+                    > .duration {
+                        display: inline-flex;
+                        align-items: center;
+                        gap: 5px;
+                        white-space: nowrap;
+
+                        // custom calendar / stopwatch glyphs, tinted via currentcolor
+                        &::before {
+                            content: '';
+                            flex: 0 0 auto;
+                            width: 13px;
+                            height: 13px;
+                            background-color: currentcolor;
+                            mask: center / contain no-repeat;
+                        }
+                    }
+
                     > .date {
                         color: $text-primary;
+
+                        &::before {
+                            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='2' y='3' width='12' height='11' rx='1.6'/%3E%3Cpath d='M2 6.5h12M5 1.4v3M11 1.4v3'/%3E%3C/svg%3E");
+                        }
+                    }
+
+                    > .duration::before {
+                        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='8' cy='9.6' r='4.8'/%3E%3Cpath d='M8 9.6V6.7M6.3 1.5h3.4M8 1.5v3.1M12.4 5l1-1'/%3E%3C/svg%3E");
+                    }
+                }
+
+                > .kebab {
+                    margin-right: 14px;
+                    appearance: none;
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 28px;
+                    height: 28px;
+                    padding: 0;
+                    border: 1px solid transparent;
+                    border-radius: 4px;
+                    background: transparent;
+                    color: $text-dark;
+                    cursor: pointer;
+
+                    &::before {
+                        content: '';
+                        width: 16px;
+                        height: 16px;
+                        background-color: currentcolor;
+                        mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='3' cy='8' r='1.4'/%3E%3Ccircle cx='8' cy='8' r='1.4'/%3E%3Ccircle cx='13' cy='8' r='1.4'/%3E%3C/svg%3E") center / contain no-repeat;
+                    }
+
+                    &:hover,
+                    &.active {
+                        color: $text-primary;
+                        background-color: $bcg-darkest;
+                        border-color: $border-primary;
                     }
                 }
             }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3822,6 +3822,42 @@ strong {
     }
 }
 
+.pcui-menu.picker-builds-filter-menu {
+    z-index: 100001;
+
+    .pcui-menu-item:not(.pcui-menu-item-has-children):hover > .pcui-menu-item-children {
+        opacity: 0;
+        visibility: hidden;
+    }
+
+    .pcui-menu-items {
+        min-width: 150px;
+        max-height: 280px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        overflow: auto;
+    }
+
+    .pcui-menu-item-content {
+        font-size: 13px;
+
+        &:hover {
+            background-color: #354144;
+        }
+
+        > .pcui-label {
+            line-height: 30px;
+            margin: 0 10px;
+        }
+    }
+
+    .pcui-menu-item.selected > .pcui-menu-item-content > .pcui-label {
+        @extend .font-bold;
+
+        color: $text-primary;
+    }
+}
+
 .pcui-container.picker-publish-new {
     &.disabled {
         opacity: 0.5;
@@ -4277,6 +4313,13 @@ strong {
 
         &.no-builds-label {
             width: 100%;
+            padding: 14px 16px;
+            border: 1px solid $border-primary;
+            border-top: none;
+            border-radius: 0 0 6px 6px;
+            color: $text-dark;
+            background-color: rgb(0 0 0 / 8%);
+            box-sizing: border-box;
         }
     }
 
@@ -4349,6 +4392,72 @@ strong {
             &.disabled {
                 opacity: 0.5;
                 cursor: not-allowed;
+            }
+        }
+    }
+
+    > .builds-history-header {
+        display: flex;
+        flex-flow: row wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px 16px;
+        margin: 12px 0 0;
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px 6px 0 0;
+        background-color: rgb(0 0 0 / 8%);
+
+        > .builds-list-heading {
+            @extend .font-bold;
+
+            flex: 0 0 auto;
+            margin: 0;
+            padding: 0;
+            color: $text-primary;
+        }
+
+        > .builds-filter-bar {
+            display: flex;
+            flex: 0 1 auto;
+            flex-flow: row wrap;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 4px;
+            margin: 0 0 0 auto;
+        }
+
+        > .builds-filter-bar > .build-filter-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 28px;
+            margin: 0;
+            padding: 0 8px 0 10px;
+            border: 1px solid transparent;
+            border-radius: 4px;
+            background-color: transparent;
+            color: $text-dark;
+            font-size: 13px;
+            line-height: 26px;
+            box-shadow: none;
+            cursor: pointer;
+
+            &::after {
+                content: '';
+                width: 8px;
+                height: 8px;
+                margin-left: 6px;
+                background-color: currentcolor;
+                mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 6h8l-4 4-4-4Z'/%3E%3C/svg%3E") center / contain no-repeat;
+            }
+
+            &:hover,
+            &.active,
+            &.selected {
+                color: $text-primary;
+                background-color: $bcg-darkest;
+                border-color: $border-primary;
             }
         }
     }
@@ -4565,7 +4674,8 @@ strong {
         margin: 0;
         padding: 0;
         border: 1px solid $border-primary;
-        border-radius: 6px;
+        border-top: none;
+        border-radius: 0 0 6px 6px;
         overflow: hidden;
         background: transparent;
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3786,6 +3786,8 @@ strong {
 }
 
 .pcui-menu.picker-builds-menu {
+    z-index: 100001;
+
     .pcui-menu-item:not(.pcui-menu-item-has-children):hover > .pcui-menu-item-children {
         opacity: 0;
         visibility: hidden;
@@ -4252,6 +4254,14 @@ strong {
             padding-top: 10px;
         }
 
+        &.primary-build-heading {
+            @extend .font-regular;
+
+            color: $text-primary;
+            padding-bottom: 10px;
+            padding-top: 10px;
+        }
+
         &.no-builds-label {
             width: 100%;
         }
@@ -4349,228 +4359,300 @@ strong {
         border: none;
         background: transparent;
 
+        &.primary-build-summary {
+            margin-bottom: 12px;
+        }
+
         > li {
             @extend .font-regular;
 
             height: auto;
-            line-height: initial;
-            padding: 0 15px 7px;
+            min-height: 72px;
+            line-height: normal;
+            padding: 0;
             position: relative;
             border-bottom: 1px solid $border-primary;
             background: transparent;
             cursor: default;
+            overflow: visible;
+            text-overflow: clip;
+            white-space: normal;
+            transition: background-color 100ms ease;
 
-            &.complete:hover {
-                background-color: #414f52;
+            &:hover {
+                background-color: #354144;
                 cursor: pointer;
+            }
+
+            > .build-row {
+                display: flex;
+                align-items: center;
+                gap: 14px;
+                min-height: 72px;
+                padding: 12px 14px;
+            }
+
+            > .build-row > .status {
+                flex: 0 0 24px;
+                width: 24px;
+                height: 24px;
+                border-radius: 50%;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 14px;
+                border: 1px solid $border-primary;
+                color: $text-dark;
+                background-color: $bcg-darkest;
+                box-sizing: border-box;
+                position: relative;
+            }
+
+            &.complete > .build-row > .status {
+                color: #6fd088;
+                border-color: #3e8c54;
+                background-color: rgb(46 160 67 / 12%);
+
+                &::before {
+                    content: '';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 9px;
+                    height: 5px;
+                    border-bottom: 2px solid currentcolor;
+                    border-left: 2px solid currentcolor;
+                    box-sizing: border-box;
+                    transform: translate(-50%, -60%) rotate(-45deg);
+                }
+            }
+
+            &.error > .build-row > .status {
+                color: #ff8a8a;
+                border-color: #a83d3d;
+                background-color: rgb(231 76 60 / 12%);
+
+                &::before {
+                    content: '';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 11px;
+                    height: 2px;
+                    background-color: currentcolor;
+                    transform: translate(-50%, -50%) rotate(45deg);
+                }
+
+                &::after {
+                    content: '';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 11px;
+                    height: 2px;
+                    background-color: currentcolor;
+                    transform: translate(-50%, -50%) rotate(-45deg);
+                }
+            }
+
+            &.running > .build-row > .status {
+                border-color: $text-dark;
+                background-color: transparent;
+
+                &::after {
+                    content: '';
+                    width: 12px;
+                    height: 12px;
+                    border: 2px solid $text-dark;
+                    border-top-color: $text-active;
+                    border-radius: 50%;
+                    animation: build-status-spin 800ms linear infinite;
+                }
+            }
+
+            > .build-row > .body {
+                min-width: 0;
+                flex: 1 1 auto;
+            }
+
+            > .build-row > .body > .name-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                min-width: 0;
+                line-height: 20px;
 
                 > .name {
-                    color: $text-active;
-                }
-            }
+                    @extend .font-bold;
 
-            &:not(.complete):hover {
-                background-color: transparent;
-            }
-
-            > .primary {
-                @extend .font-icon;
-
-                top: 15px;
-                left: 0;
-                line-height: 1;
-                height: 20px;
-                color: $text-darkest;
-                background: transparent;
-                border: none;
-                font-size: 16px;
-                position: absolute;
-
-                &:not(.disabled):hover {
-                    color: $text-dark;
-                    cursor: pointer;
-                }
-            }
-
-            &.primary > .primary {
-                color: $text-active;
-
-                &:hover {
-                    color: $text-active;
-                    cursor: default;
-                }
-            }
-
-            > .status {
-                width: 40px;
-                height: 40px;
-                line-height: 40px;
-                display: inline-block;
-                border: 1px solid $border-primary;
-                position: absolute;
-                text-align: center;
-                top: 16px;
-                left: 35px;
-                background-color: $bcg-darkest;
-            }
-
-            &.complete {
-                > .status > img {
-                    width: 40px;
-                    height: 40px;
-                }
-            }
-
-            &.running {
-                > .status > img {
-                    width: 25px;
-                    height: 25px;
-                    display: inline-block;
-                    vertical-align: middle;
-                }
-            }
-
-            &.error {
-                > .status {
-                    background-color: #e74c3c;
-
-                    &::after {
-                        color: $bcg-dark;
-
-                        @extend .font-icon;
-
-                        font-size: 24px;
-                        content: '\E132';
-                        display: inline-block;
-                        vertical-align: middle;
-                    }
-                }
-            }
-
-            > .name-row {
-                position: absolute;
-                left: 90px;
-                top: 15px;
-                line-height: 1;
-
-                > .name,
-                > .version {
+                    min-width: 0;
+                    max-width: 100%;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
-                    margin-top: 0;
-                    vertical-align: top;
-                }
-
-                > .name {
                     font-size: 14px;
-                    max-width: 710px;
                     color: $text-primary;
+                    margin: 0;
                 }
 
-                > .version {
-                    max-width: 50px;
+                > .badge {
+                    flex: 0 0 auto;
+                    height: 18px;
+                    line-height: 18px;
+                    padding: 0 6px;
+                    border: 1px solid $border-primary;
+                    border-radius: 4px;
+                    color: $text-dark;
+                    background-color: rgb(0 0 0 / 14%);
+                    font-size: 11px;
+                    text-transform: uppercase;
+                    letter-spacing: 0;
+
+                    &.publish {
+                        color: #9dd4ff;
+                        border-color: rgb(110 170 220 / 45%);
+                    }
+
+                    &.download {
+                        color: #f3c16f;
+                        border-color: rgb(225 166 62 / 45%);
+                    }
+
+                    &.primary-badge {
+                        color: $text-active;
+                        border-color: rgb(255 122 35 / 50%);
+                    }
                 }
             }
 
-            > .info {
-                position: absolute;
-                top: 35px;
-                left: 90px;
+            > .build-row > .body > .meta {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px 12px;
+                min-width: 0;
+                margin-top: 5px;
+                color: $text-dark;
+                font-size: 12px;
 
-                > .size,
-                > .views,
-                > .date,
-                > .branch {
-                    padding-right: 10px;
+                > .meta-item {
+                    min-width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
 
-                    &::before {
-                        @extend .font-icon;
-
-                        font-size: 12px;
-                        padding-right: 6px;
-                        color: $text-darkest;
+                    &.state {
+                        color: $text-primary;
                     }
                 }
+            }
 
-                > .size::before {
-                    content: '\E216';
+            > .build-row > .actions {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 6px;
+                flex: 0 0 auto;
+
+                > .pcui-button,
+                > .action-button {
+                    appearance: none;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 28px;
+                    height: 28px;
+                    line-height: 1;
+                    margin: 0;
+                    padding: 0;
+                    border: 1px solid $border-primary;
+                    border-radius: 4px;
+                    color: $text-dark;
+                    background-color: rgb(0 0 0 / 12%);
+                    text-align: center;
+                    box-sizing: border-box;
                 }
 
-                > .branch::before {
-                    content: '\E399';
+                > .pcui-button.primary {
+                    @extend .font-icon;
+
+                    color: $text-darkest;
                 }
 
-                > .views::before {
-                    content: '\E308';
+                > .action-button.dropdown,
+                > .action-button.expander {
+                    @extend .font-icon;
+                }
+
+                > .pcui-button.primary:not(.disabled):hover,
+                > .action-button.dropdown:hover,
+                > .action-button.expander:hover,
+                > .action-button.clicked {
+                    color: $text-primary;
+                    background-color: $bcg-darkest;
+                    cursor: pointer;
+                }
+
+                > .artifact {
+                    @extend .font-bold;
+
+                    height: 28px;
+                    line-height: 28px;
+                    padding: 0 10px;
+                    border: 1px solid $border-primary;
+                    border-radius: 4px;
+                    color: $text-primary;
+                    background-color: rgb(0 0 0 / 12%);
+                    text-decoration: none;
+
+                    &:hover {
+                        color: $text-active;
+                        background-color: $bcg-darkest;
+                    }
                 }
             }
 
             > .error {
                 color: #e74c3c;
-                margin-left: 80px;
+                margin: -8px 14px 12px 52px;
                 white-space: normal;
                 word-wrap: break-word;
-                margin-top: 40px;
-                width: calc(100% - 135px);
-            }
-
-            > .notes {
-                margin-top: 65px;
-                margin-left: 80px;
-                white-space: pre-wrap;
-                width: calc(100% - 135px);
-
-                &.no-wrap {
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                }
-            }
-
-            > .more {
-                background-color: transparent;
-                color: $text-dark;
-                cursor: pointer;
                 font-size: 12px;
-                border: none;
-                margin: 0;
-                padding: 0;
-                position: absolute;
-                top: 64px;
-                right: 10px;
-
-                &:hover {
-                    color: $text-primary;
-                }
             }
 
-            > .dropdown {
-                position: absolute;
-                top: 25px;
-                right: 15px;
-                width: 16px;
-                height: 16px;
-                line-height: 16px;
-                border: none;
-                padding: 0;
-                margin: 0;
-                text-align: center;
-                vertical-align: top;
+            > .details {
+                margin: -2px 14px 12px 52px;
+                padding: 10px 0 2px;
+                border-top: 1px solid rgb(255 255 255 / 6%);
+                color: $text-primary;
 
-                @extend .font-icon;
+                > .detail-row {
+                    display: flex;
+                    gap: 8px;
+                    padding-top: 4px;
+                    min-width: 0;
 
-                font-size: 12px;
-                color: $bcg-darkest;
-                background-color: $text-darkest;
+                    > .key {
+                        color: $text-dark;
+                        flex: 0 0 72px;
+                    }
 
-                &:hover,
-                &.clicked {
-                    color: $text-primary;
-                    background-color: $bcg-darkest;
+                    > .value {
+                        min-width: 0;
+                        overflow-wrap: anywhere;
+
+                        > a {
+                            color: $text-active;
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+@keyframes build-status-spin {
+    to {
+        transform: rotate(360deg);
     }
 }
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4129,6 +4129,14 @@ strong {
             gap: 10px;
         }
 
+        // explains why the action button is disabled
+        > .footer-hint {
+            margin: 0 auto 0 0;
+            color: $text-dark;
+            font-size: 12px;
+            line-height: 16px;
+        }
+
         > .pcui-button {
             @extend .font-bold;
 
@@ -4753,20 +4761,28 @@ strong {
                     font-size: 12px;
                 }
 
-                > .url {
+                > .url-row {
                     align-self: flex-start;
-                    display: inline-block;
-                    width: fit-content;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    min-width: 0;
                     max-width: 100%;
-                    color: #9dd4ff;
-                    font-size: 13px;
-                    text-decoration: none;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
 
-                    &:hover {
-                        text-decoration: underline;
+                    > .url {
+                        display: inline-block;
+                        min-width: 0;
+                        max-width: 100%;
+                        color: #9dd4ff;
+                        font-size: 13px;
+                        text-decoration: none;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+
+                        &:hover {
+                            text-decoration: underline;
+                        }
                     }
                 }
             }
@@ -4811,6 +4827,71 @@ strong {
         }
     }
 
+    // shimmer placeholder rows shown while builds load
+    > .builds-skeleton {
+        margin: 0;
+        padding: 0;
+        border: 1px solid $border-primary;
+        border-top: none;
+        border-radius: 0 0 6px 6px;
+        overflow: hidden;
+
+        > .skeleton-row {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            padding: 13px 14px;
+            border-bottom: 1px solid $border-primary;
+
+            &:last-child {
+                border-bottom: none;
+            }
+
+            &:nth-child(2) .bone { animation-delay: 120ms; }
+            &:nth-child(3) .bone { animation-delay: 240ms; }
+            &:nth-child(4) .bone { animation-delay: 360ms; }
+
+            > .skeleton-body {
+                flex: 1 1 auto;
+                display: flex;
+                flex-direction: column;
+                gap: 7px;
+            }
+        }
+
+        .bone {
+            background-color: rgb(255 255 255 / 8%);
+            border-radius: 4px;
+            animation: builds-skeleton-pulse 1.4s ease-in-out infinite;
+
+            &.dot {
+                flex: 0 0 24px;
+                width: 24px;
+                height: 24px;
+                border-radius: 50%;
+            }
+
+            &.line {
+                height: 10px;
+            }
+
+            &.title { width: 38%; }
+            &.sub { width: 22%; }
+
+            &.pill {
+                flex: 0 0 auto;
+                width: 90px;
+                height: 20px;
+                border-radius: 10px;
+            }
+
+            &.meta {
+                flex: 0 0 auto;
+                width: 70px;
+            }
+        }
+    }
+
     > .builds-list {
         margin: 0;
         padding: 0;
@@ -4833,10 +4914,42 @@ strong {
 
             grid-column: 1 / -1;
             width: 100%;
+            margin: 0;
             padding: 14px 16px;
             color: $text-dark;
             background-color: rgb(0 0 0 / 8%);
             box-sizing: border-box;
+
+            &:not(.pcui-hidden) {
+                display: flex;
+                flex-flow: row wrap;
+                align-items: center;
+                gap: 4px 10px;
+            }
+
+            > .pcui-label {
+                margin: 0;
+                color: inherit;
+                font-size: 13px;
+                line-height: 18px;
+            }
+
+            > .clear-filters {
+                appearance: none;
+                margin: 0;
+                padding: 0;
+                border: none;
+                background: transparent;
+                color: #9dd4ff;
+                font-size: 13px;
+                line-height: 18px;
+                cursor: pointer;
+
+                &:hover,
+                &:focus {
+                    text-decoration: underline;
+                }
+            }
         }
 
         > .build-item {
@@ -5044,6 +5157,53 @@ strong {
         }
     }
 
+}
+
+// GitHub-style copy-to-clipboard icon button (builds panel + build detail)
+.picker-builds-publish,
+.picker-build-detail {
+    .copy-button {
+        appearance: none;
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        margin: 0;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        background: transparent;
+        color: $text-dark;
+        box-shadow: none;
+        box-sizing: border-box;
+        cursor: pointer;
+        transition: color 100ms, background-color 100ms, border-color 100ms, opacity 100ms;
+
+        &::before {
+            content: '';
+            width: 13px;
+            height: 13px;
+            background-color: currentcolor;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z'/%3E%3Cpath d='M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z'/%3E%3C/svg%3E") center / contain no-repeat;
+        }
+
+        &:hover,
+        &:focus {
+            color: $text-primary;
+            background-color: $bcg-dark;
+            border-color: $bcg-darkest;
+        }
+
+        &.copied {
+            color: #6fd088;
+
+            &::before {
+                mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 1 1 1.06-1.06l2.72 2.72 6.72-6.72a.75.75 0 0 1 1.06 0Z'/%3E%3C/svg%3E");
+            }
+        }
+    }
 }
 
 .picker-build-detail {
@@ -5343,6 +5503,38 @@ strong {
                 opacity: $element-opacity-readonly;
                 cursor: default;
             }
+
+            > .copy-button {
+                width: 32px;
+                height: 32px;
+                border-color: $bcg-darkest;
+                border-radius: 4px;
+                color: $text-secondary;
+                background-color: $bcg-dark;
+
+                &::before {
+                    width: 15px;
+                    height: 15px;
+                }
+
+                &:hover,
+                &:focus {
+                    color: $text-primary;
+                    background-color: $bcg-dark;
+                    border-color: $bcg-darkest;
+                    box-shadow: $element-shadow-hover;
+                }
+
+                &:active {
+                    background-color: $bcg-darkest;
+                    border-color: $border-primary;
+                    box-shadow: none;
+                }
+
+                &.copied {
+                    color: #6fd088;
+                }
+            }
         }
     }
 
@@ -5378,6 +5570,121 @@ strong {
             font-size: 13px;
             line-height: 18px;
             text-transform: uppercase;
+        }
+    }
+
+    // created → build → completed step strip
+    .timeline {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 2px 0;
+
+        > .step {
+            flex: 0 0 auto;
+
+            > .step-head {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            > .step-head > .dot {
+                flex: 0 0 18px;
+                width: 18px;
+                height: 18px;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                border: 1px solid $border-primary;
+                border-radius: 50%;
+                color: $text-dark;
+                background-color: $bcg-darkest;
+                box-sizing: border-box;
+                position: relative;
+            }
+
+            > .step-head > .step-label {
+                @extend .font-bold;
+
+                color: $text-primary;
+                font-size: 13px;
+                line-height: 18px;
+            }
+
+            > .step-sub {
+                margin: 4px 0 0 26px;
+                color: $text-dark;
+                font-size: 12px;
+                line-height: 16px;
+                white-space: nowrap;
+            }
+
+            &.done > .step-head > .dot {
+                color: #6fd088;
+                border-color: #3e8c54;
+                background-color: rgb(46 160 67 / 12%);
+
+                &::before {
+                    content: '';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 7px;
+                    height: 4px;
+                    border-bottom: 2px solid currentcolor;
+                    border-left: 2px solid currentcolor;
+                    box-sizing: border-box;
+                    transform: translate(-50%, -60%) rotate(-45deg);
+                }
+            }
+
+            &.failed > .step-head > .dot {
+                color: #ff8a8a;
+                border-color: #a83d3d;
+                background-color: rgb(231 76 60 / 12%);
+
+                &::before,
+                &::after {
+                    content: '';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 8px;
+                    height: 2px;
+                    background-color: currentcolor;
+                }
+
+                &::before { transform: translate(-50%, -50%) rotate(45deg); }
+                &::after { transform: translate(-50%, -50%) rotate(-45deg); }
+            }
+
+            &.active > .step-head > .dot {
+                border-color: $text-dark;
+                background-color: transparent;
+
+                &::after {
+                    content: '';
+                    width: 9px;
+                    height: 9px;
+                    border: 2px solid $text-dark;
+                    border-top-color: $text-active;
+                    border-radius: 50%;
+                    animation: build-status-spin 800ms linear infinite;
+                }
+            }
+
+            &.pending > .step-head > .step-label {
+                color: $text-dark;
+            }
+        }
+
+        > .connector {
+            flex: 1 1 auto;
+            height: 1px;
+            min-width: 20px;
+            margin-top: 9px;
+            background-color: $border-primary;
         }
     }
 
@@ -5491,6 +5798,10 @@ strong {
         min-width: 0;
         font-size: 13px;
         line-height: 18px;
+
+        &:hover .value > .copy-button {
+            opacity: 1;
+        }
     }
 
     .key {
@@ -5534,7 +5845,9 @@ strong {
         }
 
         &.metadata-code {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
             justify-self: start;
             max-width: 100%;
             padding: 1px 5px;
@@ -5548,9 +5861,75 @@ strong {
             line-height: 16px;
         }
 
-        .metadata-list {
+        // revealed on row hover (see .detail-row:hover below)
+        > .copy-button {
+            width: 16px;
+            height: 16px;
+            border: none;
+            opacity: 0;
+
+            &::before {
+                width: 12px;
+                height: 12px;
+            }
+
+            &.copied,
+            &:focus {
+                opacity: 1;
+            }
+        }
+
+        // same pill as the build history rows
+        &.metadata-branch {
+            display: inline-block;
+            justify-self: start;
+            max-width: 100%;
+            padding: 2px 10px;
+            border: 1px solid $border-primary;
+            border-radius: 10px;
+            background-color: rgb(0 0 0 / 14%);
+            color: $text-primary;
+            font-size: 12px;
+            line-height: 16px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            overflow-wrap: normal;
+            box-sizing: border-box;
+        }
+
+        // build options checklist: green check when enabled, muted dash when off
+        .options-list {
             display: grid;
-            gap: 2px;
+            gap: 6px;
+            padding: 2px 0;
+
+            > .option {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                color: $text-primary;
+                font-size: 13px;
+                line-height: 18px;
+
+                &::before {
+                    content: '';
+                    flex: 0 0 auto;
+                    width: 14px;
+                    height: 14px;
+                    background-color: #6fd088;
+                    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 1 1 1.06-1.06l2.72 2.72 6.72-6.72a.75.75 0 0 1 1.06 0Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                }
+
+                &.off {
+                    color: $text-dark;
+
+                    &::before {
+                        background-color: $text-darkest;
+                        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 7.25h9v1.5h-9Z'/%3E%3C/svg%3E");
+                    }
+                }
+            }
         }
 
         a {
@@ -5602,6 +5981,17 @@ strong {
 @keyframes build-status-spin {
     to {
         transform: rotate(360deg);
+    }
+}
+
+@keyframes builds-skeleton-pulse {
+    0%,
+    100% {
+        opacity: 0.45;
+    }
+
+    50% {
+        opacity: 1;
     }
 }
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3813,8 +3813,7 @@ strong {
         }
     }
 
-    .pcui-menu-item.open > .pcui-menu-item-content > .pcui-label,
-    .pcui-menu-item.download > .pcui-menu-item-content > .pcui-label {
+    .pcui-menu-item.primary:not(.pcui-disabled) > .pcui-menu-item-content > .pcui-label {
         color: $text-primary;
     }
 
@@ -4276,14 +4275,6 @@ strong {
             padding-top: 10px;
         }
 
-        &.primary-build-heading {
-            @extend .font-regular;
-
-            color: $text-primary;
-            padding-bottom: 10px;
-            padding-top: 10px;
-        }
-
         &.no-builds-label {
             width: 100%;
         }
@@ -4293,15 +4284,34 @@ strong {
         width: 100%;
     }
 
-    > .builds-toolbar {
+    > .primary-build-header {
         display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: flex-end;
-        gap: 10px;
-        margin: 20px 0 8px;
+        flex-flow: row wrap;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 12px 16px;
+        margin: 20px 0 10px;
 
-        > .pcui-button {
+        > .primary-build-heading {
+            @extend .font-regular;
+
+            color: $text-primary;
+            flex: 0 0 auto;
+            margin: 0;
+            padding: 0;
+        }
+
+        > .builds-toolbar {
+            display: flex;
+            flex: 0 0 auto;
+            flex-flow: row nowrap;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 10px;
+            margin: 0 0 0 auto;
+        }
+
+        > .builds-toolbar > .pcui-button {
             @extend .font-bold;
 
             display: inline-flex;
@@ -4466,6 +4476,91 @@ strong {
         }
     }
 
+    > .primary-build-summary {
+        margin-bottom: 12px;
+
+        > .primary-build-card {
+            position: relative;
+            display: flex;
+            align-items: stretch;
+            gap: 14px;
+            padding: 16px;
+            border: 1px solid $border-primary;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: background-color 100ms ease;
+
+            &:hover {
+                background-color: #354144;
+            }
+
+            > .thumb {
+                flex: 0 0 auto;
+                width: 72px;
+                height: auto;
+                align-self: stretch;
+                border-radius: 6px;
+                object-fit: cover;
+                border: 1px solid $border-primary;
+                background-color: $bcg-darkest;
+            }
+
+            > .body {
+                min-width: 0;
+                flex: 1 1 auto;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+
+                > .sub {
+                    margin-top: 4px;
+                    color: $text-dark;
+                    font-size: 12px;
+                }
+
+                > .url {
+                    display: inline-block;
+                    max-width: 100%;
+                    color: #9dd4ff;
+                    font-size: 13px;
+                    text-decoration: none;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+
+                    &:hover {
+                        text-decoration: underline;
+                    }
+                }
+            }
+
+            > .open-external {
+                flex: 0 0 auto;
+                align-self: center;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 28px;
+                height: 28px;
+                border-radius: 4px;
+                color: $text-dark;
+
+                &::before {
+                    content: '';
+                    width: 16px;
+                    height: 16px;
+                    background-color: currentcolor;
+                    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.06-1.06l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                }
+
+                &:hover {
+                    color: $text-primary;
+                    background-color: $bcg-darkest;
+                }
+            }
+        }
+    }
+
     > .builds-list {
         margin: 0;
         padding: 0;
@@ -4474,14 +4569,10 @@ strong {
         overflow: hidden;
         background: transparent;
 
-        // each column sizes to its widest cell across all rows: status | name | branch | date | kebab
+        // shared row columns: status | name | branch | artifact | date | kebab
         display: grid;
-        grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) max-content max-content;
+        grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) 32px max-content max-content;
         column-gap: 14px;
-
-        &.primary-build-summary {
-            margin-bottom: 12px;
-        }
 
         > .build-item {
             @extend .font-regular;
@@ -4543,6 +4634,48 @@ strong {
                         overflow: hidden;
                         text-overflow: ellipsis;
                         white-space: nowrap;
+                    }
+                }
+
+                > .row-artifact {
+                    appearance: none;
+                    place-self: center;
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 28px;
+                    height: 28px;
+                    padding: 0;
+                    border: 1px solid transparent;
+                    border-radius: 4px;
+                    background: transparent;
+                    color: $text-dark;
+
+                    &::before {
+                        content: '';
+                        width: 16px;
+                        height: 16px;
+                        background-color: currentcolor;
+                        mask: center / contain no-repeat;
+                    }
+
+                    &.open::before {
+                        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M10.6 1H15v4.4h-1.5V3.6l-5 5-1.1-1.1 5-5h-1.8V1ZM3.8 3h3.5v1.5H3.8a.3.3 0 0 0-.3.3v7.4c0 .2.1.3.3.3h7.4c.2 0 .3-.1.3-.3V8.7H13v3.5c0 1-.8 1.8-1.8 1.8H3.8c-1 0-1.8-.8-1.8-1.8V4.8C2 3.8 2.8 3 3.8 3Z'/%3E%3C/svg%3E");
+                    }
+
+                    &.download::before {
+                        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7.25 1h1.5v7.1l2.3-2.3 1.1 1.1L8 11.05 3.85 6.9l1.1-1.1 2.3 2.3V1ZM2 13h12v1.5H2Z'/%3E%3C/svg%3E");
+                    }
+
+                    &.placeholder {
+                        visibility: hidden;
+                        pointer-events: none;
+                    }
+
+                    &:not(.placeholder):hover {
+                        color: $text-primary;
+                        background-color: $bcg-darkest;
+                        border-color: $border-primary;
                     }
                 }
 
@@ -4619,105 +4752,506 @@ strong {
         }
     }
 
-    > .build-detail {
+}
+
+.picker-build-detail {
+    padding: 18px 20px 24px !important;
+    color: $text-primary;
+
+    > .back {
+        @extend .font-bold;
+
+        appearance: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        margin: 0 0 14px;
         padding: 0;
+        border: none;
+        background: transparent;
+        color: $text-dark;
+        font-size: 12px;
+        text-transform: uppercase;
+        cursor: pointer;
 
-        > .back {
-            appearance: none;
-            align-self: flex-start;
-            margin: 4px 0 16px;
-            padding: 4px 0;
-            border: none;
-            background: transparent;
-            color: $text-dark;
-            font-size: 13px;
-            cursor: pointer;
+        &::before {
+            content: '';
+            width: 14px;
+            height: 14px;
+            background-color: currentcolor;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7.3 3.3 2.6 8l4.7 4.7 1.1-1.1L6.2 8.8H14V7.2H6.2l2.4-2.6-1.1-1.1Z'/%3E%3C/svg%3E") center / contain no-repeat;
+        }
 
-            &:hover {
-                color: $text-primary;
+        &:hover {
+            color: $text-primary;
+        }
+    }
+
+    .status {
+        flex: 0 0 24px;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        border: 1px solid $border-primary;
+        color: $text-dark;
+        background-color: $bcg-darkest;
+        box-sizing: border-box;
+        position: relative;
+
+        &.complete {
+            color: #6fd088;
+            border-color: #3e8c54;
+            background-color: rgb(46 160 67 / 12%);
+
+            &::before {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 9px;
+                height: 5px;
+                border-bottom: 2px solid currentcolor;
+                border-left: 2px solid currentcolor;
+                box-sizing: border-box;
+                transform: translate(-50%, -60%) rotate(-45deg);
             }
         }
 
-        > .detail-header {
-            display: flex;
-            align-items: center;
-            gap: 14px;
-            padding-bottom: 14px;
-            border-bottom: 1px solid $border-primary;
+        &.error {
+            color: #ff8a8a;
+            border-color: #a83d3d;
+            background-color: rgb(231 76 60 / 12%);
 
-            > .heading {
-                min-width: 0;
-                flex: 1 1 auto;
-
-                > .sub {
-                    margin-top: 4px;
-                    color: $text-dark;
-                    font-size: 12px;
-                }
+            &::before,
+            &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 11px;
+                height: 2px;
+                background-color: currentcolor;
             }
 
-            > .detail-actions {
+            &::before { transform: translate(-50%, -50%) rotate(45deg); }
+            &::after { transform: translate(-50%, -50%) rotate(-45deg); }
+        }
+
+        &.running {
+            border-color: $text-dark;
+            background-color: transparent;
+
+            &::after {
+                content: '';
+                width: 12px;
+                height: 12px;
+                border: 2px solid $text-dark;
+                border-top-color: $text-active;
+                border-radius: 50%;
+                animation: build-status-spin 800ms linear infinite;
+            }
+        }
+    }
+
+    .badge {
+        flex: 0 0 auto;
+        height: 18px;
+        line-height: 18px;
+        padding: 0 6px;
+        border: 1px solid $border-primary;
+        border-radius: 4px;
+        color: $text-dark;
+        background-color: rgb(0 0 0 / 14%);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+
+        &.publish {
+            color: #9dd4ff;
+            border-color: rgb(110 170 220 / 45%);
+        }
+
+        &.download {
+            color: #f3c16f;
+            border-color: rgb(225 166 62 / 45%);
+        }
+
+        &.primary-badge {
+            color: $text-active;
+            border-color: rgb(255 122 35 / 50%);
+        }
+    }
+
+    .name-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
+        min-width: 0;
+        line-height: 20px;
+
+        > .name {
+            @extend .font-bold;
+
+            min-width: 0;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-size: 18px;
+            color: $text-primary;
+            margin: 0;
+        }
+    }
+
+    > .detail-hero {
+        display: grid;
+        grid-template-columns: 72px minmax(0, 1fr) max-content;
+        align-items: center;
+        gap: 14px;
+        padding: 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 10%);
+
+        > .thumb {
+            flex: 0 0 auto;
+            width: 72px;
+            height: 72px;
+            border: 1px solid $border-primary;
+            border-radius: 6px;
+            object-fit: cover;
+            background-color: $bcg-darkest;
+        }
+
+        > .heading {
+            min-width: 0;
+
+            > .detail-stats {
                 display: flex;
                 align-items: center;
-                gap: 8px;
-                flex: 0 0 auto;
+                gap: 12px;
+                margin-top: 10px;
+                color: $text-dark;
+                font-size: 13px;
+            }
 
-                > .pcui-button {
-                    margin: 0;
-                    height: 28px;
+            .metric {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                white-space: nowrap;
+
+                &::before {
+                    content: '';
+                    width: 16px;
+                    height: 16px;
+                    background-color: currentcolor;
+                    mask: center / contain no-repeat;
                 }
 
-                > .artifact {
-                    @extend .font-bold;
-
-                    height: 28px;
-                    line-height: 28px;
-                    padding: 0 12px;
-                    border: 1px solid $border-primary;
-                    border-radius: 4px;
-                    color: $text-primary;
-                    background-color: rgb(0 0 0 / 12%);
-                    text-decoration: none;
-
-                    &:hover {
-                        color: $text-active;
-                        background-color: $bcg-darkest;
-                    }
+                &.views::before {
+                    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 3.3c3.2 0 5.7 2.1 7 4.7-1.3 2.6-3.8 4.7-7 4.7S2.3 10.6 1 8c1.3-2.6 3.8-4.7 7-4.7Zm0 1.5C5.7 4.8 3.8 6 2.7 8c1.1 2 3 3.2 5.3 3.2s4.2-1.2 5.3-3.2C12.2 6 10.3 4.8 8 4.8Zm0 1.2a2 2 0 1 1 0 4 2 2 0 0 1 0-4Z'/%3E%3C/svg%3E");
                 }
+            }
+
+            > .sub {
+                margin-top: 6px;
+                color: $text-dark;
+                font-size: 12px;
+                overflow-wrap: anywhere;
             }
         }
 
-        > .error {
-            margin: 14px 0 0;
-            color: #e74c3c;
-            font-size: 12px;
-            white-space: normal;
-            word-wrap: break-word;
+        > .detail-actions {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 8px;
+            flex-wrap: wrap;
+
+            > .pcui-button,
+            > .detail-button {
+                @extend .font-bold;
+
+                box-sizing: border-box;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                margin: 0;
+                height: 32px;
+                padding: 0 14px;
+                border: 1px solid $border-primary;
+                border-radius: 4px;
+                color: $text-primary;
+                background-color: rgb(0 0 0 / 12%);
+                box-shadow: none;
+                font-size: 14px;
+                line-height: 30px;
+                text-decoration: none;
+            }
+
+            > .pcui-button > .pcui-label {
+                margin: 0;
+                font-size: 14px;
+                line-height: 30px;
+            }
+
+            > .detail-button:hover {
+                color: $text-active;
+                background-color: $bcg-darkest;
+            }
+
+            > .pcui-button.delete {
+                color: #ff8a8a;
+                background-color: transparent;
+                border-color: rgb(168 61 61 / 65%);
+            }
+        }
+    }
+
+    > .error {
+        margin: 14px 0 0;
+        padding: 10px 12px;
+        border: 1px solid rgb(168 61 61 / 65%);
+        border-radius: 6px;
+        color: #ff8a8a;
+        background-color: rgb(231 76 60 / 10%);
+        font-size: 12px;
+        white-space: normal;
+        word-wrap: break-word;
+    }
+
+    > .detail-body {
+        display: grid;
+        gap: 12px;
+        margin-top: 14px;
+    }
+
+    .detail-section {
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
+
+        > h3 {
+            @extend .font-bold;
+
+            margin: 0 0 10px;
+            color: $text-primary;
+            font-size: 13px;
+            line-height: 18px;
+            text-transform: uppercase;
+        }
+    }
+
+    .metadata-grid {
+        display: grid;
+        grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+        gap: 8px 18px;
+    }
+
+    .artifact-list {
+        display: grid;
+        gap: 8px;
+    }
+
+    .artifact-card {
+        display: grid;
+        grid-template-columns: 34px minmax(0, 1fr) max-content;
+        align-items: center;
+        gap: 12px;
+        min-width: 0;
+        padding: 12px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 10%);
+
+        > .artifact-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 32px;
+            height: 32px;
+            border: 1px solid $border-primary;
+            border-radius: 6px;
+            color: $text-dark;
+            background-color: rgb(0 0 0 / 16%);
+
+            &::before {
+                content: '';
+                width: 18px;
+                height: 18px;
+                background-color: currentcolor;
+                mask: center / contain no-repeat;
+            }
         }
 
-        > .details {
-            margin: 14px 0 0;
+        &.app > .artifact-icon::before {
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M10.6 1H15v4.4h-1.5V3.6l-5 5-1.1-1.1 5-5h-1.8V1ZM3.8 3h3.5v1.5H3.8a.3.3 0 0 0-.3.3v7.4c0 .2.1.3.3.3h7.4c.2 0 .3-.1.3-.3V8.7H13v3.5c0 1-.8 1.8-1.8 1.8H3.8c-1 0-1.8-.8-1.8-1.8V4.8C2 3.8 2.8 3 3.8 3Z'/%3E%3C/svg%3E");
+        }
+
+        &.zip > .artifact-icon::before {
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3 1.5h6.7L13 4.8v9.7H3v-13Zm6 1.4V5.5h2.6L9 2.9ZM4.5 3v10h7V7H7.8V5.5h-1V7h1v1.2h-1v1h1v1.2h-1v1.1h2.4V10H8.3V8.9h.9V7.7h-.9V6.5h.9V5H7.8V3h-1v1h1V3H4.5Z'/%3E%3C/svg%3E");
+        }
+
+        > .artifact-body {
+            min-width: 0;
+        }
+
+        .artifact-title {
+            @extend .font-bold;
+
             color: $text-primary;
+            font-size: 14px;
+            line-height: 18px;
+        }
 
-            > .detail-row {
-                display: flex;
-                gap: 8px;
-                padding-top: 8px;
-                min-width: 0;
+        .artifact-meta {
+            margin-top: 3px;
+            color: $text-dark;
+            font-size: 12px;
+            line-height: 16px;
+        }
 
-                > .key {
-                    color: $text-dark;
-                    flex: 0 0 120px;
-                }
+        > .artifact-action {
+            @extend .font-bold;
 
-                > .value {
-                    min-width: 0;
-                    overflow-wrap: anywhere;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 28px;
+            padding: 0 12px;
+            border: 1px solid $border-primary;
+            border-radius: 4px;
+            color: $text-primary;
+            background-color: rgb(0 0 0 / 12%);
+            font-size: 13px;
+            line-height: 26px;
+            text-decoration: none;
 
-                    > a {
-                        color: $text-active;
-                    }
-                }
+            &:hover {
+                color: $text-active;
+                background-color: $bcg-darkest;
+            }
+        }
+    }
+
+    .detail-row {
+        display: grid;
+        grid-column: 1 / -1;
+        grid-template-columns: subgrid;
+        min-width: 0;
+        font-size: 13px;
+        line-height: 18px;
+    }
+
+    .key {
+        color: $text-dark;
+    }
+
+    .value {
+        min-width: 0;
+        color: $text-primary;
+        overflow-wrap: anywhere;
+
+        &.metadata-badge {
+            flex: 0 0 auto;
+            display: inline-flex;
+            align-items: center;
+            justify-self: start;
+            max-width: 100%;
+            height: 18px;
+            padding: 0 6px;
+            border: 1px solid $border-primary;
+            border-radius: 4px;
+            background-color: rgb(0 0 0 / 14%);
+            color: $text-dark;
+            font-size: 11px;
+            line-height: 18px;
+            letter-spacing: 0;
+            text-transform: uppercase;
+            box-sizing: border-box;
+            overflow-wrap: normal;
+            white-space: nowrap;
+
+            &.publish {
+                color: #9dd4ff;
+                border-color: rgb(110 170 220 / 45%);
+            }
+
+            &.download {
+                color: #f3c16f;
+                border-color: rgb(225 166 62 / 45%);
+            }
+        }
+
+        &.metadata-code {
+            display: inline-block;
+            justify-self: start;
+            max-width: 100%;
+            padding: 1px 5px;
+            border: 1px solid rgb(255 255 255 / 12%);
+            border-radius: 4px;
+            background-color: rgb(0 0 0 / 16%);
+            color: #d7e6ef;
+            font-family: inconsolatamedium, Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace;
+            font-size: 12px;
+            font-variant-numeric: tabular-nums;
+            line-height: 16px;
+        }
+
+        .metadata-list {
+            display: grid;
+            gap: 2px;
+        }
+
+        a {
+            color: #9dd4ff;
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    @media (max-width: 700px) {
+        > .detail-hero {
+            grid-template-columns: 72px minmax(0, 1fr);
+
+            > .detail-actions {
+                grid-column: 1 / -1;
+                justify-content: flex-start;
+                padding-left: 86px;
+            }
+        }
+
+        .metadata-grid,
+        .detail-row {
+            display: block;
+        }
+
+        .key {
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .detail-row + .detail-row {
+            margin-top: 8px;
+        }
+
+        .artifact-card {
+            grid-template-columns: 34px minmax(0, 1fr);
+
+            > .artifact-action {
+                grid-column: 2;
+                justify-self: flex-start;
             }
         }
     }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3571,8 +3571,7 @@ strong {
     }
 }
 
-.pcui-container.picker-scene-panel,
-.pcui-container.picker-publish-new {
+.pcui-container.picker-scene-panel {
     .ui-list.scene-list {
         margin: 0;
         padding: 0;
@@ -3873,38 +3872,160 @@ strong {
 }
 
 .pcui-container.picker-publish-new {
+    padding: 18px 20px 24px !important;
+    color: $text-primary;
+
     &.disabled {
         opacity: 0.5;
         pointer-events: none;
     }
 
-    > .pcui-container > .pcui-label,
-    > .pcui-container.info > span > .pcui-label {
+    > .back {
+        @extend .font-bold;
+
+        appearance: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        margin: 0 0 14px;
+        padding: 0;
+        border: none;
+        background: transparent;
+        color: $text-dark;
         font-size: 12px;
-        height: auto;
-        line-height: initial;
-        vertical-align: top;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: color 100ms;
 
-        &.field-label {
-            margin: 0 0 8px;
+        &::before {
+            content: '';
+            width: 14px;
+            height: 14px;
+            background-color: currentcolor;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7.3 3.3 2.6 8l4.7 4.7 1.1-1.1L6.2 8.8H14V7.2H6.2l2.4-2.6-1.1-1.1Z'/%3E%3C/svg%3E") center / contain no-repeat;
         }
 
-        &.error {
-            color: #fb222f;
-            float: right;
-        }
-
-        &.image-click {
-            margin: 3px;
+        &:hover,
+        &:focus {
+            color: $text-primary;
         }
     }
 
-    .pcui-text-input.input-field {
-        margin: 0;
-        height: 36px;
-        line-height: 34px;
-        width: 100%;
+    // card sections matching the build detail page
+    > .form-section {
+        margin: 0 0 12px;
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
+
+        &:not(.pcui-hidden) {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        > h3 {
+            @extend .font-bold;
+
+            margin: 0;
+            color: $text-primary;
+            font-size: 13px;
+            line-height: 18px;
+            text-transform: uppercase;
+        }
+
+        > .pcui-container {
+            margin: 0;
+            padding: 0;
+            border: none;
+        }
+    }
+
+    .pcui-label.field-label {
+        @extend .font-bold;
+
         display: block;
+        margin: 0 0 6px;
+        color: $text-secondary;
+        font-size: 12px;
+        line-height: 16px;
+    }
+
+    > .form-section .pcui-label.error {
+        position: absolute;
+        top: 0;
+        right: 0;
+        margin: 0;
+        color: #ff8a8a;
+        font-size: 12px;
+        line-height: 16px;
+    }
+
+    > .form-section > .info {
+        &:not(.pcui-hidden) {
+            display: flex;
+            align-items: flex-start;
+            gap: 14px;
+        }
+
+        > .image {
+            flex: 0 0 auto;
+            width: 72px;
+            height: 72px;
+            border: 1px solid $border-primary;
+            border-radius: 6px;
+            background-color: $bcg-darkest;
+            background-position: 50%;
+            background-size: cover;
+            box-sizing: border-box;
+            cursor: pointer;
+            transition: box-shadow 100ms;
+
+            &:hover {
+                box-shadow: $element-shadow-hover;
+            }
+
+            &.progress {
+                background-size: 40%;
+                background-repeat: no-repeat;
+                cursor: default;
+            }
+
+            &.blank {
+                background-size: 180%;
+            }
+        }
+
+        > span {
+            position: relative;
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+    }
+
+    .pcui-label.image-click {
+        margin: 6px 0 0;
+        color: $text-dark;
+        font-size: 12px;
+        line-height: 16px;
+    }
+
+    .pcui-container.description,
+    .pcui-container.version,
+    .pcui-container.notes {
+        position: relative;
+    }
+
+    .pcui-text-input.input-field {
+        display: block;
+        width: 100%;
+        height: 34px;
+        margin: 0;
+        border-color: $bcg-darkest;
+        border-radius: 4px;
+        line-height: 32px;
 
         > input {
             @extend .font-regular;
@@ -3915,387 +4036,349 @@ strong {
 
         &[placeholder] {
             &::after {
-                line-height: 34px;
+                line-height: 32px;
             }
         }
     }
 
-    > .description > .pcui-text-area-input,
-    > .notes > .pcui-text-area-input {
-        margin: 0; // Reset PCUI default 6px margin
+    .pcui-text-area-input {
         width: 100%;
+        margin: 0; // Reset PCUI default 6px margin
+        border: 1px solid $bcg-darkest;
+        border-radius: 4px;
         background-color: $bcg-dark;
-        border: 1px solid $bcg-darker;
-        border-radius: 0;
+        transition: background-color 100ms, box-shadow 100ms;
 
         > textarea {
-            display: block;
-            background-color: transparent;
-            color: $text-primary;
-            margin: 0;
-            padding: 10px;
-
             @extend .font-regular;
 
-            font-size: 14px;
+            display: block;
             width: calc(100% - 20px);
             height: 65px;
-
-            &.active,
-            &:hover,
-            &:focus,
-            &.focus {
-                background-color: $bcg-darkest;
-                outline: none;
-                border-color: transparent;
-                box-shadow: none;
-            }
+            margin: 0;
+            padding: 10px;
+            border: none;
+            background-color: transparent;
+            color: $text-primary;
+            font-size: 14px;
+            outline: none;
+            box-shadow: none;
         }
 
-        &:hover,
+        &:hover {
+            background-color: $bcg-darker;
+            box-shadow: $element-shadow-hover;
+        }
+
         &:focus-within {
             background-color: $bcg-darkest;
-            border-color: transparent;
+            box-shadow: $element-shadow-active;
         }
     }
 
     .pcui-select-input.engine-version-dropdown,
     .pcui-select-input.download-format-dropdown {
+        width: 100%;
+        max-width: 340px;
         margin: 0;
     }
 
-    .pcui-select-input.download-format-dropdown {
-        width: 100%;
-    }
+    .pcui-container.options > .pcui-container.field {
+        margin: 0 0 8px;
+        padding: 0;
+        border: none;
 
-    > .options > .pcui-container.field {
-        line-height: 24px;
+        &:not(.pcui-hidden) {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
 
         > .pcui-boolean-input {
-            margin: 4px 8px 0 0;
+            flex: 0 0 auto;
+            margin: 0;
         }
 
         > .pcui-label {
             margin: 0;
-            font-size: 12px;
-            line-height: 24px;
-            vertical-align: top;
+            color: $text-primary;
+            font-size: 13px;
+            line-height: 18px;
         }
     }
 
-    > .pcui-button {
-        margin: 3px 0 15px 15px; // Top margin needed for PCUI button hover shadow
-        padding: 0;
-        height: 34px;
-        line-height: 34px;
-        text-transform: uppercase;
-
-        @extend .font-bold;
-
-        &::before {
-            @extend .font-icon;
-
-            font-size: 14px;
-            color: $text-secondary;
-            vertical-align: top;
-            padding-right: 10px;
-        }
-
-        &:not(.disabled, .pcui-disabled):hover::before {
-            color: $text-active;
-        }
-
-        &.publish {
-            text-align: center;
-            width: calc(100% - 30px);
-
-            &::before {
-                content: '\E226';
-            }
-        }
-
-        &.web-download {
-            display: none;
-            width: 208px;
-
-            &::before {
-                content: '\E245';
-            }
-        }
-    }
-
-    > .pcui-container {
-        margin: 0;
-        padding: 15px;
-        border-bottom: 1px solid $border-primary;
-    }
-
-    > .pcui-container.info {
-        > .image {
-            display: inline-block;
-            width: 80px;
-            height: 80px;
-            border: 2px solid $border-primary;
-            margin-right: 15px;
-            vertical-align: top;
-            background-size: 100% 100%;
-
-            &.progress {
-                background-size: 40%;
-                background-position: 50%;
-                background-repeat: no-repeat;
-                background-color: $bcg-darkest;
-            }
-
-            &.blank {
-                background-size: 180%;
-            }
-
-            &:hover {
-                cursor: pointer;
-            }
-        }
-
-        > span {
-            display: inline-block;
-            width: calc(100% - 100px);
-
-            > .name {
-                margin-bottom: 8px;
-            }
-
-            > .pcui-label {
-                margin: 3px;
-            }
-        }
-    }
-
-    > .pcui-container.scenes {
-        border-bottom: none;
+    // sticky action bar pinned to the bottom of the scrolling panel
+    > .form-footer {
+        position: sticky;
+        bottom: 0;
+        z-index: 1;
+        margin: 0 -20px -24px;
+        padding: 12px 20px;
+        border-top: 1px solid $border-primary;
+        background-color: $bcg-primary;
 
         &:not(.pcui-hidden) {
-            display: block; // Override flex for float to work
+            display: flex;
+            flex-flow: row wrap;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 10px;
         }
 
-        > .pcui-label.field-label {
-            margin: 3px;
-        }
+        > .pcui-button {
+            @extend .font-bold;
 
-        > .pcui-boolean-input {
-            float: right;
-            margin: 2px 0 0;
-        }
-
-        > .pcui-label.select-all {
-            float: right;
-            padding-right: 10px;
-            margin: 3px;
-        }
-
-        > .pcui-progress {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 34px;
             margin: 0;
+            padding: 0 18px;
+            border: 1px solid transparent;
+            border-radius: 6px;
+            color: $text-primary;
+            background-color: $text-active;
+            font-size: 13px;
+            line-height: 32px;
+            box-shadow: none;
+            cursor: pointer;
+            transition: color 100ms, background-color 100ms, opacity 100ms, box-shadow 100ms;
+
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                color: $text-primary;
+                background-color: color.adjust($text-active, $lightness: -7%);
+                box-shadow: $element-shadow-hover;
+            }
+
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):active {
+                background-color: color.adjust($text-active, $lightness: -12%);
+                box-shadow: none;
+            }
+
+            &.disabled,
+            &.pcui-disabled {
+                opacity: $element-opacity-disabled;
+                cursor: default;
+            }
+
+            &.web-download {
+                display: none;
+            }
         }
+    }
 
-        > .pcui-label.error {
-            float: none;
-        }
+    > .scenes {
+        margin: 0 0 12px;
+        padding: 0;
+        border: none;
 
-        > .ui-list {
-            margin-top: 10px;
+        // header bar attached to the list (matches build history header)
+        > .scenes-header {
+            margin: 0;
+            padding: 14px 16px;
+            border: 1px solid $border-primary;
+            border-radius: 6px 6px 0 0;
+            background-color: rgb(0 0 0 / 8%);
+            box-sizing: border-box;
 
-            > .ui-list-item {
-                border-top: 1px solid $border-primary;
-                border-bottom: none;
-                padding-left: 0;
+            &:not(.pcui-hidden) {
+                display: flex;
+                flex-flow: row wrap;
+                align-items: center;
+                justify-content: space-between;
+                gap: 8px 16px;
+            }
 
-                &:last-child {
-                    border-bottom: 1px solid $border-primary;
+            > .pcui-label.field-label {
+                flex: 0 0 auto;
+                margin: 0;
+                color: $text-primary;
+                font-size: 13px;
+                line-height: 18px;
+                text-transform: uppercase;
+            }
+
+            > .select-all-group {
+                flex: 0 0 auto;
+                margin: 0 0 0 auto;
+
+                &:not(.pcui-hidden) {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
                 }
 
-                &:hover {
-                    background-color: transparent;
-                    cursor: default;
+                > .pcui-label {
+                    margin: 0;
+                    color: $text-dark;
+                    font-size: 12px;
+                    line-height: 16px;
+                }
 
-                    > .name {
-                        color: $text-primary;
+                > .pcui-boolean-input {
+                    margin: 0;
+                }
+            }
+        }
+
+        > .ui-list.scene-list {
+            margin: 0;
+            padding: 0;
+            min-height: 0;
+            border: 1px solid $border-primary;
+            border-top: none;
+            border-radius: 0 0 6px 6px;
+            background: transparent;
+            overflow: hidden;
+
+            > .ui-list-item {
+                @extend .font-regular;
+
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                height: auto;
+                padding: 11px 14px;
+                border-bottom: 1px solid $border-primary;
+                background: transparent;
+                line-height: 20px;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+
+                &.selected {
+                    background-color: transparent;
+                }
+
+                // empty legacy list-item text holder
+                > span:empty {
+                    display: none;
+                }
+
+                > .pcui-button.primary {
+                    @extend .font-icon;
+
+                    flex: 0 0 auto;
+                    width: 20px;
+                    height: 20px;
+                    margin: 0;
+                    padding: 0;
+                    border: none;
+                    background: transparent;
+                    color: $text-darkest;
+                    font-size: 16px;
+                    line-height: 20px;
+                    box-shadow: none;
+                    transition: color 100ms;
+
+                    &:not(.disabled):hover {
+                        color: $text-dark;
+                        cursor: pointer;
+                        box-shadow: none;
                     }
                 }
 
-                > .name {
-                    left: 30px;
+                &.primary > .pcui-button.primary {
+                    color: $text-active;
 
                     &:hover {
+                        color: $text-active;
                         cursor: default;
                     }
                 }
 
-                > .date {
-                    left: 30px;
+                > .pcui-label.name {
+                    flex: 0 1 auto;
+                    min-width: 0;
+                    margin: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    color: $text-primary;
+                    font-size: 14px;
+                    line-height: 20px;
+                }
+
+                &.current::after {
+                    @extend .font-bold;
+
+                    content: 'Current';
+                    flex: 0 0 auto;
+                    order: 1;
+                    height: 18px;
+                    padding: 0 6px;
+                    border: 1px solid rgb(255 122 35 / 50%);
+                    border-radius: 4px;
+                    color: $text-active;
+                    background-color: rgb(0 0 0 / 14%);
+                    font-size: 11px;
+                    line-height: 18px;
+                    text-transform: uppercase;
+                    box-sizing: border-box;
+                }
+
+                > .pcui-label.date {
+                    flex: 0 0 auto;
+                    order: 2;
+                    margin: 0 0 0 auto;
+                    color: $text-dark;
+                    font-size: 12px;
+                    line-height: 20px;
                 }
 
                 > .pcui-boolean-input {
-                    position: absolute;
-                    top: 25px;
-                    right: 0;
+                    flex: 0 0 auto;
+                    order: 3;
                     margin: 0;
-                }
-
-                > .pcui-button.primary {
-                    margin: 3px 3px 3px 0;
-
-                    &:hover {
-                        box-shadow: none;
-                    }
-                }
-
-                > .pcui-label.name,
-                > .pcui-label.date {
-                    margin: 3px;
                 }
             }
         }
     }
 
-    &.download-mode {
-        .pcui-container {
-            &.description,
-            &.version {
-                display: none;
-            }
+    > .scenes-empty {
+        margin: 0 0 12px;
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        color: $text-dark;
+        background-color: rgb(0 0 0 / 8%);
+        box-sizing: border-box;
 
-            &.info {
-                > .image {
-                    display: none;
-                }
-
-                > span {
-                    width: 100%;
-
-                    > .image-click {
-                        display: none;
-                    }
-                }
-            }
+        > .pcui-label {
+            margin: 0;
+            color: inherit;
+            font-size: 13px;
+            line-height: 18px;
         }
 
-        .pcui-button.publish,
-        .pcui-container.notes {
+        > .pcui-label.error {
+            color: #ff8a8a;
+        }
+
+        > .pcui-progress {
+            width: 100%;
+            margin: 10px 0 0;
+        }
+    }
+
+    &.download-mode {
+        > .form-section > .pcui-container.description,
+        > .form-section > .pcui-container.version,
+        > .form-section > .pcui-container.notes,
+        > .form-section > .info > .image,
+        > .form-section > .info .pcui-label.image-click,
+        > .form-footer > .pcui-button.publish {
             display: none;
         }
 
-        .pcui-button.web-download {
-            display: inline-block;
-        }
-
-        .progress {
-            border-top: 1px solid $border-primary;
-            padding: 15px;
-
-            > .icon {
-                background-color: $bcg-darkest;
-                width: 74px;
-                height: 74px;
-                display: inline-block;
-                text-align: center;
-
-                > img {
-                    width: 30px;
-                    height: 30px;
-                    padding-top: 20px;
-                }
-
-                &.success,
-                &.error {
-                    > img {
-                        display: none;
-                    }
-                }
-
-                &.success {
-                    &::after {
-                        @extend .font-icon;
-
-                        font-size: 34px;
-                        display: block;
-                        margin-top: 15px;
-                        color: $text-secondary;
-                        content: '\E245';
-                    }
-                }
-
-                &.error {
-                    background-color: #e74c3c;
-
-                    &::after {
-                        @extend .font-icon;
-
-                        font-size: 34px;
-                        display: block;
-                        margin-top: 15px;
-                        color: $bcg-darkest;
-                        content: '\E132';
-                    }
-                }
-            }
-
-            > .progress-info {
-                display: inline-block;
-                position: relative;
-                vertical-align: top;
-                margin-left: 2px;
-                background-color: $bcg-darkest;
-                height: 64px;
-                line-height: 64px;
-                padding: 5px;
-                width: calc(100% - 86px);
-                overflow: auto;
-
-                > .pcui-label.progress-title {
-                    margin: 3px;
-                    line-height: 22px;
-                    height: 22px;
-                    color: $text-primary;
-                    font-size: 14px;
-                    vertical-align: middle;
-
-                    &.error {
-                        position: static;
-                        padding: 0;
-                    }
-                }
-
-                > .pcui-button.ready {
-                    position: absolute;
-                    top: 15px;
-                    right: 15px;
-                    margin: 3px;
-                    background-color: color.adjust($text-active, $alpha: -0.1);
-                    width: 122px;
-                    height: 34px;
-                    font-size: 12px;
-                    line-height: 32px;
-                    padding: 0;
-                    text-align: center;
-                    color: $text-primary;
-                    text-transform: uppercase;
-
-                    @extend .font-bold;
-
-                    &::before {
-                        @extend .font-icon;
-
-                        font-size: 16px;
-                        vertical-align: top;
-                        padding-right: 10px;
-                        content: '\E245';
-                    }
-
-                    &:hover {
-                        background-color: $text-active;
-                        box-shadow: none;
-                    }
-                }
-            }
+        > .form-footer > .pcui-button.web-download {
+            display: inline-flex;
         }
     }
 }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -1519,8 +1519,17 @@ strong {
                                     height: 25px;
                                 }
 
+                                &:hover,
+                                &:focus {
+                                    color: $text-primary;
+                                    background-color: $bcg-dark;
+                                    box-shadow: $element-shadow-hover;
+                                }
+
                                 &.clicked {
+                                    color: $text-primary;
                                     background-color: $bcg-darkest;
+                                    box-shadow: $element-shadow-active;
                                 }
                             }
                         }
@@ -3690,11 +3699,16 @@ strong {
                 color: $bcg-darkest;
                 background-color: $text-darkest;
 
-                &:hover,
-                &.clicked {
+                &:hover {
                     color: $text-primary;
                     background-color: $bcg-darkest;
                     box-shadow: none;
+                }
+
+                &.clicked {
+                    color: $text-primary;
+                    background-color: $bcg-darkest;
+                    box-shadow: $element-shadow-active;
                 }
             }
 
@@ -3804,7 +3818,7 @@ strong {
         font-size: 13px;
 
         &:hover {
-            background-color: #354144;
+            background-color: $bcg-dark;
         }
 
         > .pcui-label {
@@ -3842,7 +3856,7 @@ strong {
         font-size: 13px;
 
         &:hover {
-            background-color: #354144;
+            background-color: $bcg-dark;
         }
 
         > .pcui-label {
@@ -4360,39 +4374,42 @@ strong {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            height: 32px;
+            height: 34px;
             margin: 0;
-            padding: 0 16px;
+            padding: 0 18px;
+            border: 1px solid $bcg-darkest;
             border-radius: 6px;
+            color: $text-secondary;
+            background-color: $bcg-dark;
             font-size: 13px;
             box-shadow: none;
             cursor: pointer;
+            transition: color 100ms, background-color 100ms, opacity 100ms, box-shadow 100ms;
 
-            &.download {
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
                 color: $text-primary;
-                background-color: transparent;
-                border: 1px solid $border-primary;
-
-                &:not(.disabled):hover {
-                    background-color: $bcg-darkest;
-                    border-color: $text-dark;
-                }
+                background-color: $bcg-dark;
+                box-shadow: $element-shadow-hover;
             }
 
-            &.publish {
-                color: $text-primary;
-                background-color: $text-active;
-                border: 1px solid $text-active;
-
-                &:not(.disabled):hover {
-                    filter: brightness(1.08);
-                }
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):active {
+                background-color: $bcg-darkest;
+                box-shadow: none;
             }
 
-            &.disabled {
-                opacity: 0.5;
-                cursor: not-allowed;
+            &.disabled,
+            &.pcui-disabled {
+                opacity: $element-opacity-disabled;
+                cursor: default;
             }
+        }
+
+        > .builds-toolbar > .pcui-button > .pcui-label {
+            margin: 0;
+            color: inherit;
+            font-size: inherit;
+            line-height: 32px;
         }
     }
 
@@ -4442,6 +4459,7 @@ strong {
             line-height: 26px;
             box-shadow: none;
             cursor: pointer;
+            transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
             &::after {
                 content: '';
@@ -4450,15 +4468,40 @@ strong {
                 margin-left: 6px;
                 background-color: currentcolor;
                 mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 6h8l-4 4-4-4Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                transition: transform 100ms;
             }
 
             &:hover,
-            &.active,
+            &:focus {
+                color: $text-primary;
+                background-color: $bcg-dark;
+                border-color: $bcg-darkest;
+                box-shadow: $element-shadow-hover;
+            }
+
             &.selected {
+                color: $text-primary;
+                background-color: $bcg-dark;
+                border-color: $bcg-darkest;
+            }
+
+            &.active {
                 color: $text-primary;
                 background-color: $bcg-darkest;
                 border-color: $border-primary;
+                box-shadow: $element-shadow-active;
             }
+
+            &.active::after {
+                transform: rotate(180deg);
+            }
+        }
+
+        > .builds-filter-bar > .build-filter-button > .pcui-label {
+            margin: 0;
+            color: inherit;
+            font-size: inherit;
+            line-height: 26px;
         }
     }
 
@@ -4628,7 +4671,9 @@ strong {
                 }
 
                 > .url {
+                    align-self: flex-start;
                     display: inline-block;
+                    width: fit-content;
                     max-width: 100%;
                     color: #9dd4ff;
                     font-size: 13px;
@@ -4651,8 +4696,12 @@ strong {
                 justify-content: center;
                 width: 28px;
                 height: 28px;
+                border: 1px solid transparent;
                 border-radius: 4px;
                 color: $text-dark;
+                box-shadow: none;
+                box-sizing: border-box;
+                transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
                 &::before {
                     content: '';
@@ -4662,9 +4711,18 @@ strong {
                     mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.06-1.06l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z'/%3E%3C/svg%3E") center / contain no-repeat;
                 }
 
-                &:hover {
+                &:hover,
+                &:focus {
                     color: $text-primary;
+                    background-color: $bcg-dark;
+                    border-color: $bcg-darkest;
+                    box-shadow: $element-shadow-hover;
+                }
+
+                &:active {
                     background-color: $bcg-darkest;
+                    border-color: $border-primary;
+                    box-shadow: none;
                 }
             }
         }
@@ -4680,9 +4738,23 @@ strong {
         background: transparent;
 
         // shared row columns: status | name | branch | artifact | date | kebab
-        display: grid;
         grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) 32px max-content max-content;
         column-gap: 14px;
+
+        &:not(.pcui-hidden) {
+            display: grid;
+        }
+
+        > .no-filtered-builds-label {
+            @extend .font-regular;
+
+            grid-column: 1 / -1;
+            width: 100%;
+            padding: 14px 16px;
+            color: $text-dark;
+            background-color: rgb(0 0 0 / 8%);
+            box-sizing: border-box;
+        }
 
         > .build-item {
             @extend .font-regular;
@@ -4760,6 +4832,9 @@ strong {
                     border-radius: 4px;
                     background: transparent;
                     color: $text-dark;
+                    box-shadow: none;
+                    cursor: pointer;
+                    transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
                     &::before {
                         content: '';
@@ -4782,10 +4857,18 @@ strong {
                         pointer-events: none;
                     }
 
-                    &:not(.placeholder):hover {
+                    &:not(.placeholder):hover,
+                    &:not(.placeholder):focus {
                         color: $text-primary;
+                        background-color: $bcg-dark;
+                        border-color: $bcg-darkest;
+                        box-shadow: $element-shadow-hover;
+                    }
+
+                    &:not(.placeholder):active {
                         background-color: $bcg-darkest;
                         border-color: $border-primary;
+                        box-shadow: none;
                     }
                 }
 
@@ -4841,7 +4924,9 @@ strong {
                     border-radius: 4px;
                     background: transparent;
                     color: $text-dark;
+                    box-shadow: none;
                     cursor: pointer;
+                    transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
                     &::before {
                         content: '';
@@ -4852,10 +4937,24 @@ strong {
                     }
 
                     &:hover,
+                    &:focus {
+                        color: $text-primary;
+                        background-color: $bcg-dark;
+                        border-color: $bcg-darkest;
+                        box-shadow: $element-shadow-hover;
+                    }
+
+                    &:active {
+                        background-color: $bcg-darkest;
+                        border-color: $border-primary;
+                        box-shadow: none;
+                    }
+
                     &.active {
                         color: $text-primary;
                         background-color: $bcg-darkest;
                         border-color: $border-primary;
+                        box-shadow: $element-shadow-active;
                     }
                 }
             }
@@ -4884,6 +4983,7 @@ strong {
         font-size: 12px;
         text-transform: uppercase;
         cursor: pointer;
+        transition: color 100ms;
 
         &::before {
             content: '';
@@ -4893,7 +4993,8 @@ strong {
             mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7.3 3.3 2.6 8l4.7 4.7 1.1-1.1L6.2 8.8H14V7.2H6.2l2.4-2.6-1.1-1.1Z'/%3E%3C/svg%3E") center / contain no-repeat;
         }
 
-        &:hover {
+        &:hover,
+        &:focus {
             color: $text-primary;
         }
     }
@@ -5096,31 +5197,68 @@ strong {
                 margin: 0;
                 height: 32px;
                 padding: 0 14px;
-                border: 1px solid $border-primary;
+                border: 1px solid $bcg-darkest;
                 border-radius: 4px;
-                color: $text-primary;
-                background-color: rgb(0 0 0 / 12%);
+                color: $text-secondary;
+                background-color: $bcg-dark;
                 box-shadow: none;
                 font-size: 14px;
                 line-height: 30px;
                 text-decoration: none;
+                cursor: pointer;
+                transition: color 100ms, background-color 100ms, border-color 100ms, opacity 100ms, box-shadow 100ms;
             }
 
             > .pcui-button > .pcui-label {
                 margin: 0;
+                color: inherit;
                 font-size: 14px;
                 line-height: 30px;
             }
 
-            > .detail-button:hover {
-                color: $text-active;
+            > .pcui-button:not(.pcui-disabled, .pcui-readonly):hover,
+            > .pcui-button:not(.pcui-disabled, .pcui-readonly):focus,
+            > .detail-button:hover,
+            > .detail-button:focus {
+                color: $text-primary;
+                background-color: $bcg-dark;
+                border-color: $bcg-darkest;
+                box-shadow: $element-shadow-hover;
+            }
+
+            > .pcui-button:not(.pcui-disabled, .pcui-readonly):active,
+            > .detail-button:active {
                 background-color: $bcg-darkest;
+                border-color: $border-primary;
+                box-shadow: none;
             }
 
             > .pcui-button.delete {
                 color: #ff8a8a;
                 background-color: transparent;
                 border-color: rgb(168 61 61 / 65%);
+            }
+
+            > .pcui-button.delete:not(.pcui-disabled, .pcui-readonly):hover,
+            > .pcui-button.delete:not(.pcui-disabled, .pcui-readonly):focus {
+                color: #ffb3b3;
+                background-color: $bcg-dark;
+                border-color: rgb(168 61 61 / 85%);
+            }
+
+            > .pcui-button.delete:not(.pcui-disabled, .pcui-readonly):active {
+                background-color: $bcg-darkest;
+                box-shadow: none;
+            }
+
+            > .pcui-button.pcui-disabled {
+                opacity: $element-opacity-disabled;
+                cursor: default;
+            }
+
+            > .pcui-button.pcui-readonly {
+                opacity: $element-opacity-readonly;
+                cursor: default;
             }
         }
     }
@@ -5237,17 +5375,28 @@ strong {
             justify-content: center;
             height: 28px;
             padding: 0 12px;
-            border: 1px solid $border-primary;
+            border: 1px solid $bcg-darkest;
             border-radius: 4px;
-            color: $text-primary;
-            background-color: rgb(0 0 0 / 12%);
+            color: $text-secondary;
+            background-color: $bcg-dark;
+            box-shadow: none;
             font-size: 13px;
             line-height: 26px;
             text-decoration: none;
+            transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
-            &:hover {
-                color: $text-active;
+            &:hover,
+            &:focus {
+                color: $text-primary;
+                background-color: $bcg-dark;
+                border-color: $bcg-darkest;
+                box-shadow: $element-shadow-hover;
+            }
+
+            &:active {
                 background-color: $bcg-darkest;
+                border-color: $border-primary;
+                box-shadow: none;
             }
         }
     }
@@ -6037,11 +6186,16 @@ strong {
                     background-color: $text-darkest;
 
                     &:hover,
-                    &:focus,
-                    &.clicked {
+                    &:focus {
                         color: $text-primary;
                         background-color: $bcg-darkest;
                         box-shadow: none;
+                    }
+
+                    &.clicked {
+                        color: $text-primary;
+                        background-color: $bcg-darkest;
+                        box-shadow: $element-shadow-active;
                     }
                 }
             }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4353,6 +4353,129 @@ strong {
         }
     }
 
+    // shared build-status indicator (list rows + detail header)
+    .status {
+        flex: 0 0 24px;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        border: 1px solid $border-primary;
+        color: $text-dark;
+        background-color: $bcg-darkest;
+        box-sizing: border-box;
+        position: relative;
+
+        &.complete {
+            color: #6fd088;
+            border-color: #3e8c54;
+            background-color: rgb(46 160 67 / 12%);
+
+            &::before {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 9px;
+                height: 5px;
+                border-bottom: 2px solid currentcolor;
+                border-left: 2px solid currentcolor;
+                box-sizing: border-box;
+                transform: translate(-50%, -60%) rotate(-45deg);
+            }
+        }
+
+        &.error {
+            color: #ff8a8a;
+            border-color: #a83d3d;
+            background-color: rgb(231 76 60 / 12%);
+
+            &::before,
+            &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 11px;
+                height: 2px;
+                background-color: currentcolor;
+            }
+
+            &::before { transform: translate(-50%, -50%) rotate(45deg); }
+            &::after { transform: translate(-50%, -50%) rotate(-45deg); }
+        }
+
+        &.running {
+            border-color: $text-dark;
+            background-color: transparent;
+
+            &::after {
+                content: '';
+                width: 12px;
+                height: 12px;
+                border: 2px solid $text-dark;
+                border-top-color: $text-active;
+                border-radius: 50%;
+                animation: build-status-spin 800ms linear infinite;
+            }
+        }
+    }
+
+    // shared badge pills (list rows + detail header)
+    .badge {
+        flex: 0 0 auto;
+        height: 18px;
+        line-height: 18px;
+        padding: 0 6px;
+        border: 1px solid $border-primary;
+        border-radius: 4px;
+        color: $text-dark;
+        background-color: rgb(0 0 0 / 14%);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+
+        &.publish {
+            color: #9dd4ff;
+            border-color: rgb(110 170 220 / 45%);
+        }
+
+        &.download {
+            color: #f3c16f;
+            border-color: rgb(225 166 62 / 45%);
+        }
+
+        &.primary-badge {
+            color: $text-active;
+            border-color: rgb(255 122 35 / 50%);
+        }
+    }
+
+    // shared name + badges row (list rows + detail header)
+    .name-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        line-height: 20px;
+
+        > .name {
+            @extend .font-bold;
+
+            min-width: 0;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-size: 14px;
+            color: $text-primary;
+            margin: 0;
+        }
+    }
+
     > ul {
         margin: 0;
         padding: 0;
@@ -4384,212 +4507,115 @@ strong {
                 cursor: pointer;
             }
 
+            // list is non-selectable; clicking to expand adds .selected, so neutralize the leaked theme background
+            &.selected:not(:hover) {
+                background-color: transparent;
+            }
+
             > .build-row {
                 display: flex;
                 align-items: center;
                 gap: 14px;
                 min-height: 72px;
                 padding: 12px 14px;
-            }
 
-            > .build-row > .status {
-                flex: 0 0 24px;
-                width: 24px;
-                height: 24px;
-                border-radius: 50%;
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                font-size: 14px;
-                border: 1px solid $border-primary;
-                color: $text-dark;
-                background-color: $bcg-darkest;
-                box-sizing: border-box;
-                position: relative;
-            }
-
-            &.complete > .build-row > .status {
-                color: #6fd088;
-                border-color: #3e8c54;
-                background-color: rgb(46 160 67 / 12%);
-
-                &::before {
-                    content: '';
-                    position: absolute;
-                    top: 50%;
-                    left: 50%;
-                    width: 9px;
-                    height: 5px;
-                    border-bottom: 2px solid currentcolor;
-                    border-left: 2px solid currentcolor;
-                    box-sizing: border-box;
-                    transform: translate(-50%, -60%) rotate(-45deg);
-                }
-            }
-
-            &.error > .build-row > .status {
-                color: #ff8a8a;
-                border-color: #a83d3d;
-                background-color: rgb(231 76 60 / 12%);
-
-                &::before {
-                    content: '';
-                    position: absolute;
-                    top: 50%;
-                    left: 50%;
-                    width: 11px;
-                    height: 2px;
-                    background-color: currentcolor;
-                    transform: translate(-50%, -50%) rotate(45deg);
-                }
-
-                &::after {
-                    content: '';
-                    position: absolute;
-                    top: 50%;
-                    left: 50%;
-                    width: 11px;
-                    height: 2px;
-                    background-color: currentcolor;
-                    transform: translate(-50%, -50%) rotate(-45deg);
-                }
-            }
-
-            &.running > .build-row > .status {
-                border-color: $text-dark;
-                background-color: transparent;
-
-                &::after {
-                    content: '';
-                    width: 12px;
-                    height: 12px;
-                    border: 2px solid $text-dark;
-                    border-top-color: $text-active;
-                    border-radius: 50%;
-                    animation: build-status-spin 800ms linear infinite;
-                }
-            }
-
-            > .build-row > .body {
-                min-width: 0;
-                flex: 1 1 auto;
-            }
-
-            > .build-row > .body > .name-row {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                min-width: 0;
-                line-height: 20px;
-
-                > .name {
-                    @extend .font-bold;
-
+                > .body {
                     min-width: 0;
-                    max-width: 100%;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                    font-size: 14px;
-                    color: $text-primary;
-                    margin: 0;
+                    flex: 1 1 0;
+
+                    > .sub {
+                        margin-top: 4px;
+                        color: $text-dark;
+                        font-size: 12px;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
                 }
 
-                > .badge {
-                    flex: 0 0 auto;
-                    height: 18px;
-                    line-height: 18px;
-                    padding: 0 6px;
-                    border: 1px solid $border-primary;
-                    border-radius: 4px;
+                > .branch {
+                    flex: 1 1 0;
+                    min-width: 0;
+                    display: flex;
+                    justify-content: flex-start;
+
+                    > .branch-name {
+                        max-width: 100%;
+                        padding: 2px 10px;
+                        border: 1px solid $border-primary;
+                        border-radius: 10px;
+                        color: $text-primary;
+                        background-color: rgb(0 0 0 / 14%);
+                        font-size: 12px;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+                }
+
+                > .right-meta {
+                    flex: 1 1 0;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-end;
+                    gap: 2px;
                     color: $text-dark;
-                    background-color: rgb(0 0 0 / 14%);
-                    font-size: 11px;
-                    text-transform: uppercase;
-                    letter-spacing: 0;
+                    font-size: 12px;
 
-                    &.publish {
-                        color: #9dd4ff;
-                        border-color: rgb(110 170 220 / 45%);
-                    }
-
-                    &.download {
-                        color: #f3c16f;
-                        border-color: rgb(225 166 62 / 45%);
-                    }
-
-                    &.primary-badge {
-                        color: $text-active;
-                        border-color: rgb(255 122 35 / 50%);
-                    }
-                }
-            }
-
-            > .build-row > .body > .meta {
-                display: flex;
-                flex-wrap: wrap;
-                gap: 4px 12px;
-                min-width: 0;
-                margin-top: 5px;
-                color: $text-dark;
-                font-size: 12px;
-
-                > .meta-item {
-                    min-width: 0;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-
-                    &.state {
+                    > .date {
                         color: $text-primary;
                     }
                 }
             }
+        }
+    }
 
-            > .build-row > .actions {
+    > .build-detail {
+        padding: 0;
+
+        > .back {
+            appearance: none;
+            align-self: flex-start;
+            margin: 4px 0 16px;
+            padding: 4px 0;
+            border: none;
+            background: transparent;
+            color: $text-dark;
+            font-size: 13px;
+            cursor: pointer;
+
+            &:hover {
+                color: $text-primary;
+            }
+        }
+
+        > .detail-header {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            padding-bottom: 14px;
+            border-bottom: 1px solid $border-primary;
+
+            > .heading {
+                min-width: 0;
+                flex: 1 1 auto;
+
+                > .sub {
+                    margin-top: 4px;
+                    color: $text-dark;
+                    font-size: 12px;
+                }
+            }
+
+            > .detail-actions {
                 display: flex;
                 align-items: center;
-                justify-content: flex-end;
-                gap: 6px;
+                gap: 8px;
                 flex: 0 0 auto;
 
-                > .pcui-button,
-                > .action-button {
-                    appearance: none;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    width: 28px;
-                    height: 28px;
-                    line-height: 1;
+                > .pcui-button {
                     margin: 0;
-                    padding: 0;
-                    border: 1px solid $border-primary;
-                    border-radius: 4px;
-                    color: $text-dark;
-                    background-color: rgb(0 0 0 / 12%);
-                    text-align: center;
-                    box-sizing: border-box;
-                }
-
-                > .pcui-button.primary {
-                    @extend .font-icon;
-
-                    color: $text-darkest;
-                }
-
-                > .action-button.dropdown,
-                > .action-button.expander {
-                    @extend .font-icon;
-                }
-
-                > .pcui-button.primary:not(.disabled):hover,
-                > .action-button.dropdown:hover,
-                > .action-button.expander:hover,
-                > .action-button.clicked {
-                    color: $text-primary;
-                    background-color: $bcg-darkest;
-                    cursor: pointer;
+                    height: 28px;
                 }
 
                 > .artifact {
@@ -4597,7 +4623,7 @@ strong {
 
                     height: 28px;
                     line-height: 28px;
-                    padding: 0 10px;
+                    padding: 0 12px;
                     border: 1px solid $border-primary;
                     border-radius: 4px;
                     color: $text-primary;
@@ -4610,39 +4636,37 @@ strong {
                     }
                 }
             }
+        }
 
-            > .error {
-                color: #e74c3c;
-                margin: -8px 14px 12px 52px;
-                white-space: normal;
-                word-wrap: break-word;
-                font-size: 12px;
-            }
+        > .error {
+            margin: 14px 0 0;
+            color: #e74c3c;
+            font-size: 12px;
+            white-space: normal;
+            word-wrap: break-word;
+        }
 
-            > .details {
-                margin: -2px 14px 12px 52px;
-                padding: 10px 0 2px;
-                border-top: 1px solid rgb(255 255 255 / 6%);
-                color: $text-primary;
+        > .details {
+            margin: 14px 0 0;
+            color: $text-primary;
 
-                > .detail-row {
-                    display: flex;
-                    gap: 8px;
-                    padding-top: 4px;
+            > .detail-row {
+                display: flex;
+                gap: 8px;
+                padding-top: 8px;
+                min-width: 0;
+
+                > .key {
+                    color: $text-dark;
+                    flex: 0 0 120px;
+                }
+
+                > .value {
                     min-width: 0;
+                    overflow-wrap: anywhere;
 
-                    > .key {
-                        color: $text-dark;
-                        flex: 0 0 72px;
-                    }
-
-                    > .value {
-                        min-width: 0;
-                        overflow-wrap: anywhere;
-
-                        > a {
-                            color: $text-active;
-                        }
+                    > a {
+                        color: $text-active;
                     }
                 }
             }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4156,6 +4156,11 @@ strong {
             cursor: pointer;
             transition: color 100ms, background-color 100ms, opacity 100ms, box-shadow 100ms;
 
+            &[data-icon]::before {
+                font-size: 14px;
+                line-height: 1;
+            }
+
             &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
             &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
                 color: $text-primary;
@@ -4476,6 +4481,11 @@ strong {
             box-shadow: none;
             cursor: pointer;
             transition: color 100ms, background-color 100ms, opacity 100ms, box-shadow 100ms;
+
+            &[data-icon]::before {
+                font-size: 14px;
+                line-height: 1;
+            }
 
             &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
             &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {

--- a/src/editor-api/models.ts
+++ b/src/editor-api/models.ts
@@ -453,3 +453,54 @@ export type Job<T extends object> = {
      */
     data: T;
 };
+
+export type BuildJobFormat = 'playcanvas' | 'static' | 'npm' | 'web_lens';
+
+export type BuildJob = {
+    id: number;
+    project_id: number;
+    app_id: number | null;
+    job_id: number | null;
+    type: 'publish' | 'download';
+    status: 'complete' | 'running' | 'error';
+    attempt: number;
+    branch: {
+        id: string;
+        name: string;
+    };
+    actor: {
+        id: number;
+        username: string;
+        name: string;
+    };
+    source: {
+        type: 'editor' | 'api';
+    };
+    settings: {
+        name: string;
+        description?: string;
+        version?: string;
+        release_notes?: string;
+        image_s3_key?: string;
+        scenes: {
+            id: number;
+            name: string;
+        }[];
+        scripts_concatenate: boolean;
+        scripts_minify: boolean;
+        scripts_sourcemaps: boolean;
+        optimize_scene_format: boolean;
+        engine_version?: string;
+        format: BuildJobFormat;
+    };
+    artifacts: {
+        type: 'app' | 'download';
+        url: string;
+        bytes: number | null;
+    }[];
+    message: string | null;
+    created_at: string;
+    modified_at: string;
+    completed_at: string | null;
+    duration_ms: number | null;
+};

--- a/src/editor-api/rest/projects.ts
+++ b/src/editor-api/rest/projects.ts
@@ -486,17 +486,31 @@ export const projectApps = (limit = 0, skip = 0) => {
     });
 };
 
+export type BuildJobFilters = {
+    type?: string;
+    status?: string;
+    format?: string;
+    branch?: string;
+    actor?: string;
+};
+
 /**
  * Fetches a list of durable build jobs for the current project
  *
  * @param limit - The maximum number of build jobs to return
  * @param skip - The number of build jobs to skip
+ * @param filters - Optional server-side filters (type, status, format, branch name, actor id)
  * @returns A request that responds with the list of build jobs
  */
-export const projectBuilds = (limit = 0, skip = 0) => {
+export const projectBuilds = (limit = 0, skip = 0, filters: BuildJobFilters = {}) => {
     const params = [];
     params.push(`limit=${limit}`);
     params.push(`skip=${skip}`);
+    Object.entries(filters).forEach(([key, value]) => {
+        if (value) {
+            params.push(`${key}=${encodeURIComponent(value)}`);
+        }
+    });
 
     return Ajax.get<{
         result: BuildJob[];

--- a/src/editor-api/rest/projects.ts
+++ b/src/editor-api/rest/projects.ts
@@ -1,5 +1,6 @@
 import { Ajax } from '../ajax';
 import { globals as api } from '../globals';
+import type { BuildJob } from '../models';
 
 type ProjectRequestArgs = {
     /**
@@ -481,6 +482,44 @@ export const projectApps = (limit = 0, skip = 0) => {
 
     return Ajax.get({
         url: `${api.apiUrl}/projects/${api.projectId}/apps?${params.join('&')}`,
+        auth: true
+    });
+};
+
+/**
+ * Fetches a list of durable build jobs for the current project
+ *
+ * @param limit - The maximum number of build jobs to return
+ * @param skip - The number of build jobs to skip
+ * @returns A request that responds with the list of build jobs
+ */
+export const projectBuilds = (limit = 0, skip = 0) => {
+    const params = [];
+    params.push(`limit=${limit}`);
+    params.push(`skip=${skip}`);
+
+    return Ajax.get<{
+        result: BuildJob[];
+        pagination: {
+            skip: number;
+            limit: number;
+            total: number;
+        };
+    }>({
+        url: `${api.apiUrl}/projects/${api.projectId}/builds?${params.join('&')}`,
+        auth: true
+    });
+};
+
+/**
+ * Deletes a durable build and its linked artifact
+ *
+ * @param buildJobId - The durable build job ID
+ * @returns A request that responds with the deleted build job
+ */
+export const projectBuildDelete = (buildJobId: number) => {
+    return Ajax.delete<BuildJob>({
+        url: `${api.apiUrl}/projects/${api.projectId}/builds/${buildJobId}`,
         auth: true
     });
 };

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -234,7 +234,7 @@ editor.once('load', () => {
     clearFilters.textContent = 'Clear filters';
     clearFilters.addEventListener('click', () => {
         resetBuildFilters();
-        refreshFilterVisibility();
+        loadApps();
     });
     noMatchingBuilds.dom.appendChild(clearFilters);
 
@@ -252,7 +252,28 @@ editor.once('load', () => {
     let skip = 0;
     let hasMore = true;
     let loadingMore = false;
+    let loadGen = 0;  // invalidates in-flight responses when filters change
     let scrollContainer: HTMLElement | null = null;
+
+    // values the backend can filter on; anything else stays client-side only
+    const SERVER_FILTER_GUARDS: Record<string, (value: string) => boolean> = {
+        type: value => FILTER_ORDER.type.includes(value),
+        format: value => FORMAT_FILTERS.some(option => option.value === value),
+        status: value => STATUS_FILTERS.some(option => option.value === value),
+        branch: value => value.length > 0,
+        actor: value => /^\d+$/.test(value)
+    };
+
+    const getServerFilters = function () {
+        const result: Record<string, string> = {};
+        BUILD_FILTERS.forEach((filter) => {
+            const value = filters[filter.key];
+            if (value !== FILTER_ALL && SERVER_FILTER_GUARDS[filter.key]?.(value)) {
+                result[filter.key] = value;
+            }
+        });
+        return result;
+    };
 
     const loadMoreBuilds = function () {
         if (loadingMore || !hasMore || panel.hidden || detailApp) {
@@ -260,8 +281,12 @@ editor.once('load', () => {
         }
         loadingMore = true;
         skip += APP_LIMIT;
-        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip).on('load', (status, data) => {
+        const gen = loadGen;
+        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip, getServerFilters()).on('load', (status, data) => {
             loadingMore = false;
+            if (gen !== loadGen) {
+                return;
+            }
             const results = data.result.map(normalizeBuildJob);
             const ids = getPublishAppIds(results);
             if (ids.size) {
@@ -574,8 +599,11 @@ editor.once('load', () => {
         return getFormatValue(app);
     };
 
+    // accumulated across loads so an active server-side filter doesn't shrink its own menu
+    let knownFilterLabels: Record<string, Record<string, string>> = {};
+
     const getFilterOptions = function (key: string) {
-        const labels: Record<string, string> = {};
+        const labels = knownFilterLabels[key] || (knownFilterLabels[key] = {});
         if (key === 'format') {
             FORMAT_FILTERS.forEach((option) => {
                 if (!option.superUser || config.self.flags.superUser) {
@@ -654,7 +682,7 @@ editor.once('load', () => {
         filters[key] = value;
         updateFilterButtons();
         hideFilterMenus();
-        refreshFilterVisibility();
+        loadApps();
     };
 
     const resetBuildFilters = function () {
@@ -1353,13 +1381,17 @@ editor.once('load', () => {
         skip = 0;
         hasMore = true;
         loadingMore = false;
+        const gen = ++loadGen;
 
         if (showProgress) {
             toggleProgress(true);
         }
 
         loadAppIndex(() => {
-            editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, 0).on('load', (status, data) => {
+            editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, 0, getServerFilters()).on('load', (status, data) => {
+                if (gen !== loadGen) {
+                    return;
+                }
                 const rows = data.result.map(normalizeBuildJob);
                 const ids = getPublishAppIds(rows);
                 const legacy = appList
@@ -1512,7 +1544,9 @@ editor.once('load', () => {
     };
 
     const renderPrimaryBuild = function () {
-        const app = apps.find(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
+        // filtering means browsing history; the primary summary only shows on the unfiltered view
+        const app = hasActiveFilters() ? null :
+            apps.find(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
         primaryBuildHeading.hidden = !app;
         primaryBuild.hidden = !app;
 
@@ -1574,7 +1608,9 @@ editor.once('load', () => {
     };
 
     const resetBuildsState = function () {
+        loadGen++;
         resetBuildFilters();
+        knownFilterLabels = {};
         apps = [];
         appIndex = {};
         appList = [];
@@ -1607,9 +1643,12 @@ editor.once('load', () => {
             }
         });
 
-        container.hidden = apps.length === 0;
-        noBuilds.hidden = apps.length > 0;
-        noMatchingBuilds.hidden = apps.length === 0 || filteredApps.length > 0 || !hasActiveFilters();
+        // with server-side filtering, zero rows under an active filter means "no
+        // matches", not "no builds"; the list box stays visible to host that message
+        const filtering = hasActiveFilters();
+        container.hidden = apps.length === 0 && !filtering;
+        noBuilds.hidden = apps.length > 0 || filtering;
+        noMatchingBuilds.hidden = filteredApps.length > 0 || !filtering;
         fillViewport();
     };
 

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,9 +1,55 @@
-import { Container, Label, Menu, Progress, Button } from '@playcanvas/pcui';
+import { Container, Label, Menu, MenuItem, Progress, Button } from '@playcanvas/pcui';
 
 import { bytesToHuman, convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
 const APP_LIMIT = 16;
+const FILTER_ALL = 'all';
+const BUILD_FILTERS = [{
+    key: 'type',
+    label: 'Type'
+}, {
+    key: 'format',
+    label: 'Format'
+}, {
+    key: 'status',
+    label: 'Status'
+}, {
+    key: 'branch',
+    label: 'Branch'
+}, {
+    key: 'actor',
+    label: 'Actor'
+}];
+const FILTER_ORDER = {
+    type: ['publish', 'download'],
+    format: ['playcanvas', 'static', 'npm', 'web_lens'],
+    status: ['complete', 'running', 'error']
+};
+const FORMAT_FILTERS = [{
+    value: 'playcanvas',
+    label: 'playcanvas'
+}, {
+    value: 'static',
+    label: 'static'
+}, {
+    value: 'npm',
+    label: 'npm'
+}, {
+    value: 'web_lens',
+    label: 'web_lens',
+    superUser: true
+}];
+const STATUS_FILTERS = [{
+    value: 'complete',
+    label: 'Succeeded'
+}, {
+    value: 'running',
+    label: 'Running'
+}, {
+    value: 'error',
+    label: 'Failed'
+}];
 const DUMMY_LEGACY_APP = {
     id: -1,
     sample: true,
@@ -35,6 +81,12 @@ editor.once('load', () => {
     let detailEvents = [];  // holds detail panel events
     let openingDetail = false;
     let openingBuilds = false;
+    const filters: Record<string, string> = {};
+    const filterButtons: Record<string, Button> = {};
+    const filterMenus: Record<string, Menu> = {};
+    BUILD_FILTERS.forEach((filter) => {
+        filters[filter.key] = FILTER_ALL;
+    });
 
     // disables / enables field depending on permissions
     const handlePermissions = function (field: { enabled: boolean }) {
@@ -104,12 +156,24 @@ editor.once('load', () => {
     primaryBuild.hidden = true;
     panel.append(primaryBuild);
 
+    const historyHeader = new Container({
+        flex: true,
+        class: 'builds-history-header'
+    });
+    panel.append(historyHeader);
+
     // Existing builds label
     const existingBuildsLabel = new Label({
         text: 'Build history',
         class: 'builds-list-heading'
     });
-    panel.append(existingBuildsLabel);
+    historyHeader.append(existingBuildsLabel);
+
+    const filterBar = new Container({
+        flex: true,
+        class: 'builds-filter-bar'
+    });
+    historyHeader.append(filterBar);
 
     // no builds message
     let noBuildsText = 'You have not created any builds.';
@@ -123,6 +187,13 @@ editor.once('load', () => {
         hidden: true
     });
     panel.append(noBuilds);
+
+    const noMatchingBuilds = new Label({
+        text: 'No builds match the selected filters.',
+        class: ['no-builds-label', 'no-filtered-builds-label'],
+        hidden: true
+    });
+    panel.append(noMatchingBuilds);
 
     // container for builds
     const container = new Container({ class: 'builds-list' });
@@ -162,8 +233,9 @@ editor.once('load', () => {
 
     // keep loading until the list fills the scroll area, so scrolling can trigger more
     const fillViewport = function () {
+        const needsFilteredRows = hasActiveFilters() && getFilteredApps().length === 0;
         if (scrollContainer && hasMore && !loadingMore && !panel.hidden && !detailApp &&
-            scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
+            (needsFilteredRows || scrollContainer.scrollHeight <= scrollContainer.clientHeight)) {
             loadMoreBuilds();
         }
     };
@@ -274,6 +346,7 @@ editor.once('load', () => {
         primaryBuildHeading.hidden = true;
         primaryBuild.hidden = true;
         noBuilds.hidden = toggle || apps.length > 0;
+        noMatchingBuilds.hidden = true;
     };
 
     const loadAppIndex = function (done: () => void) {
@@ -417,6 +490,201 @@ editor.once('load', () => {
         }
         return app.task.status || 'Pending';
     };
+
+    const getTypeLabel = function (app: any) {
+        return app.type === 'publish' ? 'Publish' : 'Download';
+    };
+
+    const getFormatValue = function (app: any) {
+        return app.settings && app.settings.format || app.version || app.type || '';
+    };
+
+    const getBranchLabel = function (app: any) {
+        return app.branch && app.branch.name || 'main';
+    };
+
+    const getActorLabel = function (app: any) {
+        return app.actor && (app.actor.name || app.actor.username) || '';
+    };
+
+    const getFilterValue = function (app: any, key: string) {
+        if (key === 'type') {
+            return app.type || '';
+        }
+        if (key === 'format') {
+            return getFormatValue(app);
+        }
+        if (key === 'status') {
+            return app.task.status || '';
+        }
+        if (key === 'branch') {
+            return getBranchLabel(app);
+        }
+        if (key === 'actor') {
+            return app.actor && app.actor.id !== undefined ? String(app.actor.id) : getActorLabel(app);
+        }
+        return '';
+    };
+
+    const getFilterLabel = function (app: any, key: string) {
+        if (key === 'type') {
+            return getTypeLabel(app);
+        }
+        if (key === 'status') {
+            return getStatusLabel(app);
+        }
+        if (key === 'branch') {
+            return getBranchLabel(app);
+        }
+        if (key === 'actor') {
+            return getActorLabel(app);
+        }
+        return getFormatValue(app);
+    };
+
+    const getFilterOptions = function (key: string) {
+        const labels: Record<string, string> = {};
+        if (key === 'format') {
+            FORMAT_FILTERS.forEach((option) => {
+                if (!option.superUser || config.self.flags.superUser) {
+                    labels[option.value] = option.label;
+                }
+            });
+        } else if (key === 'status') {
+            STATUS_FILTERS.forEach((option) => {
+                labels[option.value] = option.label;
+            });
+        }
+        apps.forEach((app) => {
+            const value = getFilterValue(app, key);
+            if (value) {
+                labels[value] = getFilterLabel(app, key);
+            }
+        });
+
+        const order = (FILTER_ORDER as any)[key] || [];
+        return Object.keys(labels).map(value => ({
+            value,
+            label: labels[value]
+        })).sort((a, b) => {
+            const ai = order.indexOf(a.value);
+            const bi = order.indexOf(b.value);
+            if (ai !== -1 || bi !== -1) {
+                return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi);
+            }
+            return a.label.localeCompare(b.label);
+        });
+    };
+
+    const getFilterValueLabel = function (key: string, value: string) {
+        const option = getFilterOptions(key).find(item => item.value === value);
+        return option ? option.label : value;
+    };
+
+    const hasActiveFilters = function () {
+        return BUILD_FILTERS.some(filter => filters[filter.key] !== FILTER_ALL);
+    };
+
+    const getFilteredApps = function () {
+        return apps.filter((app) => {
+            return BUILD_FILTERS.every((filter) => {
+                const value = filters[filter.key];
+                return value === FILTER_ALL || getFilterValue(app, filter.key) === value;
+            });
+        });
+    };
+
+    const hideFilterMenus = function () {
+        BUILD_FILTERS.forEach((filter) => {
+            filterMenus[filter.key].hidden = true;
+        });
+    };
+
+    const updateFilterButtons = function () {
+        BUILD_FILTERS.forEach((filter) => {
+            const value = filters[filter.key];
+            const button = filterButtons[filter.key];
+            button.text = value === FILTER_ALL ? filter.label : `${filter.label}: ${getFilterValueLabel(filter.key, value)}`;
+            if (value === FILTER_ALL) {
+                button.class.remove('selected');
+            } else {
+                button.class.add('selected');
+            }
+        });
+    };
+
+    const setBuildFilter = function (key: string, value: string) {
+        if (filters[key] === value) {
+            hideFilterMenus();
+            return;
+        }
+
+        filters[key] = value;
+        updateFilterButtons();
+        hideFilterMenus();
+        refreshApps();
+        fillViewport();
+    };
+
+    const resetBuildFilters = function () {
+        BUILD_FILTERS.forEach((filter) => {
+            filters[filter.key] = FILTER_ALL;
+        });
+        updateFilterButtons();
+        hideFilterMenus();
+    };
+
+    const updateFilterMenu = function (filter: any) {
+        const menu = filterMenus[filter.key];
+        menu.clear();
+
+        const selected = filters[filter.key];
+        menu.append(new MenuItem({
+            text: 'All',
+            class: selected === FILTER_ALL ? 'selected' : '',
+            onSelect: () => setBuildFilter(filter.key, FILTER_ALL)
+        }));
+
+        getFilterOptions(filter.key).forEach((option) => {
+            menu.append(new MenuItem({
+                text: option.label,
+                class: option.value === selected ? 'selected' : '',
+                onSelect: () => setBuildFilter(filter.key, option.value)
+            }));
+        });
+    };
+
+    const openFilterMenu = function (filter: any) {
+        const button = filterButtons[filter.key];
+        const menu = filterMenus[filter.key];
+        updateFilterMenu(filter);
+        hideFilterMenus();
+        button.class.add('active');
+        menu.hidden = false;
+
+        const rect = button.dom.getBoundingClientRect();
+        const items = menu.dom.querySelector('.pcui-menu-items') as HTMLElement;
+        menu.position(rect.right - items.clientWidth, rect.bottom);
+        menu.focus();
+    };
+
+    BUILD_FILTERS.forEach((filter) => {
+        const button = new Button({
+            text: filter.label,
+            class: 'build-filter-button'
+        });
+        filterButtons[filter.key] = button;
+        filterBar.append(button);
+        button.on('click', () => openFilterMenu(filter));
+
+        const menu = new Menu({ class: 'picker-builds-filter-menu' });
+        filterMenus[filter.key] = menu;
+        editor.call('layout.root').append(menu);
+        menu.on('hide', () => {
+            button.class.remove('active');
+        });
+    });
+    updateFilterButtons();
 
     const createValue = function (row: any) {
         const value = row.value;
@@ -615,12 +883,12 @@ editor.once('load', () => {
 
         details.appendChild(createSection('Source and settings', [{
             label: 'Type',
-            value: app.type === 'publish' ? 'Publish' : 'Download',
+            value: getTypeLabel(app),
             variant: 'badge',
             class: app.type
         }, {
             label: 'Format',
-            value: settings.format || app.version,
+            value: getFormatValue(app),
             variant: 'badge'
         }, {
             label: 'Engine',
@@ -741,12 +1009,12 @@ editor.once('load', () => {
 
         const typeBadge = document.createElement('span');
         typeBadge.classList.add('badge', app.type);
-        typeBadge.textContent = app.type === 'publish' ? 'Publish' : 'Download';
+        typeBadge.textContent = getTypeLabel(app);
         nameRow.appendChild(typeBadge);
 
         const formatBadge = document.createElement('span');
         formatBadge.classList.add('badge');
-        formatBadge.textContent = app.settings && app.settings.format || app.version || app.type;
+        formatBadge.textContent = getFormatValue(app);
         nameRow.appendChild(formatBadge);
 
         if (isPrimary) {
@@ -869,12 +1137,12 @@ editor.once('load', () => {
 
         const type = document.createElement('span');
         type.classList.add('badge', app.type);
-        type.textContent = app.type === 'publish' ? 'Publish' : 'Download';
+        type.textContent = getTypeLabel(app);
         nameRow.appendChild(type);
 
         const format = document.createElement('span');
         format.classList.add('badge');
-        format.textContent = app.settings && app.settings.format || app.version || app.type;
+        format.textContent = getFormatValue(app);
         nameRow.appendChild(format);
 
         if (isPrimaryBuild(app)) {
@@ -999,23 +1267,19 @@ editor.once('load', () => {
     // removes an app from the UI
     const removeApp = function (app: any) {
         const target = apps.find(item => isSameBuild(item, app)) || app;
-        document.getElementById(`app-${target.id}`)?.remove();
-        document.getElementById(`primary-app-${target.id}`)?.remove();
+        const removedDetail = detailApp && isSameBuild(detailApp, target);
 
         const index = apps.findIndex(item => isSameBuild(item, target));
         if (index !== -1) {
             apps.splice(index, 1);
         }
 
-        container.hidden = apps.length === 0;
-        noBuilds.hidden = apps.length > 0;
+        if (removedDetail) {
+            detailApp = null;
+        }
+        refreshApps();
 
-        // drop the primary-build summary if its build was the one removed
-        const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
-        primaryBuildHeading.hidden = !primaryExists;
-        primaryBuild.hidden = !primaryExists;
-
-        if (detailApp && isSameBuild(detailApp, target)) {
+        if (removedDetail) {
             openBuildsPanel();
         }
     };
@@ -1035,9 +1299,12 @@ editor.once('load', () => {
         destroyEvents();
         primaryBuild.dom.innerHTML = '';
         container.dom.innerHTML = '';
+        const filteredApps = getFilteredApps();
         renderPrimaryBuild();
-        container.hidden = apps.length === 0;
-        apps.forEach((app) => {
+        container.hidden = apps.length === 0 || filteredApps.length === 0;
+        noBuilds.hidden = apps.length > 0;
+        noMatchingBuilds.hidden = apps.length === 0 || filteredApps.length > 0 || !hasActiveFilters();
+        filteredApps.forEach((app) => {
             createAppItem(app);
         });
 
@@ -1257,6 +1524,7 @@ editor.once('load', () => {
             return;
         }
 
+        resetBuildFilters();
         apps = [];
         appIndex = {};
         appList = [];
@@ -1286,6 +1554,7 @@ editor.once('load', () => {
             return;
         }
 
+        resetBuildFilters();
         apps = [];
         appIndex = {};
         appList = [];

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,7 +1,5 @@
-import { Container, Label, Progress, Button } from '@playcanvas/pcui';
+import { Container, Label, Menu, Progress, Button } from '@playcanvas/pcui';
 
-import { LegacyList } from '@/common/ui/list';
-import { LegacyListItem } from '@/common/ui/list-item';
 import { bytesToHuman, convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -11,6 +9,8 @@ editor.once('load', () => {
     // global variables
     const projectSettings = editor.call('settings:project');
     let detailApp = null;  // app whose detail page is currently open
+    let menuApp = null;  // app whose row action menu is open
+    let activeKebab = null;  // kebab button that opened the menu
     let apps = [];  // all loaded builds
     let tooltips = [];  // holds all tooltips
     let events = [];  // holds events that need to be destroyed
@@ -27,39 +27,34 @@ editor.once('load', () => {
         });
     };
 
-    // collapses publish and download buttons
-    const toggleCollapsingPublishButtons = (collapse = true) => {
-        if (collapse) {
-            labelDownloadIcon.style.display = 'none';
-            labelDownloadDesc.style.display = 'none';
-            labelPublishDesc.style.display = 'none';
-            labelPublishIcon.style.display = 'none';
-
-            btnPublish.class.add('collapsed');
-            btnDownload.class.add('collapsed');
-
-            panelPlaycanvas.class.add('collapsed');
-            panelSelfHost.class.add('collapsed');
-        } else {
-            labelDownloadIcon.style.display = 'block';
-            labelDownloadDesc.style.display = 'block';
-            labelPublishDesc.style.display = 'block';
-            labelPublishIcon.style.display = 'block';
-
-            btnPublish.class.remove('collapsed');
-            btnDownload.class.remove('collapsed');
-
-            panelPlaycanvas.class.remove('collapsed');
-            panelSelfHost.class.remove('collapsed');
-        }
-    };
-
     // main panel
     const panel = new Container({
         flex: true,
         class: 'picker-builds-publish'
     });
-    // panel.class.add('picker-builds-publish');
+
+    // top toolbar: publish (primary) + download (secondary)
+    const toolbar = new Container({
+        flex: true,
+        class: 'builds-toolbar'
+    });
+    panel.append(toolbar);
+
+    const btnDownload = new Button({
+        text: 'Download .zip',
+        class: 'download'
+    });
+    handlePermissions(btnDownload);
+    btnDownload.on('click', () => editor.call('picker:publish:download'));
+    toolbar.append(btnDownload);
+
+    const btnPublish = new Button({
+        text: 'Publish',
+        class: 'publish'
+    });
+    handlePermissions(btnPublish);
+    btnPublish.on('click', () => editor.call('picker:publish:new'));
+    toolbar.append(btnPublish);
 
     // progress bar and loading label
     const loading = new Label({
@@ -78,84 +73,10 @@ editor.once('load', () => {
     });
     panel.append(primaryBuildHeading);
 
-    const primaryBuild = new LegacyList();
+    const primaryBuild = new Container({ class: 'builds-list' });
     primaryBuild.class.add('primary-build-summary');
-    primaryBuild.selectable = false;
     primaryBuild.hidden = true;
     panel.append(primaryBuild);
-
-    // publish buttons container
-    const publishButtons = new Container({
-        flex: true,
-        class: 'publish-buttons-container'
-    });
-    panel.append(publishButtons);
-
-    // playcanv.as
-    const panelPlaycanvas = new Container({
-        flex: true,
-        class: 'buttons'
-    });
-    publishButtons.append(panelPlaycanvas);
-
-    const labelPublishIcon = new Label({
-        text: '&#57960;',
-        unsafe: true,
-        class: 'icon'
-    });
-    panelPlaycanvas.append(labelPublishIcon);
-
-    const labelPublishDesc = new Label({
-        text: 'Publish your project publicly on PlayCanvas.',
-        class: 'desc'
-    });
-    panelPlaycanvas.append(labelPublishDesc);
-
-    // publish button
-    const btnPublish = new Button({
-        text: 'Publish To PlayCanvas',
-        class: 'publish'
-    });
-    handlePermissions(btnPublish);
-    panelPlaycanvas.append(btnPublish);
-
-    handlePermissions(panelPlaycanvas);
-    panelPlaycanvas.on('click', () => {
-        editor.call('picker:publish:new');
-    });
-
-    // self host
-    const panelSelfHost = new Container({
-        flex: true,
-        class: 'buttons'
-    });
-    publishButtons.append(panelSelfHost);
-
-    const labelDownloadIcon = new Label({
-        text: '&#57925;',
-        class: 'icon',
-        unsafe: true
-    });
-    panelSelfHost.append(labelDownloadIcon);
-
-    const labelDownloadDesc = new Label({
-        text: 'Download build and host it on your own server.',
-        class: 'desc'
-    });
-    panelSelfHost.append(labelDownloadDesc);
-
-    // download button
-    const btnDownload = new Button({
-        text: 'Download .zip',
-        class: 'download'
-    });
-    handlePermissions(btnDownload);
-    panelSelfHost.append(btnDownload);
-
-    handlePermissions(panelSelfHost);
-    panelSelfHost.on('click', () => {
-        editor.call('picker:publish:download');
-    });
 
     // Existing builds label
     const existingBuildsLabel = new Label({
@@ -178,17 +99,8 @@ editor.once('load', () => {
     panel.append(noBuilds);
 
     // container for builds
-    const container = new LegacyList();
-    container.selectable = false;
+    const container = new Container({ class: 'builds-list' });
     panel.append(container);
-
-    // load more builds button
-    const loadMore = new Button({
-        text: 'Load More',
-        class: 'load-more'
-    });
-    panel.append(loadMore);
-    handlePermissions(loadMore);
 
     // detail "page" for a single build (hidden until a row is opened)
     const detailView = new Container({
@@ -199,20 +111,98 @@ editor.once('load', () => {
     panel.append(detailView);
 
     // list chrome that is hidden while the detail page is open
-    const listChrome = [primaryBuildHeading, primaryBuild, publishButtons, existingBuildsLabel, noBuilds, container, loadMore];
+    const listChrome = [toolbar, primaryBuildHeading, primaryBuild, existingBuildsLabel, noBuilds, container];
 
+    // pagination state for infinite scroll
     let skip = 0;
-    loadMore.on('click', () => {
-        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip += APP_LIMIT).on('load', (status, data) => {
+    let hasMore = true;
+    let loadingMore = false;
+    let scrollContainer: HTMLElement | null = null;
+
+    const loadMoreBuilds = function () {
+        if (loadingMore || !hasMore || panel.hidden || detailApp) {
+            return;
+        }
+        loadingMore = true;
+        skip += APP_LIMIT;
+        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip).on('load', (status, data) => {
+            loadingMore = false;
             const results = data.result.map(normalizeBuildJob);
-            if (results.length === 0) {
-                loadMore.hidden = true;
-                return;
-            }
             apps.push(...results);
             results.forEach(app => createAppItem(app));
+            hasMore = data.pagination ? apps.length < data.pagination.total : results.length === APP_LIMIT;
+            fillViewport();
         });
+    };
+
+    // keep loading until the list fills the scroll area, so scrolling can trigger more
+    const fillViewport = function () {
+        if (scrollContainer && hasMore && !loadingMore && !panel.hidden && !detailApp &&
+            scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
+            loadMoreBuilds();
+        }
+    };
+
+    const onScroll = function () {
+        if (!scrollContainer || loadingMore || !hasMore || panel.hidden || detailApp) {
+            return;
+        }
+        if (scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < 240) {
+            loadMoreBuilds();
+        }
+    };
+
+    // shared per-row action menu (opened from the kebab button on each row)
+    const rowMenu = new Menu({
+        class: 'picker-builds-menu',
+        items: [{
+            text: 'Open',
+            class: 'open',
+            onIsVisible: () => menuApp?.type === 'publish' && menuApp?.task.status === 'complete' && !!menuApp?.url,
+            onSelect: () => menuApp?.url && window.open(menuApp.url, '_blank', 'noopener')
+        }, {
+            text: 'Download',
+            class: 'download',
+            onIsVisible: () => menuApp?.type === 'download' && menuApp?.task.status === 'complete' && !!menuApp?.url,
+            onSelect: () => menuApp?.url && window.open(menuApp.url, '_blank', 'noopener')
+        }, {
+            text: 'View',
+            onSelect: () => menuApp && showDetail(menuApp)
+        }, {
+            text: 'Delete',
+            class: 'delete',
+            onIsEnabled: () => editor.call('permissions:write') && !!menuApp?.build_job_id,
+            onSelect: () => {
+                if (!menuApp?.build_job_id) {
+                    return;
+                }
+                const app = menuApp;
+                editor.call('picker:confirm', 'Are you sure you want to delete this build?');
+                editor.once('picker:confirm:yes', () => {
+                    editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
+                    removeApp(app);
+                });
+            }
+        }]
     });
+    editor.call('layout.root').append(rowMenu);
+
+    rowMenu.on('hide', () => {
+        activeKebab?.classList.remove('active');
+        activeKebab = null;
+    });
+
+    const openRowMenu = function (app: any, kebab: HTMLElement) {
+        menuApp = app;
+        activeKebab = kebab;
+        kebab.classList.add('active');
+        rowMenu.hidden = false;
+
+        const rect = kebab.getBoundingClientRect();
+        const items = rowMenu.dom.querySelector('.pcui-menu-items') as HTMLElement;
+        rowMenu.position(rect.right - items.clientWidth, rect.bottom);
+        rowMenu.focus();
+    };
 
     // register panel with project popup
     editor.call('picker:project:registerMenu', 'builds-publish', 'Builds', panel, 'BUILDS & PUBLISH');
@@ -357,6 +347,26 @@ editor.once('load', () => {
         return details;
     };
 
+    // relative time for builds created today (just now / x minutes / x hours ago), absolute date otherwise
+    const formatBuildDate = function (value: any) {
+        const d = new Date(value);
+        const now = new Date();
+        const sameDay = d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+        if (!sameDay) {
+            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+
+        const mins = Math.max(0, Math.floor((now.getTime() - d.getTime()) / 60000));
+        if (mins < 1) {
+            return 'just now';
+        }
+        if (mins < 60) {
+            return mins === 1 ? '1 minute ago' : `${mins} minutes ago`;
+        }
+        const hours = Math.floor(mins / 60);
+        return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+    };
+
     // build the detail "page" for a single build
     const renderDetail = function (app: any) {
         detailView.element.innerHTML = '';
@@ -448,7 +458,6 @@ editor.once('load', () => {
                     refreshApps();
                 });
                 refreshApps();
-                toggleCollapsingPublishButtons(true);
             }));
             actions.appendChild(primary.dom);
         }
@@ -485,9 +494,8 @@ editor.once('load', () => {
         detailView.element.innerHTML = '';
 
         existingBuildsLabel.hidden = false;
-        publishButtons.hidden = false;
+        toolbar.hidden = false;
         container.hidden = apps.length === 0;
-        loadMore.hidden = apps.length === 0;
         noBuilds.hidden = apps.length > 0;
 
         const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
@@ -506,22 +514,20 @@ editor.once('load', () => {
     };
 
     // create UI for single app
-    const createAppItem = function (app: any, list: LegacyList = container, options: any = {}) {
-        const item = new LegacyListItem();
-        item.element.id = options.summary ? `primary-app-${app.id}` : `app-${app.id}`;
-
-        list.append(item);
+    const createAppItem = function (app: any, list: Container = container, options: any = {}) {
+        const item = document.createElement('div');
+        item.classList.add('build-item', app.task.status, app.type);
+        item.id = options.summary ? `primary-app-${app.id}` : `app-${app.id}`;
 
         if (config.project.primaryApp === app.app_id || config.project.primaryApp === app.id) {
-            item.class.add('primary');
+            item.classList.add('primary');
         }
 
-        item.class.add(app.task.status);
-        item.class.add(app.type);
+        list.dom.appendChild(item);
 
         const row = document.createElement('div');
         row.classList.add('build-row');
-        item.element.appendChild(row);
+        item.appendChild(row);
 
         const status = document.createElement('span');
         status.classList.add('status', app.task.status);
@@ -585,7 +591,8 @@ editor.once('load', () => {
 
         const date = document.createElement('span');
         date.classList.add('date');
-        date.textContent = convertDatetime(app.created_at);
+        date.textContent = formatBuildDate(app.created_at);
+        date.title = convertDatetime(app.created_at);
         rightMeta.appendChild(date);
 
         if (app.duration_ms) {
@@ -597,7 +604,26 @@ editor.once('load', () => {
 
         row.appendChild(rightMeta);
 
-        events.push(item.on('click', () => showDetail(app)));
+        const kebab = document.createElement('button');
+        kebab.type = 'button';
+        kebab.classList.add('kebab');
+        kebab.setAttribute('aria-label', 'Build actions');
+        const openKebab = function (e: MouseEvent) {
+            e.preventDefault();
+            e.stopPropagation();
+            openRowMenu(app, kebab);
+        };
+        kebab.addEventListener('click', openKebab);
+        events.push({
+            unbind: () => kebab.removeEventListener('click', openKebab)
+        });
+        row.appendChild(kebab);
+
+        const onItemClick = () => showDetail(app);
+        item.addEventListener('click', onItemClick);
+        events.push({
+            unbind: () => item.removeEventListener('click', onItemClick)
+        });
 
         return item;
     };
@@ -607,26 +633,23 @@ editor.once('load', () => {
     // load build job list
     const loadApps = function (showProgress: boolean = true) {
         skip = 0;
+        hasMore = true;
+        loadingMore = false;
 
         if (showProgress) {
             toggleProgress(true);
         }
 
-        editor.api.globals.rest.projects.projectBuilds().on('load', (status, data) => {
-            const results = data.result.map(normalizeBuildJob);
-            apps = results;
+        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, 0).on('load', (status, data) => {
+            apps = data.result.map(normalizeBuildJob);
+            hasMore = data.pagination ? apps.length < data.pagination.total : data.result.length === APP_LIMIT;
+
             if (showProgress) {
                 toggleProgress(false);
             }
 
-            if (apps.length > 0) {
-                panelPlaycanvas.class.add('collapsed');
-                panelSelfHost.class.add('collapsed');
-            }
-
-            toggleCollapsingPublishButtons(apps.length > 0);
-
             refreshApps();
+            fillViewport();
         });
     };
 
@@ -641,6 +664,11 @@ editor.once('load', () => {
         }
 
         container.hidden = apps.length === 0;
+
+        // drop the primary-build summary if its build was the one removed
+        const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
+        primaryBuildHeading.hidden = !primaryExists;
+        primaryBuild.hidden = !primaryExists;
 
         // if the deleted build's detail page is open, return to the list
         if (detailApp && detailApp.id === app.id) {
@@ -659,11 +687,10 @@ editor.once('load', () => {
     const refreshApps = function () {
         destroyTooltips();
         destroyEvents();
-        primaryBuild.element.innerHTML = '';
-        container.element.innerHTML = '';
+        primaryBuild.dom.innerHTML = '';
+        container.dom.innerHTML = '';
         renderPrimaryBuild();
         container.hidden = apps.length === 0;
-        loadMore.hidden = apps.length === 0;
         apps.forEach((app) => {
             createAppItem(app);
         });
@@ -769,6 +796,10 @@ editor.once('load', () => {
         showList();
         loadApps();
 
+        // the picker scrolls its content panel; watch it for infinite scroll
+        scrollContainer = panel.dom.parentElement;
+        scrollContainer?.addEventListener('scroll', onScroll);
+
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', false);
         }
@@ -779,6 +810,8 @@ editor.once('load', () => {
         apps = [];
         detailApp = null;
         detailView.hidden = true;
+        scrollContainer?.removeEventListener('scroll', onScroll);
+        scrollContainer = null;
         destroyTooltips();
         destroyEvents();
 

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,8 +1,7 @@
-import { Container, Label, Menu, Progress, Button } from '@playcanvas/pcui';
+import { Container, Label, Progress, Button } from '@playcanvas/pcui';
 
 import { LegacyList } from '@/common/ui/list';
 import { LegacyListItem } from '@/common/ui/list-item';
-import { LegacyTooltip } from '@/common/ui/tooltip';
 import { bytesToHuman, convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -11,7 +10,7 @@ const APP_LIMIT = 16;
 editor.once('load', () => {
     // global variables
     const projectSettings = editor.call('settings:project');
-    let dropdownApp = null;  // app whose dropdown was last clicked
+    let detailApp = null;  // app whose detail page is currently open
     let apps = [];  // all loaded builds
     let tooltips = [];  // holds all tooltips
     let events = [];  // holds events that need to be destroyed
@@ -190,6 +189,18 @@ editor.once('load', () => {
     });
     panel.append(loadMore);
     handlePermissions(loadMore);
+
+    // detail "page" for a single build (hidden until a row is opened)
+    const detailView = new Container({
+        flex: true,
+        class: 'build-detail',
+        hidden: true
+    });
+    panel.append(detailView);
+
+    // list chrome that is hidden while the detail page is open
+    const listChrome = [primaryBuildHeading, primaryBuild, publishButtons, existingBuildsLabel, noBuilds, container, loadMore];
+
     let skip = 0;
     loadMore.on('click', () => {
         editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip += APP_LIMIT).on('load', (status, data) => {
@@ -199,43 +210,8 @@ editor.once('load', () => {
                 return;
             }
             apps.push(...results);
-            results.forEach(createAppItem);
+            results.forEach(app => createAppItem(app));
         });
-    });
-
-    const dropdownMenu = new Menu({
-        class: 'picker-builds-menu',
-        items: [{
-            text: 'Delete',
-            onIsEnabled: () => editor.call('permissions:write') && !!dropdownApp?.build_job_id,
-            onSelect: () => {
-                if (!dropdownApp?.build_job_id) {
-                    return;
-                }
-
-                editor.call('picker:confirm', 'Are you sure you want to delete this build?');
-                editor.once('picker:confirm:yes', () => {
-                    removeApp(dropdownApp);
-                    editor.api.globals.rest.projects.projectBuildDelete(dropdownApp.build_job_id);
-                });
-            }
-        }]
-    });
-
-    editor.call('layout.root').append(dropdownMenu);
-
-    // on closing menu remove 'clicked' class from respective dropdown
-    dropdownMenu.on('hide', () => {
-        if (dropdownApp) {
-            const item = document.getElementById(`app-${dropdownApp.id}`);
-            if (item) {
-                const clicked = item.querySelector('.clicked');
-                if (clicked) {
-                    clicked.innerHTML = '&#57689;';
-                    clicked.classList.remove('clicked');
-                }
-            }
-        }
     });
 
     // register panel with project popup
@@ -381,15 +357,160 @@ editor.once('load', () => {
         return details;
     };
 
+    // build the detail "page" for a single build
+    const renderDetail = function (app: any) {
+        detailView.element.innerHTML = '';
+
+        const isComplete = app.task.status === 'complete';
+        const canPublish = app.type === 'publish' && !!app.app_id;
+        const canDelete = !!app.build_job_id;
+        const isPrimary = config.project.primaryApp === app.app_id;
+
+        const back = document.createElement('button');
+        back.type = 'button';
+        back.classList.add('back');
+        back.textContent = '← Back to builds';
+        back.addEventListener('click', showList);
+        events.push({ unbind: () => back.removeEventListener('click', showList) });
+        detailView.element.appendChild(back);
+
+        const header = document.createElement('div');
+        header.classList.add('detail-header');
+        detailView.element.appendChild(header);
+
+        const status = document.createElement('span');
+        status.classList.add('status', app.task.status);
+        header.appendChild(status);
+
+        const heading = document.createElement('div');
+        heading.classList.add('heading');
+        header.appendChild(heading);
+
+        const nameRow = document.createElement('div');
+        nameRow.classList.add('name-row');
+        heading.appendChild(nameRow);
+
+        const name = document.createElement('span');
+        name.classList.add('name');
+        name.textContent = app.name;
+        nameRow.appendChild(name);
+
+        const typeBadge = document.createElement('span');
+        typeBadge.classList.add('badge', app.type);
+        typeBadge.textContent = app.type === 'publish' ? 'Publish' : 'Download';
+        nameRow.appendChild(typeBadge);
+
+        const formatBadge = document.createElement('span');
+        formatBadge.classList.add('badge');
+        formatBadge.textContent = app.settings && app.settings.format || app.version || app.type;
+        nameRow.appendChild(formatBadge);
+
+        if (isPrimary) {
+            const primaryBadge = document.createElement('span');
+            primaryBadge.classList.add('badge', 'primary-badge');
+            primaryBadge.textContent = 'Primary';
+            nameRow.appendChild(primaryBadge);
+        }
+
+        const sub = document.createElement('div');
+        sub.classList.add('sub');
+        sub.textContent = [
+            isComplete ? 'Succeeded' : (app.task.status === 'error' ? 'Failed' : 'In progress'),
+            app.build_job_id ? `#${app.build_job_id}` : null
+        ].filter(Boolean).join(' · ');
+        heading.appendChild(sub);
+
+        const actions = document.createElement('div');
+        actions.classList.add('detail-actions');
+        header.appendChild(actions);
+
+        if (isComplete && app.url) {
+            const artifact = document.createElement('a');
+            artifact.classList.add('artifact');
+            artifact.href = app.url;
+            artifact.target = '_blank';
+            artifact.rel = 'noopener';
+            artifact.textContent = app.type === 'publish' ? 'Open' : 'Download';
+            actions.appendChild(artifact);
+        }
+
+        if (canPublish) {
+            const primary = new Button({ text: 'Set primary', class: 'set-primary' });
+            events.push(handlePermissions(primary));
+            if (primary.enabled && (!isComplete || isPrimary)) {
+                primary.enabled = false;
+            }
+            events.push(primary.on('click', () => {
+                if (isPrimary || !isComplete) {
+                    return;
+                }
+                editor.call('projects:setPrimaryApp', app.app_id, null, () => {
+                    refreshApps();
+                });
+                refreshApps();
+                toggleCollapsingPublishButtons(true);
+            }));
+            actions.appendChild(primary.dom);
+        }
+
+        if (canDelete) {
+            const del = new Button({ text: 'Delete', class: 'delete' });
+            events.push(handlePermissions(del));
+            events.push(del.on('click', () => {
+                editor.call('picker:confirm', 'Are you sure you want to delete this build?');
+                editor.once('picker:confirm:yes', () => {
+                    editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
+                    removeApp(app);
+                });
+            }));
+            actions.appendChild(del.dom);
+        }
+
+        if (app.task.status === 'error' && app.task.message) {
+            const error = document.createElement('div');
+            error.classList.add('error');
+            error.textContent = app.task.message;
+            detailView.element.appendChild(error);
+        }
+
+        const details = createDetails(app);
+        details.hidden = false;
+        detailView.element.appendChild(details);
+    };
+
+    // return from the detail page to the build list
+    const showList = function () {
+        detailApp = null;
+        detailView.hidden = true;
+        detailView.element.innerHTML = '';
+
+        existingBuildsLabel.hidden = false;
+        publishButtons.hidden = false;
+        container.hidden = apps.length === 0;
+        loadMore.hidden = apps.length === 0;
+        noBuilds.hidden = apps.length > 0;
+
+        const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
+        primaryBuildHeading.hidden = !primaryExists;
+        primaryBuild.hidden = !primaryExists;
+    };
+
+    // open the detail page for a build
+    const showDetail = function (app: any) {
+        detailApp = app;
+        listChrome.forEach((el) => {
+            el.hidden = true;
+        });
+        renderDetail(app);
+        detailView.hidden = false;
+    };
+
     // create UI for single app
     const createAppItem = function (app: any, list: LegacyList = container, options: any = {}) {
         const item = new LegacyListItem();
         item.element.id = options.summary ? `primary-app-${app.id}` : `app-${app.id}`;
 
         list.append(item);
-
-        const canPublish = !options.summary && app.type === 'publish' && !!app.app_id;
-        const canDelete = !options.summary && !!app.build_job_id;
 
         if (config.project.primaryApp === app.app_id || config.project.primaryApp === app.id) {
             item.class.add('primary');
@@ -403,8 +524,7 @@ editor.once('load', () => {
         item.element.appendChild(row);
 
         const status = document.createElement('span');
-        status.classList.add('status');
-        status.classList.add(app.task.status);
+        status.classList.add('status', app.task.status);
         if (app.task.status === 'complete') {
             status.setAttribute('aria-label', 'Succeeded');
         } else if (app.task.status === 'error') {
@@ -427,8 +547,7 @@ editor.once('load', () => {
         nameRow.appendChild(name.dom);
 
         const type = document.createElement('span');
-        type.classList.add('badge');
-        type.classList.add(app.type);
+        type.classList.add('badge', app.type);
         type.textContent = app.type === 'publish' ? 'Publish' : 'Download';
         nameRow.appendChild(type);
 
@@ -439,167 +558,46 @@ editor.once('load', () => {
 
         if (config.project.primaryApp === app.app_id) {
             const primaryBadge = document.createElement('span');
-            primaryBadge.classList.add('badge');
-            primaryBadge.classList.add('primary-badge');
+            primaryBadge.classList.add('badge', 'primary-badge');
             primaryBadge.textContent = 'Primary';
             nameRow.appendChild(primaryBadge);
         }
 
-        const meta = document.createElement('div');
-        meta.classList.add('meta');
-        body.appendChild(meta);
+        const sub = document.createElement('div');
+        sub.classList.add('sub');
+        const actor = app.actor && (app.actor.name || app.actor.username);
+        sub.textContent = [
+            app.build_job_id ? `#${app.build_job_id}` : null,
+            actor ? `by ${actor}` : null
+        ].filter(Boolean).join(' · ');
+        body.appendChild(sub);
 
-        const addMeta = function (value: any, cls?: string) {
-            if (value === undefined || value === null || value === '') {
-                return null;
-            }
+        const branch = document.createElement('div');
+        branch.classList.add('branch');
+        const branchName = document.createElement('span');
+        branchName.classList.add('branch-name');
+        branchName.textContent = app.branch && app.branch.name || 'main';
+        branch.appendChild(branchName);
+        row.appendChild(branch);
 
-            const span = document.createElement('span');
-            span.classList.add('meta-item');
-            if (cls) {
-                span.classList.add(cls);
-            }
-            span.textContent = value;
-            meta.appendChild(span);
-            return span;
-        };
+        const rightMeta = document.createElement('div');
+        rightMeta.classList.add('right-meta');
 
-        addMeta(app.task.status === 'complete' ? 'Succeeded' : (app.task.status === 'error' ? 'Failed' : 'In progress'), 'state');
-        addMeta(app.build_job_id ? `#${app.build_job_id}` : null, 'run');
-        addMeta(convertDatetime(app.created_at), 'date');
-        addMeta(app.actor && (app.actor.name || app.actor.username), 'actor');
-        addMeta(app.branch && app.branch.name || 'main', 'branch');
-        addMeta(app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null, 'duration');
-        addMeta(app.size === null ? null : bytesToHuman(app.size), 'size');
+        const date = document.createElement('span');
+        date.classList.add('date');
+        date.textContent = convertDatetime(app.created_at);
+        rightMeta.appendChild(date);
 
-        const actions = document.createElement('div');
-        actions.classList.add('actions');
-        const stopActions = function (e: MouseEvent) {
-            e.stopPropagation();
-        };
-        actions.addEventListener('click', stopActions);
-        events.push({
-            unbind: () => {
-                actions.removeEventListener('click', stopActions);
-            }
-        });
-        row.appendChild(actions);
-
-        const primary = new Button({
-            icon: 'E223',
-            class: 'primary'
-        });
-        events.push(handlePermissions(primary));
-        primary.hidden = options.summary || !canPublish;
-        if (primary.enabled && (!canPublish || app.task.status !== 'complete')) {
-            primary.enabled = false;
-        }
-        actions.appendChild(primary.dom);
-
-        events.push(primary.on('click', (e?: MouseEvent) => {
-            e?.stopPropagation();
-
-            if (!canPublish || config.project.primaryApp === app.app_id || app.task.status !== 'complete') {
-                return;
-            }
-
-            editor.call('projects:setPrimaryApp', app.app_id, null, () => {
-                refreshApps();
-            });
-
-            refreshApps();
-            toggleCollapsingPublishButtons(true);
-        }));
-
-        if (canPublish) {
-            const tooltipText = config.project.primaryApp === app.app_id ? 'Primary build' : 'Change the projects\'s primary build';
-            const tooltip = LegacyTooltip.attach({
-                target: primary.dom,
-                text: tooltipText,
-                align: 'right',
-                root: editor.call('layout.root')
-            });
-            tooltips.push(tooltip);
+        if (app.duration_ms) {
+            const duration = document.createElement('span');
+            duration.classList.add('duration');
+            duration.textContent = `${Math.round(app.duration_ms / 1000)}s`;
+            rightMeta.appendChild(duration);
         }
 
-        if (app.task.status === 'complete' && app.url) {
-            const artifact = document.createElement('a');
-            artifact.classList.add('artifact');
-            artifact.href = app.url;
-            artifact.target = '_blank';
-            artifact.rel = 'noopener';
-            artifact.textContent = app.type === 'publish' ? 'Open' : 'Download';
-            actions.appendChild(artifact);
-        }
+        row.appendChild(rightMeta);
 
-        const error = new Label({
-            text: app.task.message,
-            class: 'error',
-            hidden: app.task.status !== 'error'
-        });
-        item.element.appendChild(error.dom);
-
-        const dropdown = document.createElement('button');
-        dropdown.type = 'button';
-        dropdown.classList.add('action-button');
-        dropdown.classList.add('dropdown');
-        dropdown.innerHTML = '&#57689;';
-        dropdown.hidden = !canDelete;
-        dropdown.setAttribute('aria-label', 'Build actions');
-        actions.appendChild(dropdown);
-
-        const openMenu = function (e: MouseEvent) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            dropdown.classList.add('clicked');
-            dropdown.innerHTML = '&#57687;';
-            dropdownApp = app;
-
-            dropdownMenu.hidden = false;
-
-            const rect = dropdown.getBoundingClientRect();
-            const menuItems = dropdownMenu.dom.querySelector('.pcui-menu-items') as HTMLElement;
-            dropdownMenu.position(rect.right - menuItems.clientWidth, rect.bottom);
-            dropdownMenu.focus();
-        };
-        dropdown.addEventListener('click', openMenu);
-        events.push({
-            unbind: () => {
-                dropdown.removeEventListener('click', openMenu);
-            }
-        });
-
-        const details = createDetails(app);
-        item.element.appendChild(details);
-
-        const expand = document.createElement('button');
-        expand.type = 'button';
-        expand.classList.add('action-button');
-        expand.classList.add('expander');
-        expand.innerHTML = '&#57689;';
-        expand.setAttribute('aria-label', 'Show build details');
-        actions.appendChild(expand);
-
-        const toggleDetails = function () {
-            details.hidden = !details.hidden;
-            expand.innerHTML = details.hidden ? '&#57689;' : '&#57687;';
-            expand.setAttribute('aria-label', details.hidden ? 'Show build details' : 'Hide build details');
-        };
-
-        events.push(item.on('click', toggleDetails));
-
-        const expandDetails = function (e: MouseEvent) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleDetails();
-        };
-        expand.addEventListener('click', expandDetails);
-        events.push({
-            unbind: () => {
-                expand.removeEventListener('click', expandDetails);
-            }
-        });
+        events.push(item.on('click', () => showDetail(app)));
 
         return item;
     };
@@ -634,25 +632,20 @@ editor.once('load', () => {
 
     // removes an app from the UI
     const removeApp = function (app: any) {
-        const item = document.getElementById(`app-${app.id}`);
-        if (item) {
-            item.remove();
-        }
+        document.getElementById(`app-${app.id}`)?.remove();
+        document.getElementById(`primary-app-${app.id}`)?.remove();
 
-        // remove from apps array
-        for (let i = 0; i < apps.length; i++) {
-            if (apps[i].id === app.id) {
-                // close dropdown menu if current app deleted
-                if (dropdownApp === apps[i]) {
-                    dropdownMenu.hidden = true;
-                }
-
-                apps.splice(i, 1);
-                break;
-            }
+        const index = apps.findIndex(item => item.id === app.id);
+        if (index !== -1) {
+            apps.splice(index, 1);
         }
 
         container.hidden = apps.length === 0;
+
+        // if the deleted build's detail page is open, return to the list
+        if (detailApp && detailApp.id === app.id) {
+            showList();
+        }
     };
 
     const removeBuildJob = function (id: number) {
@@ -664,7 +657,6 @@ editor.once('load', () => {
 
     // recreate app list UI
     const refreshApps = function () {
-        dropdownMenu.hidden = true;
         destroyTooltips();
         destroyEvents();
         primaryBuild.element.innerHTML = '';
@@ -675,6 +667,16 @@ editor.once('load', () => {
         apps.forEach((app) => {
             createAppItem(app);
         });
+
+        // keep the detail page in sync if one is open
+        if (detailApp) {
+            const updated = apps.find(item => item.build_job_id === detailApp.build_job_id);
+            if (updated) {
+                showDetail(updated);
+            } else {
+                showList();
+            }
+        }
     };
 
     // LOCAL UTILS
@@ -764,6 +766,7 @@ editor.once('load', () => {
 
     // on show
     panel.on('show', () => {
+        showList();
         loadApps();
 
         if (editor.call('viewport:inViewport')) {
@@ -774,6 +777,8 @@ editor.once('load', () => {
     // on hide
     panel.on('hide', () => {
         apps = [];
+        detailApp = null;
+        detailView.hidden = true;
         destroyTooltips();
         destroyEvents();
 

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -208,7 +208,7 @@ editor.once('load', () => {
     // no builds message
     let noBuildsText = 'You have not created any builds.';
     if (!projectSettings.get('useLegacyScripts')) {
-        noBuildsText += ' Click PUBLISH to create a new build.';
+        noBuildsText += ' Click Publish or Download to create a new build.';
     }
 
     const noBuilds = new Label({

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,4 +1,4 @@
-import { Container, Label, Menu, MenuItem, Progress, Button } from '@playcanvas/pcui';
+import { Container, Label, Menu, MenuItem, Button } from '@playcanvas/pcui';
 
 import { bytesToHuman, convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
@@ -50,6 +50,12 @@ const STATUS_FILTERS = [{
     value: 'error',
     label: 'Failed'
 }];
+const BUILD_OPTIONS = [
+    ['scripts_concatenate', 'Concatenate scripts'],
+    ['scripts_minify', 'Minify scripts'],
+    ['scripts_sourcemaps', 'Source maps'],
+    ['optimize_scene_format', 'Optimize scene format']
+];
 
 editor.once('load', () => {
     // global variables
@@ -92,16 +98,6 @@ editor.once('load', () => {
         flex: true,
         class: 'picker-builds-publish'
     });
-
-    // progress bar and loading label
-    const loading = new Label({
-        text: 'Loading...'
-    });
-    panel.append(loading);
-
-    const progressBar = new Progress({ value: 100 });
-    progressBar.hidden = true;
-    panel.append(progressBar);
 
     const primaryBuildHeader = new Container({
         flex: true,
@@ -170,6 +166,43 @@ editor.once('load', () => {
     });
     historyHeader.append(filterBar);
 
+    // shimmer placeholder rows shown while builds load
+    const skeleton = new Container({
+        class: 'builds-skeleton',
+        hidden: true
+    });
+    for (let i = 0; i < 4; i++) {
+        const row = document.createElement('div');
+        row.classList.add('skeleton-row');
+
+        const dot = document.createElement('span');
+        dot.classList.add('bone', 'dot');
+        row.appendChild(dot);
+
+        const body = document.createElement('div');
+        body.classList.add('skeleton-body');
+        row.appendChild(body);
+
+        const title = document.createElement('span');
+        title.classList.add('bone', 'line', 'title');
+        body.appendChild(title);
+
+        const sub = document.createElement('span');
+        sub.classList.add('bone', 'line', 'sub');
+        body.appendChild(sub);
+
+        const pill = document.createElement('span');
+        pill.classList.add('bone', 'pill');
+        row.appendChild(pill);
+
+        const meta = document.createElement('span');
+        meta.classList.add('bone', 'line', 'meta');
+        row.appendChild(meta);
+
+        skeleton.dom.appendChild(row);
+    }
+    panel.append(skeleton);
+
     // no builds message
     let noBuildsText = 'You have not created any builds.';
     if (!projectSettings.get('useLegacyScripts')) {
@@ -183,11 +216,25 @@ editor.once('load', () => {
     });
     panel.append(noBuilds);
 
-    const noMatchingBuilds = new Label({
-        text: 'No builds match the selected filters.',
-        class: ['no-builds-label', 'no-filtered-builds-label'],
+    const noMatchingBuilds = new Container({
+        class: 'no-filtered-builds-label',
         hidden: true
     });
+
+    const noMatchingText = new Label({
+        text: 'No builds match the selected filters.'
+    });
+    noMatchingBuilds.append(noMatchingText);
+
+    const clearFilters = document.createElement('button');
+    clearFilters.type = 'button';
+    clearFilters.classList.add('clear-filters');
+    clearFilters.textContent = 'Clear filters';
+    clearFilters.addEventListener('click', () => {
+        resetBuildFilters();
+        refreshFilterVisibility();
+    });
+    noMatchingBuilds.dom.appendChild(clearFilters);
 
     // container for builds
     const container = new Container({ class: 'builds-list' });
@@ -330,8 +377,7 @@ editor.once('load', () => {
     // UI
 
     const toggleProgress = function (toggle: boolean) {
-        loading.hidden = !toggle;
-        progressBar.hidden = !toggle;
+        skeleton.hidden = !toggle;
         container.hidden = toggle || apps.length === 0;
         primaryBuildHeading.hidden = true;
         primaryBuild.hidden = true;
@@ -669,6 +715,24 @@ editor.once('load', () => {
     });
     updateFilterButtons();
 
+    // GitHub-style copy button; swaps to a check while the copy is fresh
+    const createCopyButton = function (text: string, label: string = 'Copy') {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.classList.add('copy-button');
+        btn.title = label;
+        btn.setAttribute('aria-label', label);
+        btn.addEventListener('click', (e: MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigator.clipboard.writeText(text).then(() => {
+                btn.classList.add('copied');
+                setTimeout(() => btn.classList.remove('copied'), 1500);
+            }, () => {});
+        });
+        return btn;
+    };
+
     const createValue = function (row: any) {
         const value = row.value;
         const val = document.createElement('span');
@@ -683,6 +747,9 @@ editor.once('load', () => {
             val.appendChild(value);
         } else {
             val.textContent = String(value);
+        }
+        if (row.copy) {
+            val.appendChild(createCopyButton(String(row.copy)));
         }
         return val;
     };
@@ -720,31 +787,19 @@ editor.once('load', () => {
         return section;
     };
 
+    // checklist of all build options with on / off state
     const getBuildOptions = function (settings: any) {
-        const options = [];
-        if (settings.scripts_concatenate) {
-            options.push('Concatenate scripts');
-        }
-        if (settings.scripts_minify) {
-            options.push('Minify scripts');
-        }
-        if (settings.scripts_sourcemaps) {
-            options.push('Source maps');
-        }
-        if (settings.optimize_scene_format) {
-            options.push('Optimize scene format');
-        }
-        if (!options.length) {
-            return 'None';
-        }
-
         const list = document.createElement('span');
-        list.classList.add('metadata-list');
+        list.classList.add('options-list');
         list.setAttribute('role', 'list');
-        options.forEach((option) => {
+        BUILD_OPTIONS.forEach(([key, label]) => {
             const item = document.createElement('span');
             item.setAttribute('role', 'listitem');
-            item.textContent = option;
+            item.classList.add('option');
+            if (!settings[key]) {
+                item.classList.add('off');
+            }
+            item.textContent = label;
             list.appendChild(item);
         });
         return list;
@@ -813,6 +868,73 @@ editor.once('load', () => {
         return section;
     };
 
+    // created → build → completed step strip derived from the build timestamps
+    const createTimeline = function (app: any) {
+        const section = document.createElement('section');
+        section.classList.add('detail-section', 'timeline-section');
+
+        const heading = document.createElement('h3');
+        heading.textContent = 'Timeline';
+        section.appendChild(heading);
+
+        const strip = document.createElement('div');
+        strip.classList.add('timeline');
+        section.appendChild(strip);
+
+        const status = app.task.status;
+        const duration = app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null;
+        const buildState = status === 'running' ? 'active' :
+            status === 'error' ? 'failed' :
+                status === 'complete' ? 'done' : 'pending';
+        const steps = [{
+            label: 'Created',
+            state: app.created_at ? 'done' : 'pending',
+            sub: app.created_at ? formatBuildDate(app.created_at) : null
+        }, {
+            label: 'Build',
+            state: buildState,
+            sub: status === 'running' ? 'In progress' : duration
+        }, {
+            label: 'Completed',
+            state: status === 'complete' ? 'done' : 'pending',
+            sub: status === 'complete' && app.completed_at ? formatBuildDate(app.completed_at) : null
+        }];
+
+        steps.forEach((step, i) => {
+            if (i) {
+                const connector = document.createElement('span');
+                connector.classList.add('connector');
+                strip.appendChild(connector);
+            }
+
+            const item = document.createElement('div');
+            item.classList.add('step', step.state);
+            strip.appendChild(item);
+
+            const head = document.createElement('div');
+            head.classList.add('step-head');
+            item.appendChild(head);
+
+            const dot = document.createElement('span');
+            dot.classList.add('dot');
+            head.appendChild(dot);
+
+            const label = document.createElement('span');
+            label.classList.add('step-label');
+            label.textContent = step.label;
+            head.appendChild(label);
+
+            if (step.sub) {
+                const sub = document.createElement('div');
+                sub.classList.add('step-sub');
+                sub.textContent = step.sub;
+                item.appendChild(sub);
+            }
+        });
+
+        return section;
+    };
+
     const createDetails = function (app: any) {
         const settings = app.settings || {};
         const artifacts = app.artifacts || [];
@@ -822,6 +944,8 @@ editor.once('load', () => {
         const details = document.createElement('div');
         details.classList.add('detail-body');
 
+        details.appendChild(createTimeline(app));
+
         details.appendChild(createSection('Build info', [{
             label: 'Status',
             value: getStatusLabel(app),
@@ -829,11 +953,13 @@ editor.once('load', () => {
         }, {
             label: 'Build',
             value: app.build_job_id ? `#${app.build_job_id}` : null,
-            variant: 'code'
+            variant: 'code',
+            copy: app.build_job_id
         }, {
             label: 'Job',
             value: app.job_id ? `#${app.job_id}` : null,
-            variant: 'code'
+            variant: 'code',
+            copy: app.job_id
         }, {
             label: 'Created',
             value: app.created_at ? convertDatetime(app.created_at) : null
@@ -879,7 +1005,8 @@ editor.once('load', () => {
             variant: 'code'
         }, {
             label: 'Branch',
-            value: app.branch && app.branch.name || 'main'
+            value: getBranchLabel(app),
+            variant: 'branch'
         }, {
             label: 'Source',
             value: source,
@@ -1041,6 +1168,8 @@ editor.once('load', () => {
             artifact.rel = 'noopener';
             artifact.textContent = app.type === 'publish' ? 'Open' : 'Download';
             actions.appendChild(artifact);
+
+            actions.appendChild(createCopyButton(app.url, 'Copy URL'));
         }
 
         if (canPrimary) {
@@ -1343,13 +1472,19 @@ editor.once('load', () => {
         body.appendChild(sub);
 
         if (app.url) {
+            const urlRow = document.createElement('div');
+            urlRow.classList.add('url-row');
+            body.appendChild(urlRow);
+
             const link = document.createElement('a');
             link.classList.add('url');
             link.href = app.url;
             link.target = '_blank';
             link.rel = 'noopener';
             link.textContent = app.url;
-            body.appendChild(link);
+            urlRow.appendChild(link);
+
+            urlRow.appendChild(createCopyButton(app.url, 'Copy URL'));
         }
 
         const open = document.createElement('a');
@@ -1451,8 +1586,7 @@ editor.once('load', () => {
         destroyTooltips();
         destroyEvents();
         destroyDetailEvents();
-        loading.hidden = true;
-        progressBar.hidden = true;
+        skeleton.hidden = true;
         container.hidden = true;
         primaryBuildHeading.hidden = true;
         primaryBuild.hidden = true;

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -121,6 +121,7 @@ editor.once('load', () => {
 
     const btnDownload = new Button({
         text: 'Download',
+        icon: 'E245',
         class: 'download'
     });
     handlePermissions(btnDownload);
@@ -133,6 +134,7 @@ editor.once('load', () => {
 
     const btnPublish = new Button({
         text: 'Publish',
+        icon: 'E226',
         class: 'publish'
     });
     handlePermissions(btnPublish);

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -68,17 +68,22 @@ editor.once('load', () => {
     });
     panel.append(loading);
 
-    const progressBar = new Progress({ progress: 1 });
+    const progressBar = new Progress({ value: 100 });
     progressBar.hidden = true;
     panel.append(progressBar);
 
-    // published build section
-    const publishedBuild = new Label({
-        text: `Your primary build is available at <a href="${config.project.playUrl}" target="_blank">${config.project.playUrl}</a>.`,
-        unsafe: true
+    const primaryBuildHeading = new Label({
+        text: 'Primary build',
+        class: 'primary-build-heading',
+        hidden: true
     });
-    publishedBuild.class.add('build');
-    panel.append(publishedBuild);
+    panel.append(primaryBuildHeading);
+
+    const primaryBuild = new LegacyList();
+    primaryBuild.class.add('primary-build-summary');
+    primaryBuild.selectable = false;
+    primaryBuild.hidden = true;
+    panel.append(primaryBuild);
 
     // publish buttons container
     const publishButtons = new Container({
@@ -155,13 +160,13 @@ editor.once('load', () => {
 
     // Existing builds label
     const existingBuildsLabel = new Label({
-        text: 'Existing builds',
+        text: 'Build history',
         class: 'builds-list-heading'
     });
     panel.append(existingBuildsLabel);
 
     // no builds message
-    let noBuildsText = 'You have not published any builds.';
+    let noBuildsText = 'You have not created any builds.';
     if (!projectSettings.get('useLegacyScripts')) {
         noBuildsText += ' Click PUBLISH to create a new build.';
     }
@@ -175,6 +180,7 @@ editor.once('load', () => {
 
     // container for builds
     const container = new LegacyList();
+    container.selectable = false;
     panel.append(container);
 
     // load more builds button
@@ -186,8 +192,8 @@ editor.once('load', () => {
     handlePermissions(loadMore);
     let skip = 0;
     loadMore.on('click', () => {
-        editor.api.globals.rest.projects.projectApps(APP_LIMIT, skip += APP_LIMIT).on('load', (status, data) => {
-            const results = data.result;
+        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip += APP_LIMIT).on('load', (status, data) => {
+            const results = data.result.map(normalizeBuildJob);
             if (results.length === 0) {
                 loadMore.hidden = true;
                 return;
@@ -201,12 +207,16 @@ editor.once('load', () => {
         class: 'picker-builds-menu',
         items: [{
             text: 'Delete',
-            onIsEnabled: () => editor.call('permissions:write'),
+            onIsEnabled: () => editor.call('permissions:write') && !!dropdownApp?.build_job_id,
             onSelect: () => {
+                if (!dropdownApp?.build_job_id) {
+                    return;
+                }
+
                 editor.call('picker:confirm', 'Are you sure you want to delete this build?');
                 editor.once('picker:confirm:yes', () => {
                     removeApp(dropdownApp);
-                    editor.api.globals.rest.apps.appDelete(dropdownApp.id);
+                    editor.api.globals.rest.projects.projectBuildDelete(dropdownApp.build_job_id);
                 });
             }
         }]
@@ -247,135 +257,281 @@ editor.once('load', () => {
         loading.hidden = !toggle;
         progressBar.hidden = !toggle;
         container.hidden = toggle || apps.length === 0;
-        publishedBuild.hidden = toggle || !config.project.primaryApp;
+        primaryBuildHeading.hidden = true;
+        primaryBuild.hidden = true;
         noBuilds.hidden = toggle || apps.length > 0;
     };
 
+    const normalizeBuildJob = function (job: any) {
+        const settings = job.settings || {};
+        const artifacts = job.artifacts || [];
+        const artifact = artifacts[0];
+
+        return {
+            id: job.app_id || `job-${job.id}`,
+            app_id: job.app_id,
+            job_id: job.job_id,
+            build_job_id: job.id,
+            type: job.type,
+            actor: job.actor,
+            settings,
+            artifacts,
+            branch: job.branch,
+            name: settings.name || 'Untitled',
+            version: settings.version || settings.format,
+            release_notes: settings.release_notes || '',
+            created_at: job.created_at,
+            completed_at: job.completed_at,
+            duration_ms: job.duration_ms,
+            source: job.source,
+            size: artifact && artifact.bytes !== undefined ? artifact.bytes : null,
+            views: 0,
+            url: artifact && artifact.url,
+            task: {
+                status: job.status,
+                message: job.message || ''
+            }
+        };
+    };
+
+    const createDetails = function (app: any) {
+        const details = document.createElement('div');
+        details.classList.add('details');
+        details.hidden = true;
+
+        const add = function (label: string, value: any) {
+            if (value === undefined || value === null || value === '') {
+                return;
+            }
+
+            const row = document.createElement('div');
+            row.classList.add('detail-row');
+
+            const key = document.createElement('span');
+            key.classList.add('key');
+            key.textContent = label;
+            row.appendChild(key);
+
+            const val = document.createElement('span');
+            val.classList.add('value');
+            val.textContent = value;
+            row.appendChild(val);
+
+            details.appendChild(row);
+        };
+
+        const settings = app.settings || {};
+        add('Type', app.type === 'publish' ? 'Publish' : 'Download');
+        add('Format', settings.format);
+        add('Engine', settings.engine_version);
+        add('Branch', app.branch && app.branch.name);
+        add('Created by', app.actor && (app.actor.name || app.actor.username));
+        add('Source', app.source && app.source.type);
+        add('Duration', app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null);
+        add('Release notes', app.release_notes);
+
+        if (settings.scenes && settings.scenes.length) {
+            add('Scenes', settings.scenes.map(scene => `${scene.name} (${scene.id})`).join(', '));
+        }
+
+        const options = [];
+        if (settings.scripts_concatenate) {
+            options.push('Concatenate scripts');
+        }
+        if (settings.scripts_minify) {
+            options.push('Minify scripts');
+        }
+        if (settings.scripts_sourcemaps) {
+            options.push('Source maps');
+        }
+        if (settings.optimize_scene_format) {
+            options.push('Optimize scene format');
+        }
+        add('Options', options.length ? options.join(', ') : 'None');
+
+        if (app.artifacts && app.artifacts.length) {
+            app.artifacts.forEach((artifact) => {
+                const row = document.createElement('div');
+                row.classList.add('detail-row');
+
+                const key = document.createElement('span');
+                key.classList.add('key');
+                key.textContent = 'Artifact';
+                row.appendChild(key);
+
+                const val = document.createElement('span');
+                val.classList.add('value');
+                const link = document.createElement('a');
+                link.href = artifact.url;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = artifact.type === 'app' ? 'Open app' : 'Download';
+                val.appendChild(link);
+
+                if (artifact.bytes !== null && artifact.bytes !== undefined) {
+                    const bytes = document.createTextNode(` (${bytesToHuman(artifact.bytes)})`);
+                    val.appendChild(bytes);
+                }
+
+                row.appendChild(val);
+                details.appendChild(row);
+            });
+        }
+
+        return details;
+    };
+
     // create UI for single app
-    const createAppItem = function (app: Record<string, unknown>) {
+    const createAppItem = function (app: any, list: LegacyList = container, options: any = {}) {
         const item = new LegacyListItem();
-        item.element.id = `app-${app.id}`;
+        item.element.id = options.summary ? `primary-app-${app.id}` : `app-${app.id}`;
 
-        container.append(item);
+        list.append(item);
 
-        if (config.project.primaryApp === app.id) {
+        const canPublish = !options.summary && app.type === 'publish' && !!app.app_id;
+        const canDelete = !options.summary && !!app.build_job_id;
+
+        if (config.project.primaryApp === app.app_id || config.project.primaryApp === app.id) {
             item.class.add('primary');
         }
 
         item.class.add(app.task.status);
+        item.class.add(app.type);
 
-        // primary app button
-        const primary = new Button({
-            icon: 'E223',
-            class: 'primary'
-        });
-        events.push(handlePermissions(primary));
-        if (primary.enabled && app.task.status !== 'complete') {
-            primary.enabled = false;
-        }
-        item.element.appendChild(primary.dom);
+        const row = document.createElement('div');
+        row.classList.add('build-row');
+        item.element.appendChild(row);
 
-        // set primary app
-        events.push(primary.on('click', () => {
-            if (config.project.primaryApp === app.id || app.task.status !== 'complete') {
-                return;
-            }
-
-            editor.call('projects:setPrimaryApp', app.id, null, () => {
-                // error - refresh apps again to go back to previous state
-                refreshApps();
-            });
-
-            // refresh apps instantly
-            refreshApps();
-
-            // collapse publish and download buttons
-            toggleCollapsingPublishButtons(true);
-        }));
-
-        // primary icon tooltip
-        const tooltipText = config.project.primaryApp === app.id ? 'Primary build' : 'Change the projects\'s primary build';
-        const tooltip = LegacyTooltip.attach({
-            target: primary.dom,
-            text: tooltipText,
-            align: 'right',
-            root: editor.call('layout.root')
-        });
-        tooltips.push(tooltip);
-
-        // status icon or image
         const status = document.createElement('span');
         status.classList.add('status');
-        item.element.appendChild(status);
-
-        let img;
-
+        status.classList.add(app.task.status);
         if (app.task.status === 'complete') {
-            img = new Image();
-            img.src = app.thumbnails ? app.thumbnails.s : (config.project.thumbnails.s || `${config.url.static}/platform/images/common/blank_project.png`);
-            status.appendChild(img);
-        } else if (app.task.status === 'running') {
-            img = new Image();
-            img.src = `${config.url.static}/platform/images/common/ajax-loader.gif`;
-            status.appendChild(img);
+            status.setAttribute('aria-label', 'Succeeded');
+        } else if (app.task.status === 'error') {
+            status.setAttribute('aria-label', 'Failed');
         }
+        row.appendChild(status);
+
+        const body = document.createElement('div');
+        body.classList.add('body');
+        row.appendChild(body);
 
         const nameRow = document.createElement('div');
         nameRow.classList.add('name-row');
-        item.element.appendChild(nameRow);
+        body.appendChild(nameRow);
 
-        // app name
         const name = new Label({
             text: app.name,
             class: 'name'
         });
         nameRow.appendChild(name.dom);
 
-        // app version
-        const version = new Label({
-            text: app.version,
-            class: 'version'
+        const type = document.createElement('span');
+        type.classList.add('badge');
+        type.classList.add(app.type);
+        type.textContent = app.type === 'publish' ? 'Publish' : 'Download';
+        nameRow.appendChild(type);
+
+        const format = document.createElement('span');
+        format.classList.add('badge');
+        format.textContent = app.settings && app.settings.format || app.version || app.type;
+        nameRow.appendChild(format);
+
+        if (config.project.primaryApp === app.app_id) {
+            const primaryBadge = document.createElement('span');
+            primaryBadge.classList.add('badge');
+            primaryBadge.classList.add('primary-badge');
+            primaryBadge.textContent = 'Primary';
+            nameRow.appendChild(primaryBadge);
+        }
+
+        const meta = document.createElement('div');
+        meta.classList.add('meta');
+        body.appendChild(meta);
+
+        const addMeta = function (value: any, cls?: string) {
+            if (value === undefined || value === null || value === '') {
+                return null;
+            }
+
+            const span = document.createElement('span');
+            span.classList.add('meta-item');
+            if (cls) {
+                span.classList.add(cls);
+            }
+            span.textContent = value;
+            meta.appendChild(span);
+            return span;
+        };
+
+        addMeta(app.task.status === 'complete' ? 'Succeeded' : (app.task.status === 'error' ? 'Failed' : 'In progress'), 'state');
+        addMeta(app.build_job_id ? `#${app.build_job_id}` : null, 'run');
+        addMeta(convertDatetime(app.created_at), 'date');
+        addMeta(app.actor && (app.actor.name || app.actor.username), 'actor');
+        addMeta(app.branch && app.branch.name || 'main', 'branch');
+        addMeta(app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null, 'duration');
+        addMeta(app.size === null ? null : bytesToHuman(app.size), 'size');
+
+        const actions = document.createElement('div');
+        actions.classList.add('actions');
+        const stopActions = function (e: MouseEvent) {
+            e.stopPropagation();
+        };
+        actions.addEventListener('click', stopActions);
+        events.push({
+            unbind: () => {
+                actions.removeEventListener('click', stopActions);
+            }
         });
-        nameRow.appendChild(version.dom);
+        row.appendChild(actions);
 
-        // row below name
-        const info = document.createElement('div');
-        info.classList.add('info');
-        item.element.appendChild(info);
-
-        // date
-        const date = new Label({
-            text: convertDatetime(app.created_at),
-            class: 'date',
-            hidden: app.task.status === 'error'
+        const primary = new Button({
+            icon: 'E223',
+            class: 'primary'
         });
-        info.appendChild(date.dom);
+        events.push(handlePermissions(primary));
+        primary.hidden = options.summary || !canPublish;
+        if (primary.enabled && (!canPublish || app.task.status !== 'complete')) {
+            primary.enabled = false;
+        }
+        actions.appendChild(primary.dom);
 
-        // views
-        const views = new Label({
-            text: numberWithCommas(app.views),
-            class: 'views',
-            hidden: app.task.status !== 'complete'
-        });
-        info.appendChild(views.dom);
+        events.push(primary.on('click', (e?: MouseEvent) => {
+            e?.stopPropagation();
 
-        // size
-        const size = new Label({
-            text: bytesToHuman(app.size),
-            class: 'size',
-            hidden: app.task.status !== 'complete'
-        });
-        info.appendChild(size.dom);
+            if (!canPublish || config.project.primaryApp === app.app_id || app.task.status !== 'complete') {
+                return;
+            }
 
-        // branch
-        const branch = new Label({
-            text: app.branch && app.branch.name || 'main',
-            class: 'branch',
-            hidden: app.task.status !== 'complete' || projectSettings.get('useLegacyScripts')
-        });
-        info.appendChild(branch.dom);
+            editor.call('projects:setPrimaryApp', app.app_id, null, () => {
+                refreshApps();
+            });
 
-        // error message
+            refreshApps();
+            toggleCollapsingPublishButtons(true);
+        }));
+
+        if (canPublish) {
+            const tooltipText = config.project.primaryApp === app.app_id ? 'Primary build' : 'Change the projects\'s primary build';
+            const tooltip = LegacyTooltip.attach({
+                target: primary.dom,
+                text: tooltipText,
+                align: 'right',
+                root: editor.call('layout.root')
+            });
+            tooltips.push(tooltip);
+        }
+
+        if (app.task.status === 'complete' && app.url) {
+            const artifact = document.createElement('a');
+            artifact.classList.add('artifact');
+            artifact.href = app.url;
+            artifact.target = '_blank';
+            artifact.rel = 'noopener';
+            artifact.textContent = app.type === 'publish' ? 'Open' : 'Download';
+            actions.appendChild(artifact);
+        }
+
         const error = new Label({
             text: app.task.message,
             class: 'error',
@@ -383,103 +539,87 @@ editor.once('load', () => {
         });
         item.element.appendChild(error.dom);
 
-        // release notes
-        let releaseNotes = app.release_notes || '';
-        const indexOfNewLine = releaseNotes.indexOf('\n');
-        if (indexOfNewLine !== -1) {
-            releaseNotes = releaseNotes.substring(0, indexOfNewLine);
-        }
-        const notes = new Label({
-            text: app.release_notes,
-            class: 'notes',
-            hidden: !error.hidden,
-            renderChanges: false
-        });
-        item.element.appendChild(notes.dom);
+        const dropdown = document.createElement('button');
+        dropdown.type = 'button';
+        dropdown.classList.add('action-button');
+        dropdown.classList.add('dropdown');
+        dropdown.innerHTML = '&#57689;';
+        dropdown.hidden = !canDelete;
+        dropdown.setAttribute('aria-label', 'Build actions');
+        actions.appendChild(dropdown);
 
-        // dropdown
-        const dropdown = new Button({
-            class: 'dropdown'
-        });
-        dropdown.dom.innerHTML = '&#57689;';
-        item.element.appendChild(dropdown.dom);
+        const openMenu = function (e: MouseEvent) {
+            e.preventDefault();
+            e.stopPropagation();
 
-        events.push(dropdown.on('click', () => {
-            dropdown.class.add('clicked');
-            // change arrow
-            dropdown.dom.innerHTML = '&#57687;';
+            dropdown.classList.add('clicked');
+            dropdown.innerHTML = '&#57687;';
             dropdownApp = app;
 
-            // open menu
             dropdownMenu.hidden = false;
 
-            // position dropdown menu
-            const rect = dropdown.dom.getBoundingClientRect();
+            const rect = dropdown.getBoundingClientRect();
             const menuItems = dropdownMenu.dom.querySelector('.pcui-menu-items') as HTMLElement;
             dropdownMenu.position(rect.right - menuItems.clientWidth, rect.bottom);
-        }));
-
-        const more = new Button({
-            text: 'more...',
-            class: 'more',
-            hidden: true
-        });
-        item.element.appendChild(more.dom);
-
-        events.push(more.on('click', () => {
-            if (notes.class.contains('no-wrap')) {
-                notes.text = app.release_notes;
-                notes.class.remove('no-wrap');
-                more.text = 'less...';
-            } else {
-                notes.class.add('no-wrap');
-                more.text = 'more...';
-                notes.text = releaseNotes;
+            dropdownMenu.focus();
+        };
+        dropdown.addEventListener('click', openMenu);
+        events.push({
+            unbind: () => {
+                dropdown.removeEventListener('click', openMenu);
             }
-        }));
+        });
 
-        if (notes.dom.clientHeight > 22) {
-            more.hidden = false;
-            notes.class.add('no-wrap');
-            notes.text = releaseNotes;
-        }
+        const details = createDetails(app);
+        item.element.appendChild(details);
 
-        if (app.task.status === 'complete') {
-            // handle row click
-            const validTargets = [
-                status,
-                img,
-                info,
-                item.element,
-                name.dom,
-                date.dom,
-                size.dom,
-                views.dom,
-                notes.dom
-            ];
+        const expand = document.createElement('button');
+        expand.type = 'button';
+        expand.classList.add('action-button');
+        expand.classList.add('expander');
+        expand.innerHTML = '&#57689;';
+        expand.setAttribute('aria-label', 'Show build details');
+        actions.appendChild(expand);
 
-            events.push(item.on('click', (e) => {
-                if (validTargets.indexOf(e.target) !== -1) {
-                    e.stopPropagation();
-                    window.open(app.url);
-                }
-            }));
-        }
+        const toggleDetails = function () {
+            details.hidden = !details.hidden;
+            expand.innerHTML = details.hidden ? '&#57689;' : '&#57687;';
+            expand.setAttribute('aria-label', details.hidden ? 'Show build details' : 'Hide build details');
+        };
 
+        events.push(item.on('click', toggleDetails));
+
+        const expandDetails = function (e: MouseEvent) {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleDetails();
+        };
+        expand.addEventListener('click', expandDetails);
+        events.push({
+            unbind: () => {
+                expand.removeEventListener('click', expandDetails);
+            }
+        });
 
         return item;
     };
 
     // CONTROLLERS
 
-    // load app list
-    const loadApps = function () {
-        toggleProgress(true);
+    // load build job list
+    const loadApps = function (showProgress: boolean = true) {
+        skip = 0;
 
-        editor.api.globals.rest.projects.projectApps().on('load', (status, data) => {
-            const results = data.result;
+        if (showProgress) {
+            toggleProgress(true);
+        }
+
+        editor.api.globals.rest.projects.projectBuilds().on('load', (status, data) => {
+            const results = data.result.map(normalizeBuildJob);
             apps = results;
-            toggleProgress(false);
+            if (showProgress) {
+                toggleProgress(false);
+            }
 
             if (apps.length > 0) {
                 panelPlaycanvas.class.add('collapsed');
@@ -493,7 +633,7 @@ editor.once('load', () => {
     };
 
     // removes an app from the UI
-    const removeApp = function (app: { id: string }) {
+    const removeApp = function (app: any) {
         const item = document.getElementById(`app-${app.id}`);
         if (item) {
             item.remove();
@@ -515,38 +655,38 @@ editor.once('load', () => {
         container.hidden = apps.length === 0;
     };
 
+    const removeBuildJob = function (id: number) {
+        const app = apps.find(item => item.build_job_id === id);
+        if (app) {
+            removeApp(app);
+        }
+    };
+
     // recreate app list UI
     const refreshApps = function () {
         dropdownMenu.hidden = true;
         destroyTooltips();
         destroyEvents();
+        primaryBuild.element.innerHTML = '';
         container.element.innerHTML = '';
-        hoistPrimaryBuild(apps);
+        renderPrimaryBuild();
         container.hidden = apps.length === 0;
         loadMore.hidden = apps.length === 0;
-        apps.forEach(createAppItem);
+        apps.forEach((app) => {
+            createAppItem(app);
+        });
     };
 
     // LOCAL UTILS
 
-    // hoists primary app to the top of the list
-    const hoistPrimaryBuild = function (apps: { id: string }[]) {
-        return apps.sort((a, b) => {
-            if (config.project.primaryApp === a.id) {
-                return -1;
-            }
-            if (config.project.primaryApp === b.id) {
-                return 1;
-            }
-            return 0;
-        });
-    };
+    const renderPrimaryBuild = function () {
+        const app = apps.find(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
+        primaryBuildHeading.hidden = !app;
+        primaryBuild.hidden = !app;
 
-    // adds commas every 3 decimals
-    const numberWithCommas = function (number: number) {
-        const parts = number.toString().split('.');
-        parts[0] = parts[0].replace(/\B(?=(?:\d{3})+(?!\d))/g, ',');
-        return parts.join('.');
+        if (app) {
+            createAppItem(app, primaryBuild, { summary: true });
+        }
     };
 
     const destroyTooltips = function () {
@@ -571,44 +711,16 @@ editor.once('load', () => {
             return;
         }
 
-        if (!newValue) {
-            publishedBuild.hidden = true;
-            return;
-        }
-
-        publishedBuild.hidden = false;
-
-        // check if we need to refresh UI
-        const currentPrimary = document.getElementById(`app-${newValue}`);
-        if (currentPrimary && currentPrimary.classList.contains('primary')) {
-            return;
-        }
-
         refreshApps();
     });
 
     // handle app created externally
-    editor.on('messenger:app.new', (data) => {
+    editor.on('messenger:app.new', () => {
         if (panel.hidden) {
             return;
         }
 
-        // get app from server
-        editor.api.globals.rest.apps.appGet(data.app.id).on('load', (status, app) => {
-            // add app if it's not already inside the apps array
-            let found = false;
-            for (let i = 0; i < apps.length; i++) {
-                if (apps[i].id === data.app.id) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                apps.push(app);
-                refreshApps();
-            }
-        });
+        loadApps();
     });
 
     // handle external delete
@@ -620,21 +732,29 @@ editor.once('load', () => {
         removeApp(data.app);
     });
 
+    editor.on('messenger:build_job.delete', (data) => {
+        if (panel.hidden || !data.build_job) {
+            return;
+        }
+
+        removeBuildJob(Number(data.build_job.id));
+    });
+
     // handle external app updates
-    editor.on('messenger:app.update', (data) => {
+    editor.on('messenger:app.update', () => {
         if (panel.hidden) {
             return;
         }
 
-        // get app from server
-        editor.api.globals.rest.apps.appGet(data.app.id).on('load', (status, app) => {
-            for (let i = 0; i < apps.length; i++) {
-                if (apps[i].id === app.id) {
-                    apps[i] = app;
-                }
-            }
-            refreshApps();
-        });
+        loadApps();
+    });
+
+    editor.on('messenger:job.update', (msg: any) => {
+        if (panel.hidden || !msg.job || !apps.some(app => app.job_id === Number(msg.job.id))) {
+            return;
+        }
+
+        loadApps(false);
     });
 
     // open publishing popup

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -4,6 +4,21 @@ import { bytesToHuman, convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
 const APP_LIMIT = 16;
+const DUMMY_LEGACY_APP = {
+    id: -1,
+    sample: true,
+    name: 'Legacy published app sample',
+    description: 'temporary manual legacy build description',
+    version: '1.0.0',
+    release_notes: 'temporary manual legacy build sample',
+    size: 7340032,
+    views: 42,
+    url: 'https://playcanv.as/b/legacy-sample',
+    task: { status: 'complete', message: '' },
+    created_at: new Date(Date.now() - 86400000).toISOString(),
+    completed_at: new Date(Date.now() - 86340000).toISOString(),
+    branch: { id: 'legacy', name: 'main' }
+};
 
 editor.once('load', () => {
     // global variables
@@ -12,8 +27,14 @@ editor.once('load', () => {
     let menuApp = null;  // app whose row action menu is open
     let activeKebab = null;  // kebab button that opened the menu
     let apps = [];  // all loaded builds
+    let appIndex: Record<string, any> = {};
+    let appList = [];
+    let loadedAppIndex = false;
     let tooltips = [];  // holds all tooltips
     let events = [];  // holds events that need to be destroyed
+    let detailEvents = [];  // holds detail panel events
+    let openingDetail = false;
+    let openingBuilds = false;
 
     // disables / enables field depending on permissions
     const handlePermissions = function (field: { enabled: boolean }) {
@@ -33,12 +54,35 @@ editor.once('load', () => {
         class: 'picker-builds-publish'
     });
 
+    // progress bar and loading label
+    const loading = new Label({
+        text: 'Loading...'
+    });
+    panel.append(loading);
+
+    const progressBar = new Progress({ value: 100 });
+    progressBar.hidden = true;
+    panel.append(progressBar);
+
+    const primaryBuildHeader = new Container({
+        flex: true,
+        class: 'primary-build-header'
+    });
+    panel.append(primaryBuildHeader);
+
+    const primaryBuildHeading = new Label({
+        text: 'Primary build',
+        class: 'primary-build-heading',
+        hidden: true
+    });
+    primaryBuildHeader.append(primaryBuildHeading);
+
     // top toolbar: publish (primary) + download (secondary)
     const toolbar = new Container({
         flex: true,
         class: 'builds-toolbar'
     });
-    panel.append(toolbar);
+    primaryBuildHeader.append(toolbar);
 
     const btnDownload = new Button({
         text: 'Download .zip',
@@ -56,25 +100,7 @@ editor.once('load', () => {
     btnPublish.on('click', () => editor.call('picker:publish:new'));
     toolbar.append(btnPublish);
 
-    // progress bar and loading label
-    const loading = new Label({
-        text: 'Loading...'
-    });
-    panel.append(loading);
-
-    const progressBar = new Progress({ value: 100 });
-    progressBar.hidden = true;
-    panel.append(progressBar);
-
-    const primaryBuildHeading = new Label({
-        text: 'Primary build',
-        class: 'primary-build-heading',
-        hidden: true
-    });
-    panel.append(primaryBuildHeading);
-
-    const primaryBuild = new Container({ class: 'builds-list' });
-    primaryBuild.class.add('primary-build-summary');
+    const primaryBuild = new Container({ class: 'primary-build-summary' });
     primaryBuild.hidden = true;
     panel.append(primaryBuild);
 
@@ -102,16 +128,10 @@ editor.once('load', () => {
     const container = new Container({ class: 'builds-list' });
     panel.append(container);
 
-    // detail "page" for a single build (hidden until a row is opened)
-    const detailView = new Container({
+    const detailPanel = new Container({
         flex: true,
-        class: 'build-detail',
-        hidden: true
+        class: 'picker-build-detail'
     });
-    panel.append(detailView);
-
-    // list chrome that is hidden while the detail page is open
-    const listChrome = [toolbar, primaryBuildHeading, primaryBuild, existingBuildsLabel, noBuilds, container];
 
     // pagination state for infinite scroll
     let skip = 0;
@@ -128,9 +148,14 @@ editor.once('load', () => {
         editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, skip).on('load', (status, data) => {
             loadingMore = false;
             const results = data.result.map(normalizeBuildJob);
+            const ids = getPublishAppIds(results);
+            if (ids.size) {
+                apps = apps.filter(app => app.build_job_id || app.type !== 'publish' || !ids.has(String(app.app_id)));
+            }
             apps.push(...results);
-            results.forEach(app => createAppItem(app));
-            hasMore = data.pagination ? apps.length < data.pagination.total : results.length === APP_LIMIT;
+            apps.sort(compareBuildDate);
+            hasMore = data.pagination ? skip + results.length < data.pagination.total : results.length === APP_LIMIT;
+            refreshApps();
             fillViewport();
         });
     };
@@ -152,36 +177,58 @@ editor.once('load', () => {
         }
     };
 
+    const isPrimaryBuild = function (app: any) {
+        return !!app && app.type === 'publish' && config.project.primaryApp === app.app_id;
+    };
+
+    const isPickerVisible = function () {
+        return !panel.hidden || !detailPanel.hidden;
+    };
+
+    const canSetPrimaryBuild = function (app: any) {
+        return !!app && app.type === 'publish' && app.task.status === 'complete' && !!app.app_id && !isPrimaryBuild(app);
+    };
+
+    const isSampleBuild = function (app: any) {
+        return app?.source?.sample === true;
+    };
+
+    const canDeleteBuild = function (app: any) {
+        if (!app) {
+            return false;
+        }
+
+        return !!app.build_job_id || isSampleBuild(app) ||
+            (app.type === 'publish' && Number(app.app_id) > 0);
+    };
+
+    const setPrimaryBuild = function (app: any) {
+        if (!editor.call('permissions:write') || !canSetPrimaryBuild(app)) {
+            return;
+        }
+
+        editor.call('projects:setPrimaryApp', String(app.app_id), undefined, refreshApps);
+        refreshApps();
+    };
+
     // shared per-row action menu (opened from the kebab button on each row)
     const rowMenu = new Menu({
         class: 'picker-builds-menu',
         items: [{
-            text: 'Open',
-            class: 'open',
-            onIsVisible: () => menuApp?.type === 'publish' && menuApp?.task.status === 'complete' && !!menuApp?.url,
-            onSelect: () => menuApp?.url && window.open(menuApp.url, '_blank', 'noopener')
-        }, {
-            text: 'Download',
-            class: 'download',
-            onIsVisible: () => menuApp?.type === 'download' && menuApp?.task.status === 'complete' && !!menuApp?.url,
-            onSelect: () => menuApp?.url && window.open(menuApp.url, '_blank', 'noopener')
+            text: 'Set Primary Build',
+            class: 'primary',
+            onIsVisible: () => menuApp?.type === 'publish',
+            onIsEnabled: () => editor.call('permissions:write') && canSetPrimaryBuild(menuApp),
+            onSelect: () => menuApp && setPrimaryBuild(menuApp)
         }, {
             text: 'View',
-            onSelect: () => menuApp && showDetail(menuApp)
+            onSelect: () => menuApp && openBuildDetail(menuApp)
         }, {
             text: 'Delete',
             class: 'delete',
-            onIsEnabled: () => editor.call('permissions:write') && !!menuApp?.build_job_id,
+            onIsEnabled: () => editor.call('permissions:write') && canDeleteBuild(menuApp),
             onSelect: () => {
-                if (!menuApp?.build_job_id) {
-                    return;
-                }
-                const app = menuApp;
-                editor.call('picker:confirm', 'Are you sure you want to delete this build?');
-                editor.once('picker:confirm:yes', () => {
-                    editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
-                    removeApp(app);
-                });
+                deleteBuild(menuApp);
             }
         }]
     });
@@ -206,6 +253,7 @@ editor.once('load', () => {
 
     // register panel with project popup
     editor.call('picker:project:registerMenu', 'builds-publish', 'Builds', panel, 'BUILDS & PUBLISH');
+    editor.call('picker:project:registerPanel', 'build-detail', 'Build Details', detailPanel);
 
     // hide button if the user doesn't have the right permissions
     if (!editor.call('permissions:read')) {
@@ -228,10 +276,55 @@ editor.once('load', () => {
         noBuilds.hidden = toggle || apps.length > 0;
     };
 
+    const loadAppIndex = function (done: () => void) {
+        if (loadedAppIndex) {
+            done();
+            return;
+        }
+
+        editor.api.globals.rest.projects.projectApps().on('load', (status, data) => {
+            appList = (data?.result || []).slice();
+            appIndex = {};
+            appList.forEach((app) => {
+                appIndex[String(app.id)] = app;
+            });
+            const sample = Object.assign({}, DUMMY_LEGACY_APP, {
+                id: config.project.primaryApp && !appIndex[String(config.project.primaryApp)] ?
+                    config.project.primaryApp :
+                    DUMMY_LEGACY_APP.id
+            });
+            appList.push(sample);
+            loadedAppIndex = true;
+            done();
+        });
+    };
+
+    const compareBuildDate = function (a: any, b: any) {
+        const at = new Date(a.created_at || a.completed_at || 0).getTime() || 0;
+        const bt = new Date(b.created_at || b.completed_at || 0).getTime() || 0;
+        return bt - at;
+    };
+
     const normalizeBuildJob = function (job: any) {
-        const settings = job.settings || {};
+        const raw = job.settings || {};
         const artifacts = job.artifacts || [];
         const artifact = artifacts[0];
+        const meta = job.app_id ? appIndex[String(job.app_id)] : null;
+        const name = raw.name || meta?.name || job.app?.name || 'Untitled';
+        const description = raw.description || meta?.description || job.app?.description || '';
+        const version = raw.version || meta?.version || job.app?.version || '';
+        const releaseNotes = raw.release_notes || raw.releaseNotes || meta?.release_notes ||
+            meta?.releaseNotes || job.app?.release_notes || job.app?.releaseNotes || '';
+        const size = artifact && artifact.bytes !== undefined ? artifact.bytes : meta?.size ?? job.app?.size ?? null;
+        const url = artifact && artifact.url || meta?.url || job.app?.url;
+        const rowArtifacts = artifacts.length ? artifacts :
+            url ? [{ type: job.type === 'publish' ? 'app' : job.type, url, bytes: size }] : artifacts;
+        const settings = Object.assign({}, raw, {
+            name,
+            description,
+            version,
+            release_notes: releaseNotes
+        });
 
         return {
             id: job.app_id || `job-${job.id}`,
@@ -241,18 +334,19 @@ editor.once('load', () => {
             type: job.type,
             actor: job.actor,
             settings,
-            artifacts,
+            artifacts: rowArtifacts,
             branch: job.branch,
-            name: settings.name || 'Untitled',
-            version: settings.version || settings.format,
-            release_notes: settings.release_notes || '',
+            name,
+            description,
+            version,
+            release_notes: releaseNotes,
             created_at: job.created_at,
             completed_at: job.completed_at,
             duration_ms: job.duration_ms,
             source: job.source,
-            size: artifact && artifact.bytes !== undefined ? artifact.bytes : null,
-            views: 0,
-            url: artifact && artifact.url,
+            size,
+            views: meta?.views ?? job.app?.views ?? job.views ?? 0,
+            url,
             task: {
                 status: job.status,
                 message: job.message || ''
@@ -260,46 +354,122 @@ editor.once('load', () => {
         };
     };
 
-    const createDetails = function (app: any) {
-        const details = document.createElement('div');
-        details.classList.add('details');
-        details.hidden = true;
+    const normalizeLegacyApp = function (app: any) {
+        const bytes = app.size ?? null;
+        const url = app.url;
+        return {
+            id: app.id,
+            app_id: app.id,
+            build_job_id: null,
+            type: 'publish',
+            settings: {
+                name: app.name,
+                description: app.description,
+                version: app.version,
+                release_notes: app.release_notes || app.releaseNotes,
+                format: 'playcanvas'
+            },
+            artifacts: url ? [{ type: 'app', url, bytes }] : [],
+            branch: app.branch,
+            name: app.name || 'Untitled',
+            description: app.description || '',
+            version: app.version || '',
+            release_notes: app.release_notes || app.releaseNotes || '',
+            created_at: app.created_at,
+            completed_at: app.completed_at,
+            duration_ms: null,
+            source: { type: 'legacy', sample: app.sample === true },
+            size: bytes,
+            views: app.views ?? 0,
+            url,
+            task: app.task || { status: 'complete', message: '' }
+        };
+    };
 
-        const add = function (label: string, value: any) {
+    const getPublishAppIds = function (rows: any[]) {
+        return new Set(rows
+        .filter(item => item.type === 'publish' && item.app_id !== null && item.app_id !== undefined)
+        .map(item => String(item.app_id)));
+    };
+
+    const isSameBuild = function (a: any, b: any) {
+        if (!a || !b) {
+            return false;
+        }
+        if (a.build_job_id && b.build_job_id) {
+            return Number(a.build_job_id) === Number(b.build_job_id);
+        }
+        if (a.app_id && b.app_id) {
+            return String(a.app_id) === String(b.app_id);
+        }
+        return a.id === b.id;
+    };
+
+    const getStatusLabel = function (app: any) {
+        if (app.task.status === 'complete') {
+            return 'Succeeded';
+        }
+        if (app.task.status === 'error') {
+            return 'Failed';
+        }
+        if (app.task.status === 'running') {
+            return 'Running';
+        }
+        return app.task.status || 'Pending';
+    };
+
+    const createValue = function (row: any) {
+        const value = row.value;
+        const val = document.createElement('span');
+        val.classList.add('value');
+        if (row.variant) {
+            val.classList.add(`metadata-${row.variant}`);
+        }
+        if (row.class) {
+            val.classList.add(row.class);
+        }
+        if (value instanceof Node) {
+            val.appendChild(value);
+        } else {
+            val.textContent = String(value);
+        }
+        return val;
+    };
+
+    const createSection = function (title: string, rows: any[]) {
+        const section = document.createElement('section');
+        section.classList.add('detail-section');
+
+        const heading = document.createElement('h3');
+        heading.textContent = title;
+        section.appendChild(heading);
+
+        const grid = document.createElement('div');
+        grid.classList.add('metadata-grid');
+        section.appendChild(grid);
+
+        rows.forEach((row) => {
+            const value = row.value;
             if (value === undefined || value === null || value === '') {
                 return;
             }
 
-            const row = document.createElement('div');
-            row.classList.add('detail-row');
+            const item = document.createElement('div');
+            item.classList.add('detail-row');
 
             const key = document.createElement('span');
             key.classList.add('key');
-            key.textContent = label;
-            row.appendChild(key);
+            key.textContent = row.label;
+            item.appendChild(key);
 
-            const val = document.createElement('span');
-            val.classList.add('value');
-            val.textContent = value;
-            row.appendChild(val);
+            item.appendChild(createValue(row));
+            grid.appendChild(item);
+        });
 
-            details.appendChild(row);
-        };
+        return section;
+    };
 
-        const settings = app.settings || {};
-        add('Type', app.type === 'publish' ? 'Publish' : 'Download');
-        add('Format', settings.format);
-        add('Engine', settings.engine_version);
-        add('Branch', app.branch && app.branch.name);
-        add('Created by', app.actor && (app.actor.name || app.actor.username));
-        add('Source', app.source && app.source.type);
-        add('Duration', app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null);
-        add('Release notes', app.release_notes);
-
-        if (settings.scenes && settings.scenes.length) {
-            add('Scenes', settings.scenes.map(scene => `${scene.name} (${scene.id})`).join(', '));
-        }
-
+    const getBuildOptions = function (settings: any) {
         const options = [];
         if (settings.scripts_concatenate) {
             options.push('Concatenate scripts');
@@ -313,36 +483,173 @@ editor.once('load', () => {
         if (settings.optimize_scene_format) {
             options.push('Optimize scene format');
         }
-        add('Options', options.length ? options.join(', ') : 'None');
-
-        if (app.artifacts && app.artifacts.length) {
-            app.artifacts.forEach((artifact) => {
-                const row = document.createElement('div');
-                row.classList.add('detail-row');
-
-                const key = document.createElement('span');
-                key.classList.add('key');
-                key.textContent = 'Artifact';
-                row.appendChild(key);
-
-                const val = document.createElement('span');
-                val.classList.add('value');
-                const link = document.createElement('a');
-                link.href = artifact.url;
-                link.target = '_blank';
-                link.rel = 'noopener';
-                link.textContent = artifact.type === 'app' ? 'Open app' : 'Download';
-                val.appendChild(link);
-
-                if (artifact.bytes !== null && artifact.bytes !== undefined) {
-                    const bytes = document.createTextNode(` (${bytesToHuman(artifact.bytes)})`);
-                    val.appendChild(bytes);
-                }
-
-                row.appendChild(val);
-                details.appendChild(row);
-            });
+        if (!options.length) {
+            return 'None';
         }
+
+        const list = document.createElement('span');
+        list.classList.add('metadata-list');
+        list.setAttribute('role', 'list');
+        options.forEach((option) => {
+            const item = document.createElement('span');
+            item.setAttribute('role', 'listitem');
+            item.textContent = option;
+            list.appendChild(item);
+        });
+        return list;
+    };
+
+    const createArtifactCard = function (app: any, artifact: any) {
+        const card = document.createElement('div');
+        card.classList.add('artifact-card', app.type === 'download' ? 'zip' : 'app');
+
+        const icon = document.createElement('span');
+        icon.classList.add('artifact-icon');
+        card.appendChild(icon);
+
+        const body = document.createElement('div');
+        body.classList.add('artifact-body');
+        card.appendChild(body);
+
+        const title = document.createElement('div');
+        title.classList.add('artifact-title');
+        title.textContent = app.type === 'download' ? 'zip' : 'app';
+        body.appendChild(title);
+
+        if (artifact.bytes !== null && artifact.bytes !== undefined) {
+            const meta = document.createElement('div');
+            meta.classList.add('artifact-meta');
+            meta.textContent = bytesToHuman(artifact.bytes);
+            body.appendChild(meta);
+        }
+
+        if (artifact.url) {
+            const link = document.createElement('a');
+            link.classList.add('artifact-action');
+            link.href = artifact.url;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.textContent = app.type === 'publish' ? 'Open app' : 'Download';
+            card.appendChild(link);
+        }
+
+        return card;
+    };
+
+    const createArtifactSection = function (app: any, artifacts: any[]) {
+        if (!artifacts.length) {
+            return createSection('Artifacts', [{
+                label: 'Artifacts',
+                value: 'None'
+            }]);
+        }
+
+        const section = document.createElement('section');
+        section.classList.add('detail-section', 'artifact-section');
+
+        const heading = document.createElement('h3');
+        heading.textContent = 'Artifacts';
+        section.appendChild(heading);
+
+        const list = document.createElement('div');
+        list.classList.add('artifact-list');
+        section.appendChild(list);
+
+        artifacts.forEach((artifact) => {
+            list.appendChild(createArtifactCard(app, artifact));
+        });
+
+        return section;
+    };
+
+    const createDetails = function (app: any) {
+        const settings = app.settings || {};
+        const artifacts = app.artifacts || [];
+        const scenes = settings.scenes || [];
+        const actor = app.actor && (app.actor.name || app.actor.username);
+        const source = app.source && (app.source.name || app.source.type);
+        const details = document.createElement('div');
+        details.classList.add('detail-body');
+
+        details.appendChild(createSection('Build info', [{
+            label: 'Status',
+            value: getStatusLabel(app),
+            variant: 'badge'
+        }, {
+            label: 'Build',
+            value: app.build_job_id ? `#${app.build_job_id}` : null,
+            variant: 'code'
+        }, {
+            label: 'Job',
+            value: app.job_id ? `#${app.job_id}` : null,
+            variant: 'code'
+        }, {
+            label: 'Created',
+            value: app.created_at ? convertDatetime(app.created_at) : null
+        }, {
+            label: 'Completed',
+            value: app.completed_at ? convertDatetime(app.completed_at) : null
+        }, {
+            label: 'Duration',
+            value: app.duration_ms ? `${Math.round(app.duration_ms / 1000)}s` : null
+        }, {
+            label: 'Created by',
+            value: actor
+        }]));
+
+        if (app.type === 'publish') {
+            details.appendChild(createSection('Publish details', [{
+                label: 'Title',
+                value: app.name
+            }, {
+                label: 'Description',
+                value: app.description
+            }, {
+                label: 'Version',
+                value: app.version
+            }, {
+                label: 'Release notes',
+                value: app.release_notes
+            }]));
+        }
+
+        details.appendChild(createSection('Source and settings', [{
+            label: 'Type',
+            value: app.type === 'publish' ? 'Publish' : 'Download',
+            variant: 'badge',
+            class: app.type
+        }, {
+            label: 'Format',
+            value: settings.format || app.version,
+            variant: 'badge'
+        }, {
+            label: 'Engine',
+            value: settings.engine_version,
+            variant: 'code'
+        }, {
+            label: 'Branch',
+            value: app.branch && app.branch.name || 'main'
+        }, {
+            label: 'Source',
+            value: source,
+            variant: 'badge'
+        }, {
+            label: 'Options',
+            value: getBuildOptions(settings)
+        }]));
+
+        details.appendChild(createSection('Scenes', scenes.length ? scenes.map((scene) => {
+            return {
+                label: scene.name || 'Untitled scene',
+                value: scene.id ? `ID ${scene.id}` : 'Included',
+                variant: scene.id ? 'code' : null
+            };
+        }) : [{
+            label: 'Scenes',
+            value: 'None'
+        }]));
+
+        details.appendChild(createArtifactSection(app, artifacts));
 
         return details;
     };
@@ -367,30 +674,53 @@ editor.once('load', () => {
         return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
     };
 
-    // build the detail "page" for a single build
+    const openBuildsPanel = function () {
+        editor.call('picker:builds-publish');
+    };
+
+    const deleteBuild = function (app: any) {
+        if (!canDeleteBuild(app) || !editor.call('permissions:write')) {
+            return;
+        }
+
+        editor.call('picker:confirm', 'Are you sure you want to delete this build?');
+        editor.once('picker:confirm:yes', () => {
+            if (app.build_job_id) {
+                editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
+            } else if (!isSampleBuild(app)) {
+                editor.api.globals.rest.apps.appDelete(Number(app.app_id));
+            }
+            removeApp(app);
+        });
+    };
+
     const renderDetail = function (app: any) {
-        detailView.element.innerHTML = '';
+        destroyDetailEvents();
+        detailPanel.element.innerHTML = '';
 
         const isComplete = app.task.status === 'complete';
-        const canPublish = app.type === 'publish' && !!app.app_id;
-        const canDelete = !!app.build_job_id;
-        const isPrimary = config.project.primaryApp === app.app_id;
+        const canPrimary = app.type === 'publish' && !!app.app_id;
+        const canDelete = canDeleteBuild(app);
+        const isPrimary = isPrimaryBuild(app);
 
         const back = document.createElement('button');
         back.type = 'button';
         back.classList.add('back');
-        back.textContent = '← Back to builds';
-        back.addEventListener('click', showList);
-        events.push({ unbind: () => back.removeEventListener('click', showList) });
-        detailView.element.appendChild(back);
+        back.textContent = 'Back to builds';
+        back.addEventListener('click', openBuildsPanel);
+        detailEvents.push({ unbind: () => back.removeEventListener('click', openBuildsPanel) });
+        detailPanel.element.appendChild(back);
 
         const header = document.createElement('div');
-        header.classList.add('detail-header');
-        detailView.element.appendChild(header);
+        header.classList.add('detail-hero');
+        detailPanel.element.appendChild(header);
 
-        const status = document.createElement('span');
-        status.classList.add('status', app.task.status);
-        header.appendChild(status);
+        const thumb = document.createElement('img');
+        thumb.classList.add('thumb');
+        thumb.alt = '';
+        thumb.src = config.project.thumbnails && (config.project.thumbnails.m || config.project.thumbnails.s) ||
+            `${config.url.static}/platform/images/common/blank_project.png`;
+        header.appendChild(thumb);
 
         const heading = document.createElement('div');
         heading.classList.add('heading');
@@ -399,6 +729,10 @@ editor.once('load', () => {
         const nameRow = document.createElement('div');
         nameRow.classList.add('name-row');
         heading.appendChild(nameRow);
+
+        const status = document.createElement('span');
+        status.classList.add('status', app.task.status);
+        nameRow.appendChild(status);
 
         const name = document.createElement('span');
         name.classList.add('name');
@@ -422,11 +756,25 @@ editor.once('load', () => {
             nameRow.appendChild(primaryBadge);
         }
 
+        if (app.type === 'publish') {
+            const stats = document.createElement('div');
+            stats.classList.add('detail-stats');
+            heading.appendChild(stats);
+
+            const views = document.createElement('span');
+            views.classList.add('metric', 'views');
+            views.title = 'Views';
+            views.textContent = String(app.views ?? 0);
+            stats.appendChild(views);
+        }
+
         const sub = document.createElement('div');
         sub.classList.add('sub');
         sub.textContent = [
-            isComplete ? 'Succeeded' : (app.task.status === 'error' ? 'Failed' : 'In progress'),
-            app.build_job_id ? `#${app.build_job_id}` : null
+            getStatusLabel(app),
+            app.build_job_id ? `Build #${app.build_job_id}` : null,
+            app.job_id ? `Job #${app.job_id}` : null,
+            app.created_at ? `Created ${formatBuildDate(app.created_at)}` : null
         ].filter(Boolean).join(' · ');
         heading.appendChild(sub);
 
@@ -436,7 +784,7 @@ editor.once('load', () => {
 
         if (isComplete && app.url) {
             const artifact = document.createElement('a');
-            artifact.classList.add('artifact');
+            artifact.classList.add('detail-button');
             artifact.href = app.url;
             artifact.target = '_blank';
             artifact.rel = 'noopener';
@@ -444,34 +792,21 @@ editor.once('load', () => {
             actions.appendChild(artifact);
         }
 
-        if (canPublish) {
+        if (canPrimary) {
             const primary = new Button({ text: 'Set primary', class: 'set-primary' });
-            events.push(handlePermissions(primary));
-            if (primary.enabled && (!isComplete || isPrimary)) {
-                primary.enabled = false;
-            }
-            events.push(primary.on('click', () => {
-                if (isPrimary || !isComplete) {
-                    return;
-                }
-                editor.call('projects:setPrimaryApp', app.app_id, null, () => {
-                    refreshApps();
-                });
-                refreshApps();
-            }));
+            const update = () => {
+                primary.enabled = editor.call('permissions:write') && canSetPrimaryBuild(app);
+            };
+            update();
+            detailEvents.push(editor.on(`permissions:set:${config.self.id}`, update));
+            detailEvents.push(primary.on('click', () => setPrimaryBuild(app)));
             actions.appendChild(primary.dom);
         }
 
         if (canDelete) {
             const del = new Button({ text: 'Delete', class: 'delete' });
-            events.push(handlePermissions(del));
-            events.push(del.on('click', () => {
-                editor.call('picker:confirm', 'Are you sure you want to delete this build?');
-                editor.once('picker:confirm:yes', () => {
-                    editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
-                    removeApp(app);
-                });
-            }));
+            detailEvents.push(handlePermissions(del));
+            detailEvents.push(del.on('click', () => deleteBuild(app)));
             actions.appendChild(del.dom);
         }
 
@@ -479,38 +814,18 @@ editor.once('load', () => {
             const error = document.createElement('div');
             error.classList.add('error');
             error.textContent = app.task.message;
-            detailView.element.appendChild(error);
+            detailPanel.element.appendChild(error);
         }
 
-        const details = createDetails(app);
-        details.hidden = false;
-        detailView.element.appendChild(details);
+        detailPanel.element.appendChild(createDetails(app));
     };
 
-    // return from the detail page to the build list
-    const showList = function () {
-        detailApp = null;
-        detailView.hidden = true;
-        detailView.element.innerHTML = '';
-
-        existingBuildsLabel.hidden = false;
-        toolbar.hidden = false;
-        container.hidden = apps.length === 0;
-        noBuilds.hidden = apps.length > 0;
-
-        const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
-        primaryBuildHeading.hidden = !primaryExists;
-        primaryBuild.hidden = !primaryExists;
-    };
-
-    // open the detail page for a build
-    const showDetail = function (app: any) {
+    const openBuildDetail = function (app: any) {
         detailApp = app;
-        listChrome.forEach((el) => {
-            el.hidden = true;
-        });
         renderDetail(app);
-        detailView.hidden = false;
+        openingDetail = true;
+        editor.call('picker:project', 'build-detail');
+        openingDetail = false;
     };
 
     // create UI for single app
@@ -519,7 +834,7 @@ editor.once('load', () => {
         item.classList.add('build-item', app.task.status, app.type);
         item.id = options.summary ? `primary-app-${app.id}` : `app-${app.id}`;
 
-        if (config.project.primaryApp === app.app_id || config.project.primaryApp === app.id) {
+        if (isPrimaryBuild(app)) {
             item.classList.add('primary');
         }
 
@@ -562,7 +877,7 @@ editor.once('load', () => {
         format.textContent = app.settings && app.settings.format || app.version || app.type;
         nameRow.appendChild(format);
 
-        if (config.project.primaryApp === app.app_id) {
+        if (isPrimaryBuild(app)) {
             const primaryBadge = document.createElement('span');
             primaryBadge.classList.add('badge', 'primary-badge');
             primaryBadge.textContent = 'Primary';
@@ -585,6 +900,27 @@ editor.once('load', () => {
         branchName.textContent = app.branch && app.branch.name || 'main';
         branch.appendChild(branchName);
         row.appendChild(branch);
+
+        const artifact = document.createElement('a');
+        artifact.classList.add('row-artifact');
+        if (app.task.status === 'complete' && app.url) {
+            artifact.href = app.url;
+            artifact.target = '_blank';
+            artifact.rel = 'noopener';
+            artifact.classList.add(app.type === 'publish' ? 'open' : 'download');
+            artifact.setAttribute('aria-label', app.type === 'publish' ? 'Open build' : 'Download build');
+            const stop = function (e: MouseEvent) {
+                e.stopPropagation();
+            };
+            artifact.addEventListener('click', stop);
+            events.push({
+                unbind: () => artifact.removeEventListener('click', stop)
+            });
+        } else {
+            artifact.classList.add('placeholder');
+            artifact.setAttribute('aria-hidden', 'true');
+        }
+        row.appendChild(artifact);
 
         const rightMeta = document.createElement('div');
         rightMeta.classList.add('right-meta');
@@ -619,7 +955,7 @@ editor.once('load', () => {
         });
         row.appendChild(kebab);
 
-        const onItemClick = () => showDetail(app);
+        const onItemClick = () => openBuildDetail(app);
         item.addEventListener('click', onItemClick);
         events.push({
             unbind: () => item.removeEventListener('click', onItemClick)
@@ -640,39 +976,47 @@ editor.once('load', () => {
             toggleProgress(true);
         }
 
-        editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, 0).on('load', (status, data) => {
-            apps = data.result.map(normalizeBuildJob);
-            hasMore = data.pagination ? apps.length < data.pagination.total : data.result.length === APP_LIMIT;
+        loadAppIndex(() => {
+            editor.api.globals.rest.projects.projectBuilds(APP_LIMIT, 0).on('load', (status, data) => {
+                const rows = data.result.map(normalizeBuildJob);
+                const ids = getPublishAppIds(rows);
+                const legacy = appList
+                .filter(app => !ids.has(String(app.id)))
+                .map(normalizeLegacyApp);
+                apps = rows.concat(legacy).sort(compareBuildDate);
+                hasMore = data.pagination ? rows.length < data.pagination.total : data.result.length === APP_LIMIT;
 
-            if (showProgress) {
-                toggleProgress(false);
-            }
+                if (showProgress) {
+                    toggleProgress(false);
+                }
 
-            refreshApps();
-            fillViewport();
+                refreshApps();
+                fillViewport();
+            });
         });
     };
 
     // removes an app from the UI
     const removeApp = function (app: any) {
-        document.getElementById(`app-${app.id}`)?.remove();
-        document.getElementById(`primary-app-${app.id}`)?.remove();
+        const target = apps.find(item => isSameBuild(item, app)) || app;
+        document.getElementById(`app-${target.id}`)?.remove();
+        document.getElementById(`primary-app-${target.id}`)?.remove();
 
-        const index = apps.findIndex(item => item.id === app.id);
+        const index = apps.findIndex(item => isSameBuild(item, target));
         if (index !== -1) {
             apps.splice(index, 1);
         }
 
         container.hidden = apps.length === 0;
+        noBuilds.hidden = apps.length > 0;
 
         // drop the primary-build summary if its build was the one removed
         const primaryExists = apps.some(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
         primaryBuildHeading.hidden = !primaryExists;
         primaryBuild.hidden = !primaryExists;
 
-        // if the deleted build's detail page is open, return to the list
-        if (detailApp && detailApp.id === app.id) {
-            showList();
+        if (detailApp && isSameBuild(detailApp, target)) {
+            openBuildsPanel();
         }
     };
 
@@ -680,6 +1024,8 @@ editor.once('load', () => {
         const app = apps.find(item => item.build_job_id === id);
         if (app) {
             removeApp(app);
+        } else if (detailApp?.build_job_id === id) {
+            openBuildsPanel();
         }
     };
 
@@ -697,16 +1043,89 @@ editor.once('load', () => {
 
         // keep the detail page in sync if one is open
         if (detailApp) {
-            const updated = apps.find(item => item.build_job_id === detailApp.build_job_id);
+            const updated = apps.find(item => isSameBuild(item, detailApp));
             if (updated) {
-                showDetail(updated);
-            } else {
-                showList();
+                detailApp = updated;
+                renderDetail(updated);
+            } else if (!detailPanel.hidden) {
+                renderDetail(detailApp);
             }
         }
     };
 
     // LOCAL UTILS
+
+    // Vercel-style summary card for the primary build (richer than the history rows)
+    const createPrimaryCard = function (app: any) {
+        primaryBuild.dom.innerHTML = '';
+
+        const card = document.createElement('div');
+        card.classList.add('primary-build-card', app.task.status);
+        card.id = `primary-app-${app.id}`;
+
+        // project thumbnail — the icon that the history rows dropped for the status check/cross/spinner
+        const thumb = document.createElement('img');
+        thumb.classList.add('thumb');
+        thumb.alt = '';
+        thumb.src = config.project.thumbnails && (config.project.thumbnails.m || config.project.thumbnails.s) ||
+            `${config.url.static}/platform/images/common/blank_project.png`;
+        card.appendChild(thumb);
+
+        const body = document.createElement('div');
+        body.classList.add('body');
+        card.appendChild(body);
+
+        const nameRow = document.createElement('div');
+        nameRow.classList.add('name-row');
+        body.appendChild(nameRow);
+
+        const status = document.createElement('span');
+        status.classList.add('status', app.task.status);
+        nameRow.appendChild(status);
+
+        const name = document.createElement('span');
+        name.classList.add('name');
+        name.textContent = app.name;
+        nameRow.appendChild(name);
+
+        const sub = document.createElement('div');
+        sub.classList.add('sub');
+        const actor = app.actor && (app.actor.name || app.actor.username);
+        sub.textContent = [`Last published ${formatBuildDate(app.created_at)}`, actor ? `by ${actor}` : null].filter(Boolean).join(' · ');
+        body.appendChild(sub);
+
+        if (app.url) {
+            const link = document.createElement('a');
+            link.classList.add('url');
+            link.href = app.url;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.textContent = app.url;
+            body.appendChild(link);
+        }
+
+        const open = document.createElement('a');
+        open.classList.add('open-external');
+        open.target = '_blank';
+        open.rel = 'noopener';
+        open.setAttribute('aria-label', 'Open published build');
+        if (app.url) {
+            open.href = app.url;
+        }
+        card.appendChild(open);
+
+        // click the card to open its detail page; links open the published app
+        const onCardClick = (e: MouseEvent) => {
+            if ((e.target as HTMLElement).closest('a')) {
+                return;
+            }
+            openBuildDetail(app);
+        };
+        card.addEventListener('click', onCardClick);
+        events.push({ unbind: () => card.removeEventListener('click', onCardClick) });
+
+        primaryBuild.dom.appendChild(card);
+    };
 
     const renderPrimaryBuild = function () {
         const app = apps.find(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
@@ -714,7 +1133,7 @@ editor.once('load', () => {
         primaryBuild.hidden = !app;
 
         if (app) {
-            createAppItem(app, primaryBuild, { summary: true });
+            createPrimaryCard(app);
         }
     };
 
@@ -732,11 +1151,18 @@ editor.once('load', () => {
         events = [];
     };
 
+    const destroyDetailEvents = function () {
+        detailEvents.forEach((evt) => {
+            evt.unbind();
+        });
+        detailEvents = [];
+    };
+
     // EVENTS
 
     // handle external updates to primary app
     editor.on('projects:primaryApp', (newValue, oldValue) => {
-        if (panel.hidden) {
+        if (!isPickerVisible()) {
             return;
         }
 
@@ -745,16 +1171,17 @@ editor.once('load', () => {
 
     // handle app created externally
     editor.on('messenger:app.new', () => {
-        if (panel.hidden) {
+        if (!isPickerVisible()) {
             return;
         }
 
+        loadedAppIndex = false;
         loadApps();
     });
 
     // handle external delete
     editor.on('messenger:app.delete', (data) => {
-        if (panel.hidden) {
+        if (!isPickerVisible()) {
             return;
         }
 
@@ -762,7 +1189,7 @@ editor.once('load', () => {
     });
 
     editor.on('messenger:build_job.delete', (data) => {
-        if (panel.hidden || !data.build_job) {
+        if (!isPickerVisible() || !data.build_job) {
             return;
         }
 
@@ -771,15 +1198,21 @@ editor.once('load', () => {
 
     // handle external app updates
     editor.on('messenger:app.update', () => {
-        if (panel.hidden) {
+        if (!isPickerVisible()) {
             return;
         }
 
+        loadedAppIndex = false;
         loadApps();
     });
 
     editor.on('messenger:job.update', (msg: any) => {
-        if (panel.hidden || !msg.job || !apps.some(app => app.job_id === Number(msg.job.id))) {
+        if (!isPickerVisible() || !msg.job) {
+            return;
+        }
+
+        const id = Number(msg.job.id);
+        if (!apps.some(app => app.job_id === id) && detailApp?.job_id !== id) {
             return;
         }
 
@@ -788,12 +1221,22 @@ editor.once('load', () => {
 
     // open publishing popup
     editor.method('picker:builds-publish', () => {
+        detailApp = null;
+        if (!detailPanel.hidden) {
+            openingBuilds = true;
+            destroyDetailEvents();
+            detailPanel.element.innerHTML = '';
+        }
+
         editor.call('picker:project', 'builds-publish');
+        openingBuilds = false;
     });
 
     // on show
     panel.on('show', () => {
-        showList();
+        detailApp = null;
+        destroyDetailEvents();
+        detailPanel.element.innerHTML = '';
         loadApps();
 
         // the picker scrolls its content panel; watch it for infinite scroll
@@ -807,11 +1250,47 @@ editor.once('load', () => {
 
     // on hide
     panel.on('hide', () => {
-        apps = [];
-        detailApp = null;
-        detailView.hidden = true;
         scrollContainer?.removeEventListener('scroll', onScroll);
         scrollContainer = null;
+
+        if (openingDetail) {
+            return;
+        }
+
+        apps = [];
+        appIndex = {};
+        appList = [];
+        loadedAppIndex = false;
+        detailApp = null;
+        detailPanel.element.innerHTML = '';
+        destroyTooltips();
+        destroyEvents();
+        destroyDetailEvents();
+
+        if (editor.call('viewport:inViewport')) {
+            editor.emit('viewport:hover', true);
+        }
+    });
+
+    detailPanel.on('show', () => {
+        if (editor.call('viewport:inViewport')) {
+            editor.emit('viewport:hover', false);
+        }
+    });
+
+    detailPanel.on('hide', () => {
+        destroyDetailEvents();
+        detailPanel.element.innerHTML = '';
+
+        if (openingBuilds) {
+            return;
+        }
+
+        apps = [];
+        appIndex = {};
+        appList = [];
+        loadedAppIndex = false;
+        detailApp = null;
         destroyTooltips();
         destroyEvents();
 
@@ -821,7 +1300,7 @@ editor.once('load', () => {
     });
 
     editor.on('viewport:hover', (state) => {
-        if (state && !panel.hidden) {
+        if (state && isPickerVisible()) {
             setTimeout(() => {
                 editor.emit('viewport:hover', false);
             }, 0);

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -124,7 +124,7 @@ editor.once('load', () => {
     primaryBuildHeader.append(toolbar);
 
     const btnDownload = new Button({
-        text: 'Download .zip',
+        text: 'Download',
         class: 'download'
     });
     handlePermissions(btnDownload);

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -50,21 +50,6 @@ const STATUS_FILTERS = [{
     value: 'error',
     label: 'Failed'
 }];
-const DUMMY_LEGACY_APP = {
-    id: -1,
-    sample: true,
-    name: 'Legacy published app sample',
-    description: 'temporary manual legacy build description',
-    version: '1.0.0',
-    release_notes: 'temporary manual legacy build sample',
-    size: 7340032,
-    views: 42,
-    url: 'https://playcanv.as/b/legacy-sample',
-    task: { status: 'complete', message: '' },
-    created_at: new Date(Date.now() - 86400000).toISOString(),
-    completed_at: new Date(Date.now() - 86340000).toISOString(),
-    branch: { id: 'legacy', name: 'main' }
-};
 
 editor.once('load', () => {
     // global variables
@@ -80,7 +65,9 @@ editor.once('load', () => {
     let events = [];  // holds events that need to be destroyed
     let detailEvents = [];  // holds detail panel events
     let openingDetail = false;
+    let openingBuildForm = false;
     let openingBuilds = false;
+    let reloadOnNextShow = false;
     const filters: Record<string, string> = {};
     const filterButtons: Record<string, Button> = {};
     const filterMenus: Record<string, Menu> = {};
@@ -141,7 +128,11 @@ editor.once('load', () => {
         class: 'download'
     });
     handlePermissions(btnDownload);
-    btnDownload.on('click', () => editor.call('picker:publish:download'));
+    btnDownload.on('click', () => {
+        openingBuildForm = true;
+        editor.call('picker:publish:download');
+        openingBuildForm = false;
+    });
     toolbar.append(btnDownload);
 
     const btnPublish = new Button({
@@ -149,7 +140,11 @@ editor.once('load', () => {
         class: 'publish'
     });
     handlePermissions(btnPublish);
-    btnPublish.on('click', () => editor.call('picker:publish:new'));
+    btnPublish.on('click', () => {
+        openingBuildForm = true;
+        editor.call('picker:publish:new');
+        openingBuildForm = false;
+    });
     toolbar.append(btnPublish);
 
     const primaryBuild = new Container({ class: 'primary-build-summary' });
@@ -193,10 +188,10 @@ editor.once('load', () => {
         class: ['no-builds-label', 'no-filtered-builds-label'],
         hidden: true
     });
-    panel.append(noMatchingBuilds);
 
     // container for builds
     const container = new Container({ class: 'builds-list' });
+    container.dom.appendChild(noMatchingBuilds.dom);
     panel.append(container);
 
     const detailPanel = new Container({
@@ -261,17 +256,12 @@ editor.once('load', () => {
         return !!app && app.type === 'publish' && app.task.status === 'complete' && !!app.app_id && !isPrimaryBuild(app);
     };
 
-    const isSampleBuild = function (app: any) {
-        return app?.source?.sample === true;
-    };
-
     const canDeleteBuild = function (app: any) {
         if (!app) {
             return false;
         }
 
-        return !!app.build_job_id || isSampleBuild(app) ||
-            (app.type === 'publish' && Number(app.app_id) > 0);
+        return !!app.build_job_id || (app.type === 'publish' && Number(app.app_id) > 0);
     };
 
     const setPrimaryBuild = function (app: any) {
@@ -279,8 +269,8 @@ editor.once('load', () => {
             return;
         }
 
-        editor.call('projects:setPrimaryApp', String(app.app_id), undefined, refreshApps);
-        refreshApps();
+        editor.call('projects:setPrimaryApp', String(app.app_id), undefined, syncPrimaryBuildUi);
+        syncPrimaryBuildUi();
     };
 
     // shared per-row action menu (opened from the kebab button on each row)
@@ -361,12 +351,6 @@ editor.once('load', () => {
             appList.forEach((app) => {
                 appIndex[String(app.id)] = app;
             });
-            const sample = Object.assign({}, DUMMY_LEGACY_APP, {
-                id: config.project.primaryApp && !appIndex[String(config.project.primaryApp)] ?
-                    config.project.primaryApp :
-                    DUMMY_LEGACY_APP.id
-            });
-            appList.push(sample);
             loadedAppIndex = true;
             done();
         });
@@ -451,7 +435,7 @@ editor.once('load', () => {
             created_at: app.created_at,
             completed_at: app.completed_at,
             duration_ms: null,
-            source: { type: 'legacy', sample: app.sample === true },
+            source: { type: 'legacy' },
             size: bytes,
             views: app.views ?? 0,
             url,
@@ -622,8 +606,7 @@ editor.once('load', () => {
         filters[key] = value;
         updateFilterButtons();
         hideFilterMenus();
-        refreshApps();
-        fillViewport();
+        refreshFilterVisibility();
     };
 
     const resetBuildFilters = function () {
@@ -955,7 +938,7 @@ editor.once('load', () => {
         editor.once('picker:confirm:yes', () => {
             if (app.build_job_id) {
                 editor.api.globals.rest.projects.projectBuildDelete(app.build_job_id);
-            } else if (!isSampleBuild(app)) {
+            } else {
                 editor.api.globals.rest.apps.appDelete(Number(app.app_id));
             }
             removeApp(app);
@@ -1299,14 +1282,12 @@ editor.once('load', () => {
         destroyEvents();
         primaryBuild.dom.innerHTML = '';
         container.dom.innerHTML = '';
-        const filteredApps = getFilteredApps();
+        container.dom.appendChild(noMatchingBuilds.dom);
         renderPrimaryBuild();
-        container.hidden = apps.length === 0 || filteredApps.length === 0;
-        noBuilds.hidden = apps.length > 0;
-        noMatchingBuilds.hidden = apps.length === 0 || filteredApps.length > 0 || !hasActiveFilters();
-        filteredApps.forEach((app) => {
+        apps.forEach((app) => {
             createAppItem(app);
         });
+        refreshFilterVisibility();
 
         // keep the detail page in sync if one is open
         if (detailApp) {
@@ -1389,7 +1370,6 @@ editor.once('load', () => {
             openBuildDetail(app);
         };
         card.addEventListener('click', onCardClick);
-        events.push({ unbind: () => card.removeEventListener('click', onCardClick) });
 
         primaryBuild.dom.appendChild(card);
     };
@@ -1402,6 +1382,37 @@ editor.once('load', () => {
         if (app) {
             createPrimaryCard(app);
         }
+    };
+
+    const syncPrimaryBuildUi = function () {
+        renderPrimaryBuild();
+        apps.forEach((app) => {
+            const item = document.getElementById(`app-${app.id}`);
+            if (!item) {
+                return;
+            }
+
+            const primary = isPrimaryBuild(app);
+            const badge = item.querySelector('.primary-badge');
+            item.classList.toggle('primary', primary);
+
+            if (primary && !badge) {
+                const newBadge = document.createElement('span');
+                newBadge.classList.add('badge', 'primary-badge');
+                newBadge.textContent = 'Primary';
+                item.querySelector('.name-row')?.appendChild(newBadge);
+            } else if (!primary && badge) {
+                badge.remove();
+            }
+        });
+
+        if (detailApp && !detailPanel.hidden) {
+            const updated = apps.find(item => isSameBuild(item, detailApp));
+            detailApp = updated || detailApp;
+            renderDetail(detailApp);
+        }
+
+        fillViewport();
     };
 
     const destroyTooltips = function () {
@@ -1425,6 +1436,47 @@ editor.once('load', () => {
         detailEvents = [];
     };
 
+    const resetBuildsState = function () {
+        resetBuildFilters();
+        apps = [];
+        appIndex = {};
+        appList = [];
+        loadedAppIndex = false;
+        detailApp = null;
+        reloadOnNextShow = false;
+        primaryBuild.dom.innerHTML = '';
+        container.dom.innerHTML = '';
+        container.dom.appendChild(noMatchingBuilds.dom);
+        detailPanel.element.innerHTML = '';
+        destroyTooltips();
+        destroyEvents();
+        destroyDetailEvents();
+        loading.hidden = true;
+        progressBar.hidden = true;
+        container.hidden = true;
+        primaryBuildHeading.hidden = true;
+        primaryBuild.hidden = true;
+        noBuilds.hidden = true;
+        noMatchingBuilds.hidden = true;
+    };
+
+    const refreshFilterVisibility = function () {
+        const filteredApps = getFilteredApps();
+        const visible = new Set(filteredApps.map(app => `app-${app.id}`));
+
+        apps.forEach((app) => {
+            const item = document.getElementById(`app-${app.id}`);
+            if (item) {
+                item.hidden = !visible.has(item.id);
+            }
+        });
+
+        container.hidden = apps.length === 0;
+        noBuilds.hidden = apps.length > 0;
+        noMatchingBuilds.hidden = apps.length === 0 || filteredApps.length > 0 || !hasActiveFilters();
+        fillViewport();
+    };
+
     // EVENTS
 
     // handle external updates to primary app
@@ -1433,7 +1485,7 @@ editor.once('load', () => {
             return;
         }
 
-        refreshApps();
+        syncPrimaryBuildUi();
     });
 
     // handle app created externally
@@ -1487,7 +1539,8 @@ editor.once('load', () => {
     });
 
     // open publishing popup
-    editor.method('picker:builds-publish', () => {
+    editor.method('picker:builds-publish', (options: { reload?: boolean } = {}) => {
+        reloadOnNextShow = !!options.reload;
         detailApp = null;
         if (!detailPanel.hidden) {
             openingBuilds = true;
@@ -1497,6 +1550,11 @@ editor.once('load', () => {
 
         editor.call('picker:project', 'builds-publish');
         openingBuilds = false;
+
+        if (reloadOnNextShow && !panel.hidden) {
+            loadApps(apps.length === 0);
+            reloadOnNextShow = false;
+        }
     });
 
     // on show
@@ -1504,11 +1562,17 @@ editor.once('load', () => {
         detailApp = null;
         destroyDetailEvents();
         detailPanel.element.innerHTML = '';
-        loadApps();
 
         // the picker scrolls its content panel; watch it for infinite scroll
         scrollContainer = panel.dom.parentElement;
         scrollContainer?.addEventListener('scroll', onScroll);
+
+        if (reloadOnNextShow || apps.length === 0) {
+            loadApps(apps.length === 0);
+            reloadOnNextShow = false;
+        } else {
+            refreshFilterVisibility();
+        }
 
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', false);
@@ -1520,20 +1584,11 @@ editor.once('load', () => {
         scrollContainer?.removeEventListener('scroll', onScroll);
         scrollContainer = null;
 
-        if (openingDetail) {
+        if (openingDetail || openingBuildForm) {
             return;
         }
 
-        resetBuildFilters();
-        apps = [];
-        appIndex = {};
-        appList = [];
-        loadedAppIndex = false;
-        detailApp = null;
-        detailPanel.element.innerHTML = '';
-        destroyTooltips();
-        destroyEvents();
-        destroyDetailEvents();
+        resetBuildsState();
 
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', true);
@@ -1554,17 +1609,16 @@ editor.once('load', () => {
             return;
         }
 
-        resetBuildFilters();
-        apps = [];
-        appIndex = {};
-        appList = [];
-        loadedAppIndex = false;
-        detailApp = null;
-        destroyTooltips();
-        destroyEvents();
+        resetBuildsState();
 
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', true);
+        }
+    });
+
+    editor.on('picker:close', (name) => {
+        if (name === 'project' && panel.hidden && detailPanel.hidden && (apps.length > 0 || loadedAppIndex || hasActiveFilters())) {
+            resetBuildsState();
         }
     });
 

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -233,7 +233,7 @@ editor.once('load', () => {
 
             // ensure all panels are visible
             for (const key in menuOptions) {
-                if (key !== 'publish-download' && key !== 'publish-new') {
+                if (!menuOptions[key].panelOnly) {
                     menuOptions[key].item.hidden = false;
                 }
             }
@@ -625,7 +625,8 @@ editor.once('load', () => {
         menuOptions[name] = {
             item: menuItem,
             title: title,
-            panel: panel
+            panel: panel,
+            panelOnly: false
         };
         panel.hidden = true;
         rightPanel.append(panel);
@@ -636,6 +637,8 @@ editor.once('load', () => {
     editor.method('picker:project:registerPanel', (name, title, panel) => {
         // just do the regular registration but hide the menu
         const item = editor.call('picker:project:registerMenu', name, title, panel);
+        menuOptions[name].panelOnly = true;
+        item.hidden = true;
         item.class.add('hidden');
         return item;
     });

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -554,6 +554,13 @@ editor.once('load', () => {
     });
     container.append(footer);
 
+    // explains why the action button is disabled
+    const footerHint = new Label({
+        class: 'footer-hint',
+        hidden: true
+    });
+    footer.append(footerHint);
+
     // publish button
     const btnPublish = new Button({
         text: 'Publish',
@@ -676,16 +683,29 @@ editor.once('load', () => {
 
     const refreshButtonsState = function () {
         const selectedScenes = getSelectedScenes();
-        const enabled =
-            inputName.value.length > 0 &&
-            inputName.value.length <= 1000 &&
-            selectedScenes.length > 0 &&
-            inputDescription.value.length <= 10000 &&
-            inputNotes.value.length <= 10000 &&
-            inputVersion.value.length <= 20 &&
-            !isUploadingImage &&
-            !jobInProgress;
 
+        let reason = '';
+        if (!inputName.value.length) {
+            reason = 'Title is required';
+        } else if (inputName.value.length > 1000) {
+            reason = 'Title cannot exceed 1000 characters';
+        } else if (selectedScenes.length === 0) {
+            reason = 'Select at least one scene';
+        } else if (inputDescription.value.length > 10000) {
+            reason = 'Description is too long';
+        } else if (inputNotes.value.length > 10000) {
+            reason = 'Release notes are too long';
+        } else if (inputVersion.value.length > 20) {
+            reason = 'Version cannot exceed 20 characters';
+        } else if (isUploadingImage) {
+            reason = 'Uploading image…';
+        }
+
+        footerHint.text = reason;
+        // while scenes are still loading the empty state explains itself
+        footerHint.hidden = !reason || !scenes.length;
+
+        const enabled = !reason && !jobInProgress;
         btnPublish.enabled = enabled;
         btnWebDownload.enabled = enabled;
     };

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -568,7 +568,7 @@ editor.once('load', () => {
 
         editor.api.globals.rest.apps.appCreate(data).on('load', () => {
             jobInProgress = false;
-            editor.call('picker:builds-publish');
+            editor.call('picker:builds-publish', { reload: true });
         }).on('error', (status) => {
             jobInProgress = false;
             editor.call('status:error', `Error while publishing: ${status}`);
@@ -610,7 +610,7 @@ editor.once('load', () => {
         // ajax call
         editor.api.globals.rest.apps.appDownload(data).on('load', () => {
             jobInProgress = false;
-            editor.call('picker:builds-publish');
+            editor.call('picker:builds-publish', { reload: true });
         }).on('error', (status, error) => {
             jobInProgress = false;
 

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -486,7 +486,7 @@ editor.once('load', () => {
     const getSelectedScenes = function () {
         const result = [];
 
-        const listItems = sceneList.innerElement.childNodes;
+        const listItems = sceneList.innerElement.childNodes as any;
         for (let i = 0; i < listItems.length; i++) {
             if (listItems[i].ui.isSelected()) {
                 result.push(listItems[i].ui.sceneId);
@@ -525,7 +525,7 @@ editor.once('load', () => {
 
         refreshButtonsState();
 
-        const data = {
+        const data: Record<string, any> = {
             name: inputName.value,
             project_id: config.project.id,
             branch_id: config.self.branch.id,
@@ -583,8 +583,6 @@ editor.once('load', () => {
     });
     container.append(btnWebDownload);
 
-    let urlToDownload: string | null = null;
-
     // download app
     const download = function () {
         jobInProgress = true;
@@ -595,7 +593,7 @@ editor.once('load', () => {
         const npmProject = format === DOWNLOAD_FORMAT_NPM;
 
         // post data
-        const data = {
+        const data: Record<string, any> = {
             name: inputName.value,
             project_id: config.project.id,
             branch_id: config.self.branch.id,
@@ -610,61 +608,9 @@ editor.once('load', () => {
         data.engine_version = config.engineVersions[engineVersionDropdown.value].version;
 
         // ajax call
-        editor.api.globals.rest.apps.appDownload(data).on('load', (status, job) => {
-            // show download progress
-            panelDownloadProgress.hidden = false;
-            btnDownloadReady.hidden = true;
-            downloadProgressIconWrapper.classList.remove('success');
-            downloadProgressIconWrapper.classList.remove('error');
-
-            downloadProgressTitle.class.remove('error');
-            downloadProgressTitle.text = 'Preparing build...';
-
-            // smoothly scroll to the bottom
-            panelDownloadProgress.scrollIntoView({
-                behavior: 'smooth',
-                block: 'end'
-            });
-
-            // when job is updated get the job and
-            // proceed depending on job status
-            const evt = editor.on('messenger:job.update', (msg) => {
-                if (msg.job.id === job.id) {
-                    evt.unbind();
-
-                    // get job
-                    editor.api.globals.rest.jobs.jobGet({ jobId: job.id })
-                    .on('load', (status, data) => {
-                        const job = data;
-                        // success ?
-                        if (job.status === 'complete') {
-                            downloadProgressIconWrapper.classList.add('success');
-                            downloadProgressTitle.text = 'Your build is ready';
-                            urlToDownload = job.data.download_url;
-                            btnDownloadReady.hidden = false;
-                            jobInProgress = false;
-
-                            refreshButtonsState();
-                        } else if (job.status === 'error') { // handle error
-                            downloadProgressIconWrapper.classList.add('error');
-                            downloadProgressTitle.class.add('error');
-                            downloadProgressTitle.text = job.messages[0];
-                            jobInProgress = false;
-
-                            refreshButtonsState();
-                        }
-                    }).on('error', () => {
-                        // error
-                        downloadProgressIconWrapper.classList.add('error');
-                        downloadProgressTitle.class.add('error');
-                        downloadProgressTitle.text = 'Error: Could not start download';
-                        jobInProgress = false;
-
-                        refreshButtonsState();
-                    });
-                }
-            });
-            events.push(evt);
+        editor.api.globals.rest.apps.appDownload(data).on('load', () => {
+            jobInProgress = false;
+            editor.call('picker:builds-publish');
         }).on('error', (status, error) => {
             jobInProgress = false;
 
@@ -683,46 +629,6 @@ editor.once('load', () => {
         download();
     });
 
-    // download progress
-    const panelDownloadProgress = document.createElement('div');
-    panelDownloadProgress.classList.add('progress');
-    panelDownloadProgress.classList.add('download');
-    container.append(panelDownloadProgress);
-
-    // icon
-    const downloadProgressIconWrapper = document.createElement('span');
-    downloadProgressIconWrapper.classList.add('icon');
-    panelDownloadProgress.appendChild(downloadProgressIconWrapper);
-
-    const downloadProgressImg = new Image();
-    downloadProgressIconWrapper.appendChild(downloadProgressImg);
-    downloadProgressImg.src = `${config.url.static}/platform/images/common/ajax-loader.gif`;
-
-    // progress info
-    const downloadProgressInfo = document.createElement('span');
-    downloadProgressInfo.classList.add('progress-info');
-    panelDownloadProgress.appendChild(downloadProgressInfo);
-
-    const downloadProgressTitle = new Label({
-        text: 'Preparing build',
-        class: 'progress-title'
-    });
-    downloadProgressInfo.appendChild(downloadProgressTitle.dom);
-
-    const btnDownloadReady = new Button({
-        text: 'Download',
-        class: 'ready'
-    });
-    downloadProgressInfo.appendChild(btnDownloadReady.dom);
-
-    btnDownloadReady.on('click', () => {
-        if (urlToDownload) {
-            window.open(urlToDownload);
-        }
-
-        editor.call('picker:publish');
-    });
-
     const refreshButtonsState = function () {
         const selectedScenes = getSelectedScenes();
         const enabled =
@@ -739,8 +645,8 @@ editor.once('load', () => {
         btnWebDownload.enabled = enabled;
     };
 
-    const createSceneItem = function (scene: Record<string, unknown>) {
-        const row = new LegacyListItem();
+    const createSceneItem = function (scene: any) {
+        const row: any = new LegacyListItem();
         row.element.id = `picker-scene-${scene.id}`;
         row.sceneId = scene.id;
 
@@ -883,7 +789,6 @@ editor.once('load', () => {
 
     // on show
     container.on('show', () => {
-        panelDownloadProgress.hidden = true;
         containerNoScenes.hidden = false;
         labelNoScenes.hidden = true;
         loadingScenes.hidden = false;
@@ -979,7 +884,6 @@ editor.once('load', () => {
         primaryScene = null;
         imageS3Key = null;
         isUploadingImage = false;
-        urlToDownload = null;
         jobInProgress = false;
         destroyTooltips();
         destroyEvents();

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -564,6 +564,7 @@ editor.once('load', () => {
     // publish button
     const btnPublish = new Button({
         text: 'Publish',
+        icon: 'E226',
         class: 'publish'
     });
     footer.append(btnPublish);
@@ -631,6 +632,7 @@ editor.once('load', () => {
     // web download button
     const btnWebDownload = new Button({
         text: 'Download',
+        icon: 'E245',
         class: 'web-download'
     });
     footer.append(btnWebDownload);

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -24,6 +24,7 @@ editor.once('load', () => {
 
     // root container
     const container = new Container({
+        flex: true,
         class: 'picker-publish-new'
     });
 
@@ -59,11 +60,35 @@ editor.once('load', () => {
         refreshDownloadFormatOptions();
     });
 
+    // back to builds list
+    const back = document.createElement('button');
+    back.type = 'button';
+    back.classList.add('back');
+    back.textContent = 'Back to builds';
+    back.addEventListener('click', () => {
+        editor.call('picker:builds-publish');
+    });
+    container.dom.appendChild(back);
+
+    // card-style form section with a heading (matches build detail sections)
+    const createFormSection = (className: string, title: string) => {
+        const section = new Container({
+            class: ['form-section', className]
+        });
+        const heading = document.createElement('h3');
+        heading.textContent = title;
+        section.dom.appendChild(heading);
+        container.append(section);
+        return section;
+    };
+
+    const sectionDetails = createFormSection('details', 'Build details');
+
     // info panel
     const containerInfo = new Container({
         class: 'info'
     });
-    container.append(containerInfo);
+    sectionDetails.append(containerInfo);
 
     // image
     const imageField = document.createElement('div');
@@ -173,11 +198,11 @@ editor.once('load', () => {
     group.appendChild(labelImageClick.dom);
 
     // Helper to create a text area section with label and error
-    const createTextAreaSection = (className: string, labelText: string, maxLength: number) => {
+    const createTextAreaSection = (className: string, labelText: string, maxLength: number, placeholder?: string) => {
         const sectionContainer = new Container({
             class: className
         });
-        container.append(sectionContainer);
+        sectionDetails.append(sectionContainer);
 
         const label = new Label({
             text: labelText,
@@ -193,7 +218,8 @@ editor.once('load', () => {
         sectionContainer.append(errorLabel);
 
         const input = new TextAreaInput({
-            keyChange: true
+            keyChange: true,
+            placeholder
         });
         sectionContainer.append(input);
 
@@ -211,7 +237,7 @@ editor.once('load', () => {
     const containerVersion = new Container({
         class: 'version'
     });
-    container.append(containerVersion);
+    sectionDetails.append(containerVersion);
 
     const labelVersion = new Label({
         text: 'Version',
@@ -238,7 +264,9 @@ editor.once('load', () => {
         refreshButtonsState();
     });
 
-    const inputNotes = createTextAreaSection('notes', 'Release Notes', 10000);
+    const inputNotes = createTextAreaSection('notes', 'Release Notes', 10000, 'What\'s changed in this build?');
+
+    const sectionSettings = createFormSection('settings', 'Build settings');
 
     // engine version
     const containerEngineVersion = new Container({
@@ -264,7 +292,7 @@ editor.once('load', () => {
         })
     });
     containerEngineVersion.append(engineVersionDropdown);
-    container.append(containerEngineVersion);
+    sectionSettings.append(containerEngineVersion);
 
     let fieldOptionsConcat: BooleanInput | null = null;
     let fieldOptionsMinify: BooleanInput | null = null;
@@ -287,7 +315,7 @@ editor.once('load', () => {
             class: 'options'
         });
         containerBuildOptions = containerOptions;
-        container.append(containerOptions);
+        sectionSettings.append(containerOptions);
 
         const labelOptions = new Label({
             text: 'Options',
@@ -339,7 +367,7 @@ editor.once('load', () => {
     containerDownloadOptions = new Container({
         class: 'options'
     });
-    container.append(containerDownloadOptions);
+    sectionSettings.append(containerDownloadOptions);
     containerDownloadOptions.hidden = true;
 
     const labelDownloadOptions = new Label({
@@ -434,20 +462,31 @@ editor.once('load', () => {
     });
     container.append(containerScenes);
 
+    // header bar attached to the scene list (matches build history header)
+    const scenesHeader = new Container({
+        class: 'scenes-header'
+    });
+    containerScenes.append(scenesHeader);
+
     const labelChooseScenes = new Label({
-        text: 'Choose Scenes',
+        text: 'Scenes',
         class: 'field-label'
     });
-    containerScenes.append(labelChooseScenes);
+    scenesHeader.append(labelChooseScenes);
 
-    const selectAll = new BooleanInput();
-    containerScenes.append(selectAll);
+    const selectAllGroup = new Container({
+        class: 'select-all-group'
+    });
+    scenesHeader.append(selectAllGroup);
 
     const labelSelectAll = new Label({
         text: 'Select all',
         class: 'select-all'
     });
-    containerScenes.append(labelSelectAll);
+    selectAllGroup.append(labelSelectAll);
+
+    const selectAll = new BooleanInput();
+    selectAllGroup.append(selectAll);
 
     // scenes container
     const sceneList = new LegacyList();
@@ -455,7 +494,7 @@ editor.once('load', () => {
     containerScenes.append(sceneList);
 
     const containerNoScenes = new Container({
-        class: 'scenes'
+        class: 'scenes-empty'
     });
     container.append(containerNoScenes);
 
@@ -509,12 +548,18 @@ editor.once('load', () => {
 
     let jobInProgress = false;
 
+    // footer action buttons
+    const footer = new Container({
+        class: 'form-footer'
+    });
+    container.append(footer);
+
     // publish button
     const btnPublish = new Button({
-        text: 'Publish Now',
+        text: 'Publish',
         class: 'publish'
     });
-    container.append(btnPublish);
+    footer.append(btnPublish);
 
     btnPublish.on('click', () => {
         if (jobInProgress) {
@@ -581,7 +626,7 @@ editor.once('load', () => {
         text: 'Download',
         class: 'web-download'
     });
-    container.append(btnWebDownload);
+    footer.append(btnWebDownload);
 
     // download app
     const download = function () {

--- a/test-suite/test/ui/basic.test.ts
+++ b/test-suite/test/ui/basic.test.ts
@@ -320,22 +320,33 @@ test.describe('publish/download', () => {
         test(`download app (scripts: ${scripts})`, async () => {
             test.setTimeout(4 * 60 * 1000);
             expect(await capture(`download-project-${scripts}`, page, async () => {
-                // open publish dialog
+                // open builds dialog
                 await page.getByRole('button', { name: '' }).click();
 
-                // download app
+                // open download form
                 const scenesList = page.waitForResponse(/playcanvas.com\/api\/projects\/\d+\/scenes/);
-                await page.getByRole('button', { name: 'Download .zip' }).click();
+                await page.locator('.builds-toolbar > .download').click();
                 await scenesList;
-                await page.getByText('Download', { exact: true }).nth(1).click();
 
-                // download link
+                // start download build
+                await page.waitForSelector('.picker-publish-new > .form-footer > .web-download.pcui-button:not(.pcui-disabled)');
+                await page.locator('.picker-publish-new > .form-footer > .web-download').click();
+
+                // wait for the new build to complete in the history list
+                await page.waitForSelector('.build-item.download.complete .row-artifact.download', { timeout: 3 * 60 * 1000 });
+
+                // download artifact link
                 const downloadPagePromise = page.waitForEvent('popup');
                 const downloadPromise = page.waitForEvent('download');
-                await page.waitForSelector('.picker-publish-new > .web-download.pcui-button:not(.pcui-disabled)', { timeout: 3 * 60 * 1000 });
-                await page.getByText('Download', { exact: true }).nth(2).click();
+                await page.locator('.build-item.download.complete .row-artifact.download').first().click();
                 await downloadPagePromise;
                 await downloadPromise;
+
+                // delete build so the next iteration starts with an empty download history
+                await page.locator('.build-item.download.complete .kebab').first().click();
+                await page.locator('.picker-builds-menu .pcui-menu-item').filter({ hasText: /^Delete$/ }).first().click();
+                await page.getByRole('button', { name: 'Yes' }).click();
+                await page.waitForSelector('.build-item.download', { state: 'detached' });
 
                 // dismiss dialog
                 await page.locator('.picker-project .close').first().click();
@@ -345,28 +356,36 @@ test.describe('publish/download', () => {
         test(`publish app (scripts: ${scripts})`, async () => {
             test.setTimeout(4 * 60 * 1000);
             expect(await capture(`publish-project-${scripts}`, page, async () => {
-                // open publish dialog
+                // open builds dialog
                 await page.getByRole('button', { name: '' }).click();
 
-                // publish app
+                // open publish form
                 const scenesList = page.waitForResponse(/playcanvas.com\/api\/projects\/\d+\/scenes/);
-                await page.getByRole('button', { name: 'Publish To PlayCanvas' }).click();
+                await page.locator('.builds-toolbar > .publish').click();
                 await scenesList;
-                await page.waitForSelector('.picker-publish-new > .publish.pcui-button:not(.pcui-disabled)');
-                await page.getByText('Publish Now').click();
-                await page.waitForSelector('.ui-list-item.complete', { timeout: 3 * 60 * 1000 });
+
+                // start publish build
+                await page.waitForSelector('.picker-publish-new > .form-footer > .publish.pcui-button:not(.pcui-disabled)');
+                await page.locator('.picker-publish-new > .form-footer > .publish').click();
+
+                // wait for the new build to complete in the history list
+                await page.waitForSelector('.build-item.publish.complete .row-artifact.open', { timeout: 3 * 60 * 1000 });
 
                 // launch app
                 const appPagePromise = page.waitForEvent('popup');
-                await page.getByText(projectName, { exact: true }).click();
+                await page.locator('.build-item.publish.complete .row-artifact.open').first().click();
                 const appPage = await appPagePromise;
                 await appPage.waitForURL('**/b/**', { waitUntil: 'networkidle' });
                 await appPage.close();
 
                 // delete app
-                await page.getByRole('button', { name: '' }).click();
-                await page.locator('.pcui-menu-item').filter({ hasText: /^Delete$/ }).first().click();
+                await page.locator('.build-item.publish.complete .kebab').first().click();
+                await page.locator('.picker-builds-menu .pcui-menu-item').filter({ hasText: /^Delete$/ }).first().click();
                 await page.getByRole('button', { name: 'Yes' }).click();
+                await page.waitForSelector('.build-item.publish', { state: 'detached' });
+
+                // dismiss dialog
+                await page.locator('.picker-project .close').first().click();
             })).toStrictEqual([]);
         });
     }


### PR DESCRIPTION
## Summary
- Redesigns the builds panel: modernized build history list, primary build card, and a dedicated build detail page (replacing inline expand)
- Adds build history filters driven through the server, with filtered rows and separators hidden client-side
- Modernizes the publish and download pages with copy buttons, skeleton loading states, a build timeline, form hints, and restored icons on publish/download buttons
- Extends editor-api with new project REST endpoints and models to support the above

## Preview
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/d59e8d63-faff-41a0-a365-c1cdd8629fea" />

<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/df482352-db00-4187-8266-43b9da65eb5f" />

<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/6e7ed298-915b-4a51-aa0b-f6446f63f067" />


## Test Plan
- [x] `npm test` passes (157 passing)
- [x] Open the builds panel and verify the history list, filters, and build detail page render and behave correctly
- [x] Publish a new build and download an existing one to verify both flows end to end
- [x] Verify the empty builds message mentions both build types