### PR TITLE
fix: vc diff overlay underlapping toolbar + flatten close button

### DIFF
--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -10,7 +10,9 @@ $vc-add-edge: #3fb950;
 
     > .pcui-overlay-content {
         position: absolute;
-        inset: 0;
+
+        // sit right of the 40px left toolbar (#layout-root grid column) instead of underlapping it
+        inset: 0 0 0 40px;
         display: flex;
     }
 }
@@ -47,6 +49,14 @@ $vc-add-edge: #3fb950;
 
     > .vc-diff-close {
         margin-left: auto;
+        background: transparent;
+        border: 0;
+
+        &:hover {
+            border: 0;
+            box-shadow: none;
+            color: $text-active;
+        }
     }
 }
 


### PR DESCRIPTION
### What's Changed
Two styling fixes for the version control full-diff overlay (`_editor-version-control-diff.scss`):

- **Overlay underlapped the left toolbar.** The overlay content was positioned at `inset: 0`, spanning the full viewport including the 40px left toolbar column. `#layout-toolbar` (z-index 400) paints over the overlay (z-index 300), clipping the left edge of the diff sidebar ("Changes"/"CONFIG"/"GAMEPLAY" rendered as "nges"/"FIG"/"EPLAY"). Offset the overlay by `inset: 0 0 0 40px` so it sits beside the toolbar instead of under it.
- **Close button styling.** The overlay close button inherited the default PCUI button border/background box, inconsistent with the editor's borderless icon-button close controls. Made it `background: transparent; border: 0` with a color-only active hover, matching the existing flat close-button convention.

### Verification
- Stylelint clean on the file
- `sass/editor.scss` compiles successfully; confirmed both declarations land in the output CSS

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)