### PR TITLE
feat(material): show "Enable GGX Specular" toggle for all users

### DIFF
--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1393,13 +1393,6 @@ class MaterialAssetInspector extends Container {
         this._refractionInspector.getField('data.dispersion').parent.hidden = !pathExists(pc, 'StandardMaterial.prototype.dispersion');
         this._ambientInspector.getField('data.aoIntensity').parent.hidden = !pathExists(pc, 'StandardMaterial.prototype.aoIntensity');
 
-        // separated out because it needs more work before release
-        if (!editor.call('users:hasFlag', 'hasAnisoGGXSpec')) {
-
-            this._specularInspector.getField('data.enableGGXSpecular').parent.hidden = true;
-
-        }
-
         this._assets = null;
         this._suppressToggleFields = false;
         this._suppressOffsetTilingAndRotationFields = false;


### PR DESCRIPTION
## Summary

Removes the per-user `hasAnisoGGXSpec` feature-flag gate on the **Enable GGX Specular** control in the material inspector's Specular section. The toggle is now visible for **all accounts**, with its **default unchanged (`false`)** — so existing materials and projects are visually unaffected and GGX stays opt-in.

## Why

The gate caused the option to appear for some accounts (flagged users + superusers) and not others, generating user/support confusion (we received a report about exactly this). The feature is fully implemented in the engine, already documented in the public user manual (`user-manual/editor/assets/inspectors/material.md`), and the original cautionary reason for gating it — *"separated out because it needs more work before release"* — referred to the lack of a dedicated isotropic GGX path, which has since landed in the engine (playcanvas/engine#8299, closing playcanvas/engine#8295).

The control was originally added by #89, which was closed as *done* with the gate still in place, so nothing was tracking its removal.

## Change

```diff
-        // separated out because it needs more work before release
-        if (!editor.call('users:hasFlag', 'hasAnisoGGXSpec')) {
-            this._specularInspector.getField('data.enableGGXSpecular').parent.hidden = true;
-        }
```

- Toggle visible for all users; default stays unchecked (`false`).
- Anisotropy sub-fields continue to show/hide based on the toggle value (`material.ts` `_toggleAnisotropyFields`), unchanged.
- No remaining `hasAnisoGGXSpec` references in `src/`. The server-side flag definition can be cleaned up separately.

## Out of scope

Whether GGX should become the **default** (or Blinn-Phong be deprecated/removed) is an engine-side decision tracked in playcanvas/engine#8296. This PR only un-gates the existing opt-in toggle; if the engine later changes the default, the editor UI should follow separately.

## Testing

- Static: confirmed no remaining `hasAnisoGGXSpec` references; the only behavioral line removed is the visibility gate.
- The "Enable GGX Specular" row now renders in the Specular section regardless of account flags; toggling it on/off shows/hides the anisotropy map, intensity and rotation fields as before.

Relates to #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)