### PR TITLE
Fix builds panel view counts, text selection and primary permalink

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4911,8 +4911,8 @@ strong {
         overflow: hidden;
         background: transparent;
 
-        // shared row columns: status | name | branch | artifact | date | kebab
-        grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) 32px max-content max-content;
+        // shared row columns: status | name | branch | views | artifact | date | kebab
+        grid-template-columns: max-content minmax(0, 1fr) minmax(0, 200px) max-content 32px max-content max-content;
         column-gap: 14px;
 
         &:not(.pcui-hidden) {
@@ -5028,6 +5028,29 @@ strong {
                         overflow: hidden;
                         text-overflow: ellipsis;
                         white-space: nowrap;
+                    }
+                }
+
+                > .row-views {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 5px;
+                    justify-self: end;
+                    color: $text-dark;
+                    font-size: 12px;
+                    white-space: nowrap;
+
+                    &::before {
+                        content: '';
+                        flex: 0 0 auto;
+                        width: 14px;
+                        height: 14px;
+                        background-color: currentcolor;
+                        mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 3.3c3.2 0 5.7 2.1 7 4.7-1.3 2.6-3.8 4.7-7 4.7S2.3 10.6 1 8c1.3-2.6 3.8-4.7 7-4.7Zm0 1.5C5.7 4.8 3.8 6 2.7 8c1.1 2 3 3.2 5.3 3.2s4.2-1.2 5.3-3.2C12.2 6 10.3 4.8 8 4.8Zm0 1.2a2 2 0 1 1 0 4 2 2 0 0 1 0-4Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                    }
+
+                    &.placeholder {
+                        visibility: hidden;
                     }
                 }
 
@@ -5225,6 +5248,13 @@ strong {
 .picker-build-detail {
     padding: 18px 20px 24px !important;
     color: $text-primary;
+
+    // the overlay disables selection globally; detail fields are read-only so allow copying them
+    user-select: text;
+
+    button {
+        user-select: none;
+    }
 
     > .back {
         @extend .font-bold;

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -5249,7 +5249,8 @@ strong {
     padding: 18px 20px 24px !important;
     color: $text-primary;
 
-    // the overlay disables selection globally; detail fields are read-only so allow copying them
+    // detail text is read-only and tagged .selectable, which exempts it from the
+    // global mousedown preventDefault in layout.ts; user-select pairs with that
     user-select: text;
 
     button {

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4288,7 +4288,17 @@ strong {
                     font-size: 16px;
                     line-height: 20px;
                     box-shadow: none;
+                    position: relative;
                     transition: color 100ms;
+
+                    > .primary-tooltip-anchor {
+                        position: absolute;
+                        top: 50%;
+                        left: 0;
+                        width: 100%;
+                        height: 0;
+                        pointer-events: none;
+                    }
 
                     &:not(.disabled):hover {
                         color: $text-dark;

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -4679,6 +4679,8 @@ strong {
 
     // shared badge pills (list rows + detail header)
     .badge {
+        @extend .font-regular;
+
         flex: 0 0 auto;
         height: 18px;
         line-height: 18px;
@@ -5360,6 +5362,8 @@ strong {
     }
 
     .badge {
+        @extend .font-regular;
+
         flex: 0 0 auto;
         height: 18px;
         line-height: 18px;

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -5391,7 +5391,6 @@ strong {
     .name-row {
         display: flex;
         align-items: center;
-        flex-wrap: wrap;
         gap: 8px;
         min-width: 0;
         line-height: 20px;

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1531,6 +1531,16 @@ editor.once('load', () => {
         name.textContent = app.name;
         nameRow.appendChild(name);
 
+        const typeBadge = document.createElement('span');
+        typeBadge.classList.add('badge', app.type);
+        typeBadge.textContent = getTypeLabel(app);
+        nameRow.appendChild(typeBadge);
+
+        const formatBadge = document.createElement('span');
+        formatBadge.classList.add('badge');
+        formatBadge.textContent = getFormatValue(app);
+        nameRow.appendChild(formatBadge);
+
         const primaryBadge = document.createElement('span');
         primaryBadge.classList.add('badge', 'primary-badge');
         primaryBadge.textContent = 'Primary';

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1311,6 +1311,18 @@ editor.once('load', () => {
         branch.appendChild(branchName);
         row.appendChild(branch);
 
+        // views only exist for published builds; placeholder keeps the subgrid columns aligned
+        const views = document.createElement('span');
+        views.classList.add('row-views');
+        if (app.type === 'publish') {
+            views.textContent = String(app.views ?? 0);
+            views.title = 'Views';
+        } else {
+            views.classList.add('placeholder');
+            views.setAttribute('aria-hidden', 'true');
+        }
+        row.appendChild(views);
+
         const artifact = document.createElement('a');
         artifact.classList.add('row-artifact');
         if (app.task.status === 'complete' && app.url) {

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -766,7 +766,8 @@ editor.once('load', () => {
     const createValue = function (row: any) {
         const value = row.value;
         const val = document.createElement('span');
-        val.classList.add('value');
+        // 'selectable' exempts text from the global mousedown preventDefault in layout.ts
+        val.classList.add('value', 'selectable');
         if (row.variant) {
             val.classList.add(`metadata-${row.variant}`);
         }
@@ -789,11 +790,12 @@ editor.once('load', () => {
         section.classList.add('detail-section');
 
         const heading = document.createElement('h3');
+        heading.classList.add('selectable');
         heading.textContent = title;
         section.appendChild(heading);
 
         const grid = document.createElement('div');
-        grid.classList.add('metadata-grid');
+        grid.classList.add('metadata-grid', 'selectable');
         section.appendChild(grid);
 
         rows.forEach((row) => {
@@ -806,7 +808,7 @@ editor.once('load', () => {
             item.classList.add('detail-row');
 
             const key = document.createElement('span');
-            key.classList.add('key');
+            key.classList.add('key', 'selectable');
             key.textContent = row.label;
             item.appendChild(key);
 
@@ -820,12 +822,12 @@ editor.once('load', () => {
     // checklist of all build options with on / off state
     const getBuildOptions = function (settings: any) {
         const list = document.createElement('span');
-        list.classList.add('options-list');
+        list.classList.add('options-list', 'selectable');
         list.setAttribute('role', 'list');
         BUILD_OPTIONS.forEach(([key, label]) => {
             const item = document.createElement('span');
             item.setAttribute('role', 'listitem');
-            item.classList.add('option');
+            item.classList.add('option', 'selectable');
             if (!settings[key]) {
                 item.classList.add('off');
             }
@@ -884,6 +886,7 @@ editor.once('load', () => {
         section.classList.add('detail-section', 'artifact-section');
 
         const heading = document.createElement('h3');
+        heading.classList.add('selectable');
         heading.textContent = 'Artifacts';
         section.appendChild(heading);
 
@@ -904,6 +907,7 @@ editor.once('load', () => {
         section.classList.add('detail-section', 'timeline-section');
 
         const heading = document.createElement('h3');
+        heading.classList.add('selectable');
         heading.textContent = 'Timeline';
         section.appendChild(heading);
 
@@ -950,13 +954,13 @@ editor.once('load', () => {
             head.appendChild(dot);
 
             const label = document.createElement('span');
-            label.classList.add('step-label');
+            label.classList.add('step-label', 'selectable');
             label.textContent = step.label;
             head.appendChild(label);
 
             if (step.sub) {
                 const sub = document.createElement('div');
-                sub.classList.add('step-sub');
+                sub.classList.add('step-sub', 'selectable');
                 sub.textContent = step.sub;
                 item.appendChild(sub);
             }
@@ -972,7 +976,7 @@ editor.once('load', () => {
         const actor = app.actor && (app.actor.name || app.actor.username);
         const source = app.source && (app.source.name || app.source.type);
         const details = document.createElement('div');
-        details.classList.add('detail-body');
+        details.classList.add('detail-body', 'selectable');
 
         details.appendChild(createTimeline(app));
 
@@ -1143,7 +1147,7 @@ editor.once('load', () => {
         nameRow.appendChild(status);
 
         const name = document.createElement('span');
-        name.classList.add('name');
+        name.classList.add('name', 'selectable');
         name.textContent = app.name;
         nameRow.appendChild(name);
 
@@ -1170,14 +1174,14 @@ editor.once('load', () => {
             heading.appendChild(stats);
 
             const views = document.createElement('span');
-            views.classList.add('metric', 'views');
+            views.classList.add('metric', 'views', 'selectable');
             views.title = 'Views';
             views.textContent = String(app.views ?? 0);
             stats.appendChild(views);
         }
 
         const sub = document.createElement('div');
-        sub.classList.add('sub');
+        sub.classList.add('sub', 'selectable');
         sub.textContent = [
             getStatusLabel(app),
             app.build_job_id ? `Build #${app.build_job_id}` : null,
@@ -1222,7 +1226,7 @@ editor.once('load', () => {
 
         if (app.task.status === 'error' && app.task.message) {
             const error = document.createElement('div');
-            error.classList.add('error');
+            error.classList.add('error', 'selectable');
             error.textContent = app.task.message;
             detailPanel.element.appendChild(error);
         }

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -74,6 +74,8 @@ editor.once('load', () => {
     let openingBuildForm = false;
     let openingBuilds = false;
     let reloadOnNextShow = false;
+    let primaryFallback = null;  // primary app fetched by id when missing from the loaded pages
+    let primaryFallbackId = null;  // last id fetched for the fallback (one attempt per id)
     const filters: Record<string, string> = {};
     const filterButtons: Record<string, Button> = {};
     const filterMenus: Record<string, Menu> = {};
@@ -1561,10 +1563,34 @@ editor.once('load', () => {
         primaryBuild.dom.appendChild(card);
     };
 
+    // the builds and apps endpoints are paginated, so a primary build older than the
+    // loaded pages may be missing from the list; fetch the app row directly by id
+    const fetchPrimaryFallback = function (id: number) {
+        if (primaryFallbackId === id) {
+            return;
+        }
+        primaryFallbackId = id;
+        editor.api.globals.rest.apps.appGet(id).on('load', (status, data) => {
+            if (config.project.primaryApp !== id || !data) {
+                return;
+            }
+            primaryFallback = normalizeLegacyApp(data);
+            renderPrimaryBuild();
+        });
+    };
+
     const renderPrimaryBuild = function () {
+        const primaryId = config.project.primaryApp;
         // filtering means browsing history; the primary summary only shows on the unfiltered view
-        const app = hasActiveFilters() ? null :
-            apps.find(item => item.type === 'publish' && item.app_id === config.project.primaryApp);
+        let app = hasActiveFilters() || !primaryId ? null :
+            apps.find(item => item.type === 'publish' && item.app_id === primaryId);
+        if (!app && primaryId && !hasActiveFilters()) {
+            if (primaryFallback && primaryFallback.app_id === primaryId) {
+                app = primaryFallback;
+            } else {
+                fetchPrimaryFallback(primaryId);
+            }
+        }
         primaryBuildHeading.hidden = !app;
         primaryBuild.hidden = !app;
 
@@ -1635,6 +1661,8 @@ editor.once('load', () => {
         loadedAppIndex = false;
         detailApp = null;
         reloadOnNextShow = false;
+        primaryFallback = null;
+        primaryFallbackId = null;
         primaryBuild.dom.innerHTML = '';
         container.dom.innerHTML = '';
         container.dom.appendChild(noMatchingBuilds.dom);

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -409,8 +409,12 @@ editor.once('load', () => {
     const toggleProgress = function (toggle: boolean) {
         skeleton.hidden = !toggle;
         container.hidden = toggle || apps.length === 0;
-        primaryBuildHeading.hidden = true;
-        primaryBuild.hidden = true;
+        // only hide the primary card on the initial empty load; reloads (e.g. filter
+        // changes) keep it in place so the layout doesn't jump
+        if (apps.length === 0) {
+            primaryBuildHeading.hidden = true;
+            primaryBuild.hidden = true;
+        }
         noBuilds.hidden = toggle || apps.length > 0;
         noMatchingBuilds.hidden = true;
     };
@@ -1610,10 +1614,10 @@ editor.once('load', () => {
 
     const renderPrimaryBuild = function () {
         const primaryId = config.project.primaryApp;
-        // filtering means browsing history; the primary summary only shows on the unfiltered view
-        let app = hasActiveFilters() || !primaryId ? null :
-            apps.find(item => item.type === 'publish' && item.app_id === primaryId);
-        if (!app && primaryId && !hasActiveFilters()) {
+        // the card stays visible while filtering so the layout doesn't jump
+        let app = primaryId ?
+            apps.find(item => item.type === 'publish' && item.app_id === primaryId) : null;
+        if (!app && primaryId) {
             if (primaryFallback && primaryFallback.app_id === primaryId) {
                 app = primaryFallback;
             } else {

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1531,6 +1531,11 @@ editor.once('load', () => {
         name.textContent = app.name;
         nameRow.appendChild(name);
 
+        const primaryBadge = document.createElement('span');
+        primaryBadge.classList.add('badge', 'primary-badge');
+        primaryBadge.textContent = 'Primary';
+        nameRow.appendChild(primaryBadge);
+
         const sub = document.createElement('div');
         sub.classList.add('sub');
         const actor = app.actor && (app.actor.name || app.actor.username);

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,9 +1,10 @@
 import { Container, Label, Menu, MenuItem, Button } from '@playcanvas/pcui';
 
-import { bytesToHuman, convertDatetime } from '@/common/utils';
+import { bytesToHuman, convertDatetime, countToHuman } from '@/common/utils';
 import { config } from '@/editor/config';
 
 const APP_LIMIT = 16;
+const APP_INDEX_PAGE = 128;
 const FILTER_ALL = 'all';
 const BUILD_FILTERS = [{
     key: 'type',
@@ -414,21 +415,33 @@ editor.once('load', () => {
         noMatchingBuilds.hidden = true;
     };
 
+    // job rows depend on this index for app metadata like the view count, and the
+    // endpoint treats limit 0 as 16, so page through every app explicitly
     const loadAppIndex = function (done: () => void) {
         if (loadedAppIndex) {
             done();
             return;
         }
 
-        editor.api.globals.rest.projects.projectApps().on('load', (status, data) => {
-            appList = (data?.result || []).slice();
-            appIndex = {};
-            appList.forEach((app) => {
-                appIndex[String(app.id)] = app;
+        const fetched = [];
+        const fetchPage = function (skip: number) {
+            editor.api.globals.rest.projects.projectApps(APP_INDEX_PAGE, skip).on('load', (status, data) => {
+                const page = data?.result || [];
+                fetched.push(...page);
+                if (page.length === APP_INDEX_PAGE) {
+                    fetchPage(skip + APP_INDEX_PAGE);
+                    return;
+                }
+                appList = fetched.slice();
+                appIndex = {};
+                appList.forEach((app) => {
+                    appIndex[String(app.id)] = app;
+                });
+                loadedAppIndex = true;
+                done();
             });
-            loadedAppIndex = true;
-            done();
-        });
+        };
+        fetchPage(0);
     };
 
     const compareBuildDate = function (a: any, b: any) {
@@ -852,13 +865,13 @@ editor.once('load', () => {
         card.appendChild(body);
 
         const title = document.createElement('div');
-        title.classList.add('artifact-title');
+        title.classList.add('artifact-title', 'selectable');
         title.textContent = app.type === 'download' ? 'zip' : 'app';
         body.appendChild(title);
 
         if (artifact.bytes !== null && artifact.bytes !== undefined) {
             const meta = document.createElement('div');
-            meta.classList.add('artifact-meta');
+            meta.classList.add('artifact-meta', 'selectable');
             meta.textContent = bytesToHuman(artifact.bytes);
             body.appendChild(meta);
         }
@@ -1321,8 +1334,9 @@ editor.once('load', () => {
         const views = document.createElement('span');
         views.classList.add('row-views');
         if (app.type === 'publish') {
-            views.textContent = String(app.views ?? 0);
-            views.title = 'Views';
+            const count = Number(app.views) || 0;
+            views.textContent = countToHuman(count);
+            views.title = count === 1 ? '1 view' : `${count} views`;
         } else {
             views.classList.add('placeholder');
             views.setAttribute('aria-hidden', 'true');

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1517,20 +1517,22 @@ editor.once('load', () => {
         sub.textContent = [`Last published ${formatBuildDate(app.created_at)}`, actor ? `by ${actor}` : null].filter(Boolean).join(' · ');
         body.appendChild(sub);
 
-        if (app.url) {
+        // the permalink always points at the current primary build, unlike the build-specific url
+        const url = config.project.playUrl || app.url;
+        if (url) {
             const urlRow = document.createElement('div');
             urlRow.classList.add('url-row');
             body.appendChild(urlRow);
 
             const link = document.createElement('a');
             link.classList.add('url');
-            link.href = app.url;
+            link.href = url;
             link.target = '_blank';
             link.rel = 'noopener';
-            link.textContent = app.url;
+            link.textContent = url;
             urlRow.appendChild(link);
 
-            urlRow.appendChild(createCopyButton(app.url, 'Copy URL'));
+            urlRow.appendChild(createCopyButton(url, 'Copy URL'));
         }
 
         const open = document.createElement('a');
@@ -1538,8 +1540,8 @@ editor.once('load', () => {
         open.target = '_blank';
         open.rel = 'noopener';
         open.setAttribute('aria-label', 'Open published build');
-        if (app.url) {
-            open.href = app.url;
+        if (url) {
+            open.href = url;
         }
         card.appendChild(open);
 

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -261,10 +261,12 @@ editor.once('load', () => {
         if (closeCallback && !closeCallback()) {
             return;
         }
-        if ((evt.target as HTMLElement).closest('.pcui-menu')) {
+        const target = evt.target as HTMLElement;
+        const tooltip = target.closest('.pcui-tooltip');
+        if (target.closest('.pcui-menu') || tooltip?.querySelector('.primary-scene-tooltip')) {
             return;
         }
-        const targetOverlay = (evt.target as HTMLElement).closest('.pcui-overlay');
+        const targetOverlay = target.closest('.pcui-overlay');
         if (targetOverlay && targetOverlay !== overlay.dom) {
             return;
         }

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -1,5 +1,5 @@
 import type { EventHandle } from '@playcanvas/observer';
-import { BooleanInput, Button, Container, Label, Progress, SelectInput, TextAreaInput, TextInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, Container, Element, Label, Progress, SelectInput, TextAreaInput, TextInput } from '@playcanvas/pcui';
 
 import { tooltip, tooltipSimpleItem } from '@/common/tooltips';
 import { LegacyList } from '@/common/ui/list';
@@ -731,6 +731,10 @@ editor.once('load', () => {
             text: '\uE223',
             class: 'primary'
         });
+        const tooltipAnchor = new Element({
+            class: 'primary-tooltip-anchor'
+        });
+        primary.dom.appendChild(tooltipAnchor.dom);
         row.element.appendChild(primary.dom);
 
         primary.on('click', () => {
@@ -756,6 +760,7 @@ editor.once('load', () => {
         tooltip().attach({
             container: tooltipSimpleItem({ text: tooltipText }),
             target: primary,
+            vertAlignEl: tooltipAnchor,
             align: 'right'
         });
         tooltipTargets.push(primary);

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -758,7 +758,7 @@ editor.once('load', () => {
         // show tooltip for primary scene icon
         const tooltipText = scene.id === primaryScene ? 'Primary Scene' : 'Set Primary Scene';
         tooltip().attach({
-            container: tooltipSimpleItem({ text: tooltipText }),
+            container: tooltipSimpleItem({ text: tooltipText, classNames: ['primary-scene-tooltip'] }),
             target: primary,
             vertAlignEl: tooltipAnchor,
             align: 'right'


### PR DESCRIPTION
Follow-ups to the builds panel redesign (#2080).

- Restore the views counter on publish rows, left of the open icon. Fixes #2085
- Make read-only text in the build detail page selectable — tag it with the `selectable` class exempted from the global mousedown `preventDefault()`. Checkpoint text is deferred to the version control picker redesign. Fixes #2084
- Show the project permalink (`playUrl`) on the primary build card instead of the build-specific `/b/` URL. Fixes #2086
- Page through the full app index — the apps endpoint treats `limit=0` as 16, which hid builds older than the 16 newest apps and zeroed their view counts. Fixes #2083
- Fetch the primary app by id when it falls outside the loaded pages, so the primary card no longer depends on pagination.
- Polish: primary card shows the type/format/primary pills, pills share `font-regular` styling everywhere, the detail hero no longer wraps badges (long names truncate), and the primary card stays visible while filtering instead of jumping in and out.
- Keep the picker open when clicking a tooltip — tooltips mount outside the overlay content, so the clickable overlay treated them as backdrop clicks and closed (reported on Discord with the set-primary-scene icon in the download form).