### PR TITLE
Version control diff viewer: structured diffs, name resolution, delta lists

### DIFF
--- a/sass/editor/_editor-common.scss
+++ b/sass/editor/_editor-common.scss
@@ -81,3 +81,25 @@ $component-icons: (
         }
     }
 }
+
+// hover tooltip for ellipsis-truncated text (see ellipsis-tooltip.ts); body-level
+// so it escapes the pickers' overflow clipping
+.ellipsis-tooltip {
+    position: fixed;
+    z-index: 1000000;
+    max-width: 420px;
+    padding: 5px 9px;
+    border: 1px solid $border-primary;
+    border-radius: 4px;
+    background-color: $bcg-darkest;
+    color: $text-primary;
+    font-size: 12px;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 35%);
+    pointer-events: none;
+
+    &[hidden] {
+        display: none;
+    }
+}

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -333,12 +333,6 @@ $vc-add-edge: #3fb950;
     > .vc-diff-entity-tree {
         margin-bottom: 6px;
         pointer-events: none;
-
-        // the root item's connector spine reaches up to a parent that doesn't
-        // exist; collapse it so the orphaned line is gone
-        > .pcui-treeview-item::before {
-            height: 0;
-        }
     }
 }
 
@@ -498,6 +492,11 @@ $vc-add-edge: #3fb950;
         color: $text-dark;
         font-size: 10px;
     }
+}
+
+// entity-id remap shown as a count; the full mapping is available on hover
+.vc-diff-entity-map {
+    color: $text-dark;
 }
 
 // ---- text diff iframe (existing behaviour) ----

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -390,6 +390,18 @@ $vc-add-edge: #3fb950;
     min-height: 32px;
     padding: 3px 10px 3px 6px;
 
+    // a tall multi-item list pins the gutter + field name to the top (with a
+    // little breathing room) instead of floating them in the centre; single
+    // values stay vertically centred
+    &:has(.vc-diff-array.multi) {
+        align-items: flex-start;
+
+        > .gutter,
+        > .label {
+            margin-top: 6px;
+        }
+    }
+
     > .gutter {
         flex: none;
         width: 14px;
@@ -471,6 +483,10 @@ $vc-add-edge: #3fb950;
     max-width: 100%;
     height: 24px;
     padding: 0 7px;
+
+    // reset the fixed-px line-height inherited from pcui so the full-size name
+    // doesn't sit low on its baseline while the small uppercase tag centres
+    line-height: normal;
     background-color: $bcg-dark;
     border: 1px solid $bcg-darker;
     border-radius: 2px;
@@ -486,12 +502,52 @@ $vc-add-edge: #3fb950;
     > .tag {
         color: $text-darkest;
         font-size: 10px;
+
+        // collapse the inherited line box so the small uppercase label centres
+        // against the chip instead of sitting high on its baseline
+        line-height: 1;
         text-transform: uppercase;
+    }
+
+    > .sign {
+        flex: none;
+        line-height: 1;
+        font-family: inconsolatamedium, Monaco, Menlo, monospace;
+    }
+
+    // plain pills (tags) carry no type label — render a touch smaller
+    &.pill {
+        gap: 4px;
+        height: 20px;
+        padding: 0 6px;
+        font-size: 11px;
     }
 
     &.missing > .name {
         color: $text-darkest;
         font-style: italic;
+    }
+
+    // membership-delta chips: tint the chip (not the whole row) so a single
+    // changed list item doesn't read as the entire field being added/removed
+    &.added {
+        background-color: $vc-add-tint;
+        border-color: $vc-add-edge;
+
+        > .sign,
+        > .name {
+            color: #6fd088;
+        }
+    }
+
+    &.removed {
+        background-color: $vc-del-tint;
+        border-color: $vc-del-edge;
+
+        > .sign,
+        > .name {
+            color: #ff8a8a;
+        }
     }
 }
 

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -30,8 +30,12 @@ $vc-add-edge: #3fb950;
     flex: none;
     align-items: center;
     gap: 12px;
-    padding: 0 16px;
-    height: 48px;
+
+    // right padding equals the close button's vertical centring gap ((33 − 28) / 2) so its corner spacing is symmetric
+    padding: 0 2.5px 0 16px;
+
+    // match the picker-project panel header height (its content is offset by 33px)
+    height: 33px;
     background-color: $bcg-dark;
     border-bottom: 1px solid $border-primary;
 
@@ -48,7 +52,8 @@ $vc-add-edge: #3fb950;
     }
 
     > .vc-diff-close {
-        margin-left: auto;
+        // reset PCUI's default 6px margin so the header padding alone sets the corner gap; auto-left keeps it pushed right
+        margin: 0 0 0 auto;
         background: transparent;
         border: 0;
 

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -223,6 +223,95 @@ $vc-add-edge: #3fb950;
     text-align: center;
 }
 
+// loading skeleton — mirrors the sidebar list (dot + line rows) and the main
+// detail layout (header + panel blocks); reuses the picker's pulse keyframe
+.vc-diff-skeleton {
+    .bone {
+        border-radius: 4px;
+        background-color: rgb(255 255 255 / 8%);
+        animation: vc-skeleton-pulse 1.4s ease-in-out infinite;
+
+        &.line {
+            flex: 1 1 auto;
+            height: 10px;
+        }
+
+        &.title {
+            flex: none;
+            width: 180px;
+            height: 14px;
+        }
+
+        &.badge {
+            flex: none;
+            width: 58px;
+            height: 16px;
+        }
+
+        &.label {
+            flex: none;
+            width: 30%;
+            max-width: 180px;
+            height: 10px;
+        }
+
+        &.value {
+            flex: 1 1 auto;
+            height: 10px;
+        }
+    }
+
+    // sidebar rows: name + status badge (no leading icon, matching .vc-diff-row)
+    > .skeleton-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 11px 12px;
+        border-bottom: 1px solid $border-primary;
+    }
+
+    &.main {
+        padding: 12px 16px;
+
+        > .skeleton-head {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 14px;
+        }
+
+        // panel: header bar over field rows, like .vc-diff-panel
+        > .skeleton-panel {
+            margin-bottom: 10px;
+            border: 1px solid $border-primary;
+            border-radius: 3px;
+            overflow: hidden;
+
+            > .skeleton-phead {
+                padding: 10px 12px;
+                background-color: $bcg-dark;
+                border-bottom: 1px solid $border-primary;
+
+                > .bone.line {
+                    max-width: 120px;
+                }
+            }
+
+            > .skeleton-field {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 9px 12px;
+                border-bottom: 1px solid $border-primary;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+    }
+}
+
 // ---- inspector sections ----
 .vc-diff-inspector {
     display: flex;

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -326,13 +326,32 @@ $vc-add-edge: #3fb950;
 .vc-diff-inspector {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+
+    // more space between cards than within one (tree -> panels is 6px below)
+    // so each entity's breadcrumb + panels reads as a single grouped unit
+    gap: 16px;
 }
 
 .vc-diff-section {
     > .vc-diff-entity-tree {
         margin-bottom: 6px;
         pointer-events: none;
+
+        // the root's own spine is the leftmost vertical and never connects to
+        // anything (each child draws its own spine + elbow), so collapse it in
+        // every case. top: only relocates the stub; height: 0 removes it.
+        > .pcui-treeview-item {
+            &::before {
+                height: 0;
+            }
+
+            // the root's horizontal elbow only dangles when the root is a leaf
+            // (single-node tree). with children the elbow is the junction to
+            // the first child's spine, so keep it — hide it for leaves only.
+            &.pcui-treeview-item-empty > .pcui-treeview-item-contents > .pcui-treeview-item-icon::before {
+                display: none;
+            }
+        }
     }
 }
 

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -88,16 +88,22 @@ $vc-add-edge: #3fb950;
 
         padding: 10px 12px;
         color: $text-primary;
-        font-size: 12px;
+        font-size: 13px;
         border-bottom: 1px solid $border-primary;
     }
 
     > .vc-diff-group {
-        padding: 8px 12px 4px;
-        color: $text-dark;
+        @extend .font-bold;
+
+        // match the picker's section bars (.vc-group): bold + dark bar so the
+        // header reads distinctly from the $text-dark sub line below it
+        padding: 5px 12px;
+        background-color: rgb(0 0 0 / 12%);
+        border-bottom: 1px solid $border-primary;
+        color: $text-secondary;
         font-size: 10px;
+        letter-spacing: 0.4px;
         text-transform: uppercase;
-        letter-spacing: 0.5px;
     }
 
     > .vc-diff-row {
@@ -115,7 +121,7 @@ $vc-add-edge: #3fb950;
         border-bottom: 1px solid $border-primary;
         background: transparent;
         color: $text-primary;
-        font-size: 12px;
+        font-size: 13px;
         text-align: left;
         cursor: pointer;
         transition: background-color 100ms ease;
@@ -141,12 +147,12 @@ $vc-add-edge: #3fb950;
             width: 100%;
             order: 3;
             color: $text-dark;
-            font-size: 10px;
+            font-size: 11px;
         }
 
         > .counts {
             order: 4;
-            font-size: 10px;
+            font-size: 11px;
         }
 
         > .status {

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -10,7 +10,9 @@ $vc-add-edge: #3fb950;
 
     > .pcui-overlay-content {
         position: absolute;
-        inset: 0;
+
+        // sit right of the 40px left toolbar (#layout-root grid column) instead of underlapping it
+        inset: 0 0 0 40px;
         display: flex;
     }
 }
@@ -47,6 +49,14 @@ $vc-add-edge: #3fb950;
 
     > .vc-diff-close {
         margin-left: auto;
+        background: transparent;
+        border: 0;
+
+        &:hover {
+            border: 0;
+            box-shadow: none;
+            color: $text-active;
+        }
     }
 }
 

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -57,10 +57,14 @@ $vc-add-edge: #3fb950;
         background: transparent;
         border: 0;
 
+        // match the version control picker's header close (picker-project .close)
+        color: $text-secondary;
+        font-size: 14px;
+
         &:hover {
             border: 0;
             box-shadow: none;
-            color: $text-active;
+            color: $text-primary;
         }
     }
 }

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -333,6 +333,12 @@ $vc-add-edge: #3fb950;
     > .vc-diff-entity-tree {
         margin-bottom: 6px;
         pointer-events: none;
+
+        // the root item's connector spine reaches up to a parent that doesn't
+        // exist; collapse it so the orphaned line is gone
+        > .pcui-treeview-item::before {
+            height: 0;
+        }
     }
 }
 

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -939,6 +939,35 @@
         }
     }
 
+    // changes-tab preview: structured property diff (compact) above any textual file rows
+    .vc-field-preview {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    // compact structured property diff reuses the full diff's .vc-diff-* classes;
+    // only density and the text breadcrumb differ from the overlay
+    .vc-card .vc-diff-inspector.compact {
+        gap: 8px;
+
+        .vc-diff-crumb {
+            padding-bottom: 8px;
+            overflow: hidden;
+            color: $text-secondary;
+            font-size: 13px;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        // field rows sit in pcui panel content (larger ambient); pin them to the
+        // breadcrumb's size so the preview's text scale stays consistent
+        .vc-diff-field-row {
+            min-height: 26px;
+            font-size: 12px;
+        }
+    }
+
     // grouped change list inside the detail diff card; no inner scroll —
     // the surrounding .vc-main is the single scroll context
     .vc-diff-list {

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -965,6 +965,15 @@
         .vc-diff-field-row {
             min-height: 26px;
             font-size: 12px;
+
+            // text values stay on one line and ellipsis; an unbreakable value would
+            // otherwise hard-clip at the pane edge (overflow-x is hidden)
+            > .value > span {
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
         }
     }
 

--- a/src/code-editor/monaco/diff-editor.ts
+++ b/src/code-editor/monaco/diff-editor.ts
@@ -14,6 +14,11 @@ const REGEX_HUNK = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@$/gm;
 
 const LARGE_FILE_SIZE = 300000;
 
+// colour every changed line; only bail on a pathological number of edits, so a
+// large file with few changes still gets colours (gate on changed-line count,
+// not total file size)
+const MAX_DIFF_OVERLAYS = 10000;
+
 class DiffEditor {
     type: string;
 
@@ -59,7 +64,6 @@ class DiffEditor {
 
     createOverlays() {
         const content = this.content;
-        const isLarge = (content.length > LARGE_FILE_SIZE);
         let match;
 
         let hunk;
@@ -83,7 +87,10 @@ class DiffEditor {
         // depending on the line contents
         const lineCount = this.model.getLineCount();
 
+        // hunk-label overlays are always applied; per-line add/remove colours
+        // are collected separately so they can be gated by their count
         const decorations = [];
+        const lineOverlays = [];
 
         for (let i = 0, len = hunks.length; i < len; i++) {
             hunk = hunks[i];
@@ -102,16 +109,14 @@ class DiffEditor {
                 if (line.startsWith('+')) {
                     showLine = true;
                     // 'add' overlay
-                    if (!isLarge) {
-                        decorations.push(this.createLineOverlay(j + 1, 'add'));
-                    }
-                } else if (!isLarge && line.startsWith('-')) {
+                    lineOverlays.push(this.createLineOverlay(j + 1, 'add'));
+                } else if (line.startsWith('-')) {
                     // if the line was removed from the current state
                     // then don't increase the line number
                     codeLine--;
 
                     // 'remove' overlay
-                    decorations.push(this.createLineOverlay(j + 1, 'remove'));
+                    lineOverlays.push(this.createLineOverlay(j + 1, 'remove'));
                 }
 
                 // line number (only for current state)
@@ -127,6 +132,11 @@ class DiffEditor {
                 text: `Lines ${hunk.hunkRightStart}-${codeLine - 1}:`,
                 range: new monaco.Range(hunk.hunkStart, 1, hunk.hunkStart, hunk.hunkLength + 1)
             }]);
+        }
+
+        // skip per-line colours only when there are pathologically many edits
+        if (lineOverlays.length <= MAX_DIFF_OVERLAYS) {
+            decorations.push(...lineOverlays);
         }
 
         this.decorations = this.monacoEditor.deltaDecorations(this.decorations, decorations);

--- a/src/common/ellipsis-tooltip.ts
+++ b/src/common/ellipsis-tooltip.ts
@@ -1,0 +1,104 @@
+// Lightweight hover tooltip for ellipsis-truncated text. Shows the full value
+// after a short, tunable delay — unlike the native `title` attribute, whose
+// ~1s delay the browser hard-codes. Delegated, so it survives re-renders and
+// needs no per-element setup: any titled element, or any truncated leaf text,
+// becomes hoverable. See gh issue 2088.
+
+const SHOW_DELAY = 400; // ms — snappier than native title, deliberate enough not to flicker on a quick pass
+const GAP = 6;
+
+let tipEl: HTMLDivElement = null;
+let timer: ReturnType<typeof setTimeout> = null;
+let active: HTMLElement = null;
+
+const getTip = () => {
+    if (!tipEl) {
+        tipEl = document.createElement('div');
+        tipEl.classList.add('ellipsis-tooltip');
+        tipEl.hidden = true;
+        document.body.appendChild(tipEl);
+    }
+    return tipEl;
+};
+
+const hide = () => {
+    if (timer) {
+        clearTimeout(timer);
+        timer = null;
+    }
+    if (tipEl) {
+        tipEl.hidden = true;
+    }
+    active = null;
+};
+
+const place = (el: HTMLElement) => {
+    const tip = getTip();
+    const r = el.getBoundingClientRect();
+    const t = tip.getBoundingClientRect();
+    const left = Math.max(GAP, Math.min(r.left + (r.width - t.width) / 2, window.innerWidth - t.width - GAP));
+    let top = r.bottom + GAP;
+    if (top + t.height > window.innerHeight - GAP) {
+        top = r.top - t.height - GAP;
+    }
+    tip.style.left = `${left}px`;
+    tip.style.top = `${Math.max(GAP, top)}px`;
+};
+
+export const installEllipsisTooltips = (root: HTMLElement) => {
+    const onOver = (e: PointerEvent) => {
+        const target = e.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+        let el = target.closest<HTMLElement>('[title], [data-ellipsis-tip]');
+        let full: string;
+        if (el && root.contains(el)) {
+            // migrate the native title once so the slow browser tooltip never fires
+            if (el.hasAttribute('title')) {
+                el.dataset.ellipsisTip = el.getAttribute('title') ?? '';
+                el.removeAttribute('title');
+            }
+            full = el.dataset.ellipsisTip ?? '';
+        } else {
+            // a truncated leaf text element shows its (clipped) full text
+            el = target;
+            full = el.children.length === 0 ? (el.textContent ?? '').trim() : '';
+        }
+        if (!el || !full || el === active) {
+            return;
+        }
+        const truncated = el.scrollWidth > el.clientWidth + 1;
+        // skip fully-visible text whose tooltip would just repeat it
+        if (!truncated && full === (el.textContent ?? '').trim()) {
+            return;
+        }
+        hide();
+        active = el;
+        timer = setTimeout(() => {
+            timer = null;
+            getTip().textContent = full;
+            getTip().hidden = false;
+            place(el);
+        }, SHOW_DELAY);
+    };
+
+    const onOut = (e: PointerEvent) => {
+        const to = e.relatedTarget;
+        if (active && (!(to instanceof HTMLElement) || !active.contains(to))) {
+            hide();
+        }
+    };
+
+    root.addEventListener('pointerover', onOver);
+    root.addEventListener('pointerout', onOut);
+    // a moved or scrolled target leaves the tooltip mispositioned
+    window.addEventListener('scroll', hide, true);
+
+    return () => {
+        root.removeEventListener('pointerover', onOver);
+        root.removeEventListener('pointerout', onOut);
+        window.removeEventListener('scroll', hide, true);
+        hide();
+    };
+};

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1417,6 +1417,13 @@ editor.once('load', () => {
     // CONTROLLERS
 
     // load build job list
+    // signature of everything the list rows + primary card render from, so a
+    // background refresh can skip the full teardown/rebuild when nothing changed
+    const appsFingerprint = function () {
+        const rows = apps.map(a => `${a.id}:${a.task?.status ?? ''}:${a.completed_at ?? ''}:${a.views ?? ''}`);
+        return `${config.project.primaryApp}|${rows.join(',')}`;
+    };
+
     const loadApps = function (showProgress: boolean = true) {
         skip = 0;
         hasMore = true;
@@ -1437,6 +1444,7 @@ editor.once('load', () => {
                 const legacy = appList
                 .filter(app => !ids.has(String(app.id)))
                 .map(normalizeLegacyApp);
+                const prevSig = appsFingerprint();
                 apps = rows.concat(legacy).sort(compareBuildDate);
                 hasMore = data.pagination ? rows.length < data.pagination.total : data.result.length === APP_LIMIT;
 
@@ -1444,7 +1452,14 @@ editor.once('load', () => {
                     toggleProgress(false);
                 }
 
-                refreshApps();
+                // explicit (progress) loads always re-render; a background refresh
+                // only tears down + rebuilds when the data actually changed, so a
+                // cached reopen doesn't reflow the whole list
+                if (showProgress || appsFingerprint() !== prevSig) {
+                    refreshApps();
+                } else {
+                    refreshFilterVisibility();
+                }
                 fillViewport();
             });
         });
@@ -1829,7 +1844,12 @@ editor.once('load', () => {
             loadApps(apps.length === 0);
             reloadOnNextShow = false;
         } else {
+            // cached (unfiltered) list is still in the DOM: show it instantly,
+            // re-apply visibility, and refresh in the background — no skeleton,
+            // no teardown, and the list only rebuilds if something changed
             refreshFilterVisibility();
+            loadedAppIndex = false;
+            loadApps(false);
         }
 
         if (editor.call('viewport:inViewport')) {
@@ -1846,7 +1866,12 @@ editor.once('load', () => {
             return;
         }
 
-        resetBuildsState();
+        // cache the loaded builds for an instant, reflow-free reopen; only a
+        // filtered session can't be reused (its rows are server-filtered), so
+        // reset just that case to keep the filter bar and data in sync
+        if (hasActiveFilters()) {
+            resetBuildsState();
+        }
 
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', true);
@@ -1867,7 +1892,11 @@ editor.once('load', () => {
             return;
         }
 
-        resetBuildsState();
+        // preserve the cache; only a filtered session needs a full reset (see
+        // the builds panel hide handler)
+        if (hasActiveFilters()) {
+            resetBuildsState();
+        }
 
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', true);
@@ -1875,7 +1904,7 @@ editor.once('load', () => {
     });
 
     editor.on('picker:close', (name) => {
-        if (name === 'project' && panel.hidden && detailPanel.hidden && (apps.length > 0 || loadedAppIndex || hasActiveFilters())) {
+        if (name === 'project' && panel.hidden && detailPanel.hidden && hasActiveFilters()) {
             resetBuildsState();
         }
     });

--- a/src/editor/pickers/picker-builds-publish.ts
+++ b/src/editor/pickers/picker-builds-publish.ts
@@ -1,5 +1,6 @@
 import { Container, Label, Menu, MenuItem, Button } from '@playcanvas/pcui';
 
+import { installEllipsisTooltips } from '@/common/ellipsis-tooltip';
 import { bytesToHuman, convertDatetime, countToHuman } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -250,6 +251,9 @@ editor.once('load', () => {
         flex: true,
         class: 'picker-build-detail'
     });
+
+    installEllipsisTooltips(panel.dom);
+    installEllipsisTooltips(detailPanel.dom);
 
     // pagination state for infinite scroll
     let skip = 0;

--- a/src/editor/pickers/version-control/branch-switcher.ts
+++ b/src/editor/pickers/version-control/branch-switcher.ts
@@ -167,41 +167,43 @@ export const createBranchSwitcher = (host: Container) => {
             sub.classList.add('sub');
             sub.textContent = 'current';
             row.appendChild(sub);
-        } else {
-            const actions = document.createElement('span');
-            actions.classList.add('row-actions');
-            row.appendChild(actions);
-
-            if (!branch.closed) {
-                const sw = document.createElement('button');
-                sw.type = 'button';
-                sw.classList.add('switch');
-                sw.textContent = 'Switch';
-                sw.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    hidePanel();
-                    button.emit('switch', branch);
-                });
-                actions.appendChild(sw);
-            }
-
-            const kebab = document.createElement('button');
-            kebab.type = 'button';
-            kebab.classList.add('kebab');
-            kebab.setAttribute('aria-label', 'Branch actions');
-            kebab.addEventListener('click', (e) => {
-                e.stopPropagation();
-                contextBranch = branch;
-                // hold the hover-revealed actions open while the menu is up
-                activeKebab = kebab;
-                kebab.classList.add('active');
-                row.classList.add('menu-open');
-                menu.hidden = false;
-                const rect = kebab.getBoundingClientRect();
-                menu.position(rect.right - menu.innerElement.clientWidth, rect.bottom);
-            });
-            actions.appendChild(kebab);
         }
+
+        const actions = document.createElement('span');
+        actions.classList.add('row-actions');
+        row.appendChild(actions);
+
+        // the current branch can't be switched to, but its menu still offers
+        // Copy Branch ID / Version Control Graph
+        if (!isCurrent(branch) && !branch.closed) {
+            const sw = document.createElement('button');
+            sw.type = 'button';
+            sw.classList.add('switch');
+            sw.textContent = 'Switch';
+            sw.addEventListener('click', (e) => {
+                e.stopPropagation();
+                hidePanel();
+                button.emit('switch', branch);
+            });
+            actions.appendChild(sw);
+        }
+
+        const kebab = document.createElement('button');
+        kebab.type = 'button';
+        kebab.classList.add('kebab');
+        kebab.setAttribute('aria-label', 'Branch actions');
+        kebab.addEventListener('click', (e) => {
+            e.stopPropagation();
+            contextBranch = branch;
+            // hold the hover-revealed actions open while the menu is up
+            activeKebab = kebab;
+            kebab.classList.add('active');
+            row.classList.add('menu-open');
+            menu.hidden = false;
+            const rect = kebab.getBoundingClientRect();
+            menu.position(rect.right - menu.innerElement.clientWidth, rect.bottom);
+        });
+        actions.appendChild(kebab);
 
         row.addEventListener('click', () => {
             hidePanel();

--- a/src/editor/pickers/version-control/branch-switcher.ts
+++ b/src/editor/pickers/version-control/branch-switcher.ts
@@ -27,6 +27,7 @@ export const createBranchSwitcher = (host: Container) => {
     button.dom.appendChild(labels);
     const nameEl = labels.querySelector('.name') as HTMLElement;
     nameEl.textContent = config.self.branch.name;
+    nameEl.title = config.self.branch.name;
 
     // dropdown panel floats inside the picker, anchored under the button
     const panel = new Container({ class: 'vc-branch-panel', hidden: true });
@@ -347,6 +348,7 @@ export const createBranchSwitcher = (host: Container) => {
                 load(true);
             }
             nameEl.textContent = config.self.branch.name;
+            nameEl.title = config.self.branch.name;
         },
         closePanel: hidePanel,
         getBranch: (id: string) => branches[id],

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -4,7 +4,7 @@ import { config } from '@/editor/config';
 
 import { templateEntitiesFor, templateEntityPath } from './vc-diff-data';
 import { renderPreviewPropertyDiff } from './vc-diff-preview';
-import { diffTextChangeCounts, hashChip, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
+import { diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
 export const createChangesPanel = () => {
@@ -240,7 +240,7 @@ export const createChangesPanel = () => {
     const renderFieldDiff = (conflict: any) => {
         const wrap = document.createElement('div');
         wrap.classList.add('vc-field-preview');
-        const data = conflict.data ?? [];
+        const data = (conflict.data ?? []).filter((e: any) => !isHiddenDiffField(e.path));
         const files = data.filter((e: any) => fileName(conflict, e, 'src') || fileName(conflict, e, 'dst'));
         const props = data.filter((e: any) => !(fileName(conflict, e, 'src') || fileName(conflict, e, 'dst')));
 

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -2,7 +2,8 @@ import { Container, TextAreaInput } from '@playcanvas/pcui';
 
 import { config } from '@/editor/config';
 
-import { diffTextChangeCounts, formatDiffPath, hashChip, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
+import { renderPreviewPropertyDiff } from './vc-diff-preview';
+import { diffTextChangeCounts, hashChip, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
 export const createChangesPanel = () => {
@@ -176,51 +177,6 @@ export const createChangesPanel = () => {
         return typeof name === 'string' ? name : undefined;
     };
 
-    const appendPath = (row: HTMLElement, path: HTMLElement, vals: HTMLElement, conflict: any, entry: any) => {
-        const value = entry.path;
-        path.title = value;
-        if (conflict.itemType !== 'scene' && conflict.itemType !== 'settings') {
-            path.textContent = value;
-            return false;
-        }
-        const info = formatDiffPath(value, conflict.itemType, entityName(conflict, value));
-        if (!info.labels.length) {
-            path.textContent = value;
-            return false;
-        }
-        row.classList.add('tree');
-        path.classList.add('tree');
-        vals.hidden = true;
-        const tree = document.createElement('span');
-        tree.classList.add('vc-path-tree');
-        info.labels.forEach((label, i) => {
-            const seg = document.createElement('span');
-            seg.classList.add('seg');
-            seg.style.paddingLeft = `${Math.min(i, 8) * 12}px`;
-            seg.textContent = label.text;
-            seg.title = label.title ?? label.text;
-            tree.appendChild(seg);
-        });
-        const line = (kind: string, text: string) => {
-            const seg = document.createElement('span');
-            seg.classList.add('change', kind);
-            seg.style.paddingLeft = `${Math.min(info.labels.length, 8) * 12}px`;
-            seg.textContent = text;
-            seg.title = text;
-            tree.appendChild(seg);
-        };
-        if (entry.missingInDst) {
-            line('new', `+ ${info.field}: ${fmtVal(entry.srcValue)}`);
-        } else if (entry.missingInSrc) {
-            line('old', `- ${info.field}: ${fmtVal(entry.dstValue)}`);
-        } else {
-            line('old', `- ${info.field}: ${fmtVal(entry.dstValue)}`);
-            line('new', `+ ${info.field}: ${fmtVal(entry.srcValue)}`);
-        }
-        path.appendChild(tree);
-        return true;
-    };
-
     const fileText = (entry: any) => {
         if (entry.missingInDst) {
             return 'added';
@@ -231,66 +187,50 @@ export const createChangesPanel = () => {
         return 'changed';
     };
 
-    // field-level rows for one conflict, straight from the loaded diff
-    const renderFieldDiff = (conflict: any) => {
+    // textual asset merges (e.g. scripts) — line counts; the preview can't host the full diff's iframe
+    const renderFileRows = (conflict: any, entries: any[]) => {
         const wrap = document.createElement('div');
         wrap.classList.add('vc-field-diff');
-        for (const entry of conflict.data ?? []) {
+        for (const entry of entries) {
             const row = document.createElement('div');
             row.classList.add('vc-field-row');
             const path = document.createElement('span');
             path.classList.add('path');
+            path.textContent = fileName(conflict, entry, 'src') ?? fileName(conflict, entry, 'dst');
             const vals = document.createElement('span');
             vals.classList.add('vals');
-
-            const srcName = fileName(conflict, entry, 'src');
-            const dstName = fileName(conflict, entry, 'dst');
-            if (srcName || dstName) {
-                path.textContent = srcName ?? dstName;
-                vals.textContent = 'Loading…';
-                loadLineCounts(conflict, entry).then((counts) => {
-                    if (!row.isConnected) {
-                        return;
-                    }
-                    vals.innerHTML = '';
-                    if (counts) {
-                        appendLineCounts(vals, counts);
-                    } else {
-                        vals.textContent = `${fileText(entry)} — use Open Full Diff to view`;
-                    }
-                });
-            } else if (!entry.path) {
-                // whole-item add/delete
-                path.textContent = conflict.itemName;
-                vals.textContent = entry.missingInDst ? 'added since the checkpoint' :
-                    entry.missingInSrc ? 'deleted since the checkpoint' : 'changed';
-            } else if (!appendPath(row, path, vals, conflict, entry)) {
-                // src is the working state (new), dst is the checkpoint (old)
-                if (entry.missingInDst) {
-                    const nv = document.createElement('span');
-                    nv.classList.add('new');
-                    nv.textContent = `+ ${fmtVal(entry.srcValue)}`;
-                    vals.appendChild(nv);
-                } else if (entry.missingInSrc) {
-                    const ov = document.createElement('span');
-                    ov.classList.add('old');
-                    ov.textContent = fmtVal(entry.dstValue);
-                    vals.appendChild(ov);
-                } else {
-                    const ov = document.createElement('span');
-                    ov.classList.add('old');
-                    ov.textContent = fmtVal(entry.dstValue);
-                    vals.appendChild(ov);
-                    vals.appendChild(document.createTextNode(' → '));
-                    const nv = document.createElement('span');
-                    nv.classList.add('new');
-                    nv.textContent = fmtVal(entry.srcValue);
-                    vals.appendChild(nv);
+            vals.textContent = 'Loading…';
+            loadLineCounts(conflict, entry).then((counts) => {
+                if (!row.isConnected) {
+                    return;
                 }
-            }
+                vals.innerHTML = '';
+                if (counts) {
+                    appendLineCounts(vals, counts);
+                } else {
+                    vals.textContent = `${fileText(entry)} — use Open Full Diff to view`;
+                }
+            });
             row.appendChild(path);
             row.appendChild(vals);
             wrap.appendChild(row);
+        }
+        return wrap;
+    };
+
+    // property diffs reuse the full diff's structured look (compact); textual merges stay as line-count rows
+    const renderFieldDiff = (conflict: any) => {
+        const wrap = document.createElement('div');
+        wrap.classList.add('vc-field-preview');
+        const data = conflict.data ?? [];
+        const files = data.filter((e: any) => fileName(conflict, e, 'src') || fileName(conflict, e, 'dst'));
+        const props = data.filter((e: any) => !(fileName(conflict, e, 'src') || fileName(conflict, e, 'dst')));
+
+        if (props.length) {
+            wrap.appendChild(renderPreviewPropertyDiff(conflict, props, { entityName, fmtVal }));
+        }
+        if (files.length) {
+            wrap.appendChild(renderFileRows(conflict, files));
         }
         return wrap;
     };

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -21,6 +21,8 @@ export const createChangesPanel = () => {
     // .then/.catch discard results when the generation has moved on (stale-response guard)
     let gen = 0;
     let rawDiffLive = false;
+    // the in-flight diff job, so Open Full Diff works before the summary finishes loading
+    let rawPromise: Promise<any> = null;
     const fileStats = new Map<string, Promise<{ deleted: number; added: number } | null>>();
 
     const diffId = (diff: any) => diff?.id ?? diff?.merge_id;
@@ -264,12 +266,13 @@ export const createChangesPanel = () => {
             side.appendChild(meta);
         }
 
-        if (current && current.total) {
+        // show while loading and whenever there are changes; hide only once we know there are none
+        if (branch.latestCheckpointId && (loading || !current || current.total)) {
             const openBtn = document.createElement('button');
             openBtn.type = 'button';
             openBtn.classList.add('vc-button');
             openBtn.textContent = 'Open Full Diff';
-            openBtn.addEventListener('click', () => summary.emit('openDiff', rawDiffLive ? raw : null));
+            openBtn.addEventListener('click', () => summary.emit('openDiff', !loading && rawDiffLive ? raw : null, rawPromise));
             side.appendChild(openBtn);
         }
 
@@ -335,17 +338,20 @@ export const createChangesPanel = () => {
         loading = true;
         const snap = ++gen;
         render();
-        diffCreate({
+        const pending = diffCreate({
             srcBranchId: branch.id,
             srcCheckpointId: null,
             dstBranchId: branch.id,
             dstCheckpointId: branch.latestCheckpointId
-        }).then((diff: any) => {
+        });
+        rawPromise = pending;
+        pending.then((diff: any) => {
             // single-flight: clear loading even for superseded responses or refresh deadlocks
             loading = false;
             if (snap !== gen) {
                 return;
             }
+            rawPromise = null;
             stale = false;
             const oldId = rawDiffLive ? diffId(raw) : null;
             const next = diff ?? {};
@@ -366,6 +372,7 @@ export const createChangesPanel = () => {
             if (snap !== gen) {
                 return;
             }
+            rawPromise = null;
             log.error(err);
             current = null;
             releaseRawDiff();

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -2,6 +2,7 @@ import { Container, TextAreaInput } from '@playcanvas/pcui';
 
 import { config } from '@/editor/config';
 
+import { templateEntityPath } from './vc-diff-data';
 import { renderPreviewPropertyDiff } from './vc-diff-preview';
 import { diffTextChangeCounts, hashChip, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
@@ -173,6 +174,10 @@ export const createChangesPanel = () => {
 
     const entityName = (conflict: any, value: string) => {
         const id = splitDiffPath(value)[1];
+        // template entities live in the asset's own data.entities (best-effort)
+        if (conflict.assetType === 'template') {
+            return templateEntityPath(editor.call('assets:get', conflict.itemId)?.get('data.entities'), id);
+        }
         const src = raw?.srcCheckpoint?.scenes?.[conflict.itemId]?.entities?.[id];
         const dst = raw?.dstCheckpoint?.scenes?.[conflict.itemId]?.entities?.[id];
         const name = src ?? dst;

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -2,7 +2,7 @@ import { Container, TextAreaInput } from '@playcanvas/pcui';
 
 import { config } from '@/editor/config';
 
-import { templateEntityPath } from './vc-diff-data';
+import { templateEntitiesFor, templateEntityPath } from './vc-diff-data';
 import { renderPreviewPropertyDiff } from './vc-diff-preview';
 import { diffTextChangeCounts, hashChip, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
@@ -172,11 +172,20 @@ export const createChangesPanel = () => {
         return Promise.resolve(null);
     };
 
+    // combined template entity maps, memoised per conflict (built once per render)
+    const tplEntities = new Map<any, any>();
+
     const entityName = (conflict: any, value: string) => {
         const id = splitDiffPath(value)[1];
-        // template entities live in the asset's own data.entities (best-effort)
+        // template entities live in the asset's own data.entities, plus any the
+        // diff reports as added/removed on the side that isn't loaded
         if (conflict.assetType === 'template') {
-            return templateEntityPath(editor.call('assets:get', conflict.itemId)?.get('data.entities'), id);
+            let entities = tplEntities.get(conflict);
+            if (!entities) {
+                entities = templateEntitiesFor(conflict, (assetId: any) => editor.call('assets:get', assetId));
+                tplEntities.set(conflict, entities);
+            }
+            return templateEntityPath(entities, id);
         }
         const src = raw?.srcCheckpoint?.scenes?.[conflict.itemId]?.entities?.[id];
         const dst = raw?.dstCheckpoint?.scenes?.[conflict.itemId]?.entities?.[id];

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -197,6 +197,7 @@ export const createChangesPanel = () => {
             const path = document.createElement('span');
             path.classList.add('path');
             path.textContent = fileName(conflict, entry, 'src') ?? fileName(conflict, entry, 'dst');
+            path.title = path.textContent;
             const vals = document.createElement('span');
             vals.classList.add('vals');
             vals.textContent = 'Loading…';
@@ -209,6 +210,7 @@ export const createChangesPanel = () => {
                     appendLineCounts(vals, counts);
                 } else {
                     vals.textContent = `${fileText(entry)} — use Open Full Diff to view`;
+                    vals.title = vals.textContent;
                 }
             });
             row.appendChild(path);

--- a/src/editor/pickers/version-control/panel-history.ts
+++ b/src/editor/pickers/version-control/panel-history.ts
@@ -97,12 +97,14 @@ export const createHistoryPanel = () => {
         const desc = document.createElement('div');
         desc.classList.add('desc');
         desc.textContent = label ?? checkpoint.description.split('\n')[0];
+        desc.title = checkpoint?.description ?? desc.textContent;
         body.appendChild(desc);
         const sub = document.createElement('div');
         sub.classList.add('sub');
         sub.textContent = checkpoint ?
             `${checkpoint.user.fullName || 'Unknown'} · ${formatRelativeDate(checkpoint.createdAt)}` :
             'uncheckpointed changes';
+        sub.title = sub.textContent;
         body.appendChild(sub);
         row.appendChild(body);
 

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -553,25 +553,45 @@ editor.once('load', () => {
         fileStats.clear();
     };
 
+    // mouse/browser back closes the diff, mirroring how the scene picker is
+    // dismissed by the same history navigation (see the scenes-load popstate)
+    let closingViaBack = false;
+    const onPopState = () => {
+        if (!overlay.hidden) {
+            closingViaBack = true;
+            overlay.hidden = true;
+        }
+    };
+
     overlay.on('show', () => {
         editor.emit('picker:open', 'version-control-diff');
+        window.addEventListener('popstate', onPopState);
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', false);
         }
     });
 
     overlay.on('hide', () => {
+        window.removeEventListener('popstate', onPopState);
         const id = diffId(current);
         if (typeof id === 'string' && !isRetainedDiff(id)) {
             editor.emit('picker:diffManager:closed', id);
             handleCallback(editor.api.globals.rest.merge.mergeDelete({ mergeId: id }), () => {});
         }
-        if (editor.call('picker:isOpen', 'project')) {
+        if (closingViaBack) {
+            // the scene-router back already closed/navigated the picker beneath the
+            // diff; only clear its suspended state (set in presentDiff) so it's
+            // interactive again when reopened — resume is a no-op if not suspended
             editor.call('picker:project:resume');
         } else {
-            editor.call('picker:versioncontrol');
+            if (editor.call('picker:isOpen', 'project')) {
+                editor.call('picker:project:resume');
+            } else {
+                editor.call('picker:versioncontrol');
+            }
+            editor.call('vcgraph:moveToForeground');
         }
-        editor.call('vcgraph:moveToForeground');
+        closingViaBack = false;
         current = null;
         nameIndex = null;
         selected = 0;

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -6,9 +6,11 @@ import { config } from '@/editor/config';
 import { buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
 import { createValueField, destroyValueFields } from './vc-diff-fields';
 import {
+    assetDiffField,
     diffTextChangeCounts,
     formatDiffPath,
     hashChip,
+    isHiddenDiffField,
     lineChangeCounts,
     splitDiffPath,
     summarizeDiff,
@@ -102,7 +104,7 @@ editor.once('load', () => {
 
     const textEntry = (conflict: any) => (conflict?.data ?? []).find((entry: any) => entry.isTextualMerge || entry.mergedFilePath);
 
-    const propertyEntries = (conflict: any) => (conflict?.data ?? []).filter((entry: any) => !entry.isTextualMerge && !entry.mergedFilePath);
+    const propertyEntries = (conflict: any) => (conflict?.data ?? []).filter((entry: any) => !entry.isTextualMerge && !entry.mergedFilePath && !isHiddenDiffField(entry.path));
 
     const selectedConflict = () => current?.conflicts?.[selected] ?? null;
 
@@ -187,6 +189,12 @@ editor.once('load', () => {
         const path = tpl ? entry.path.slice('data.'.length) : entry.path;
         const type = tpl ? 'scene' : conflict.itemType;
         const raw = entry.path || conflict.itemName;
+        // generic asset property diffs: humanise data.opacityDither -> "Opacity
+        // Dither" and group under the asset-type panel, like the inspector
+        if (!tpl && type === 'asset' && path) {
+            const a = assetDiffField(conflict.assetType, path);
+            return { entityContext: [], section: a.section, context: [], field: a.field, title: a.title, type: '' };
+        }
         if (!path || (type !== 'scene' && type !== 'settings')) {
             return {
                 entityContext: [],
@@ -314,6 +322,11 @@ editor.once('load', () => {
         // a template's source id is an asset reference — show it as the asset name
         if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
             return createValueField('asset', value, nameIndex);
+        }
+        // an asset's folder path is a variable-length list of folder ids; render
+        // it as a folder chip list (a move resizes it), not a fixed-size vector
+        if (!missing && entry.path === 'path' && Array.isArray(value)) {
+            return createValueField('array:asset', value, nameIndex);
         }
         // an entity's children is a list of entity ids — resolve them to leaf names
         if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
@@ -520,7 +533,7 @@ editor.once('load', () => {
 
                 const sub = document.createElement('span');
                 sub.classList.add('sub');
-                const count = conflict?.data?.length ?? 0;
+                const count = (conflict?.data ?? []).filter((e: any) => !isHiddenDiffField(e.path)).length;
                 sub.textContent = `${conflict?.assetType ?? conflict?.itemType ?? group.type} · ${count} change${count === 1 ? '' : 's'}`;
                 row.appendChild(sub);
 

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -337,7 +337,11 @@ editor.once('load', () => {
         const wrap = document.createElement('div');
         wrap.classList.add('vc-diff-inspector');
 
-        let section: { key: string; panel: Panel; subs: Map<string, Panel> } = null;
+        // one card per entity (its breadcrumb shown once); the entity's panels
+        // stack inside, so an entity changed across several sections (e.g.
+        // Entity + Template instance) isn't redrawn as separate repeated parts
+        let card: { entity: string; dom: HTMLElement } = null;
+        let section: { name: string; panel: Panel; subs: Map<string, Panel> } = null;
         const hostDom = (parts: { sub: string; panel: string }) => {
             if (!parts.sub) {
                 return section.panel.content.dom;
@@ -358,13 +362,18 @@ editor.once('load', () => {
 
         for (const entry of entries) {
             const parts = sectionParts(conflict, entry);
-            const key = JSON.stringify([parts.entity?.title ?? parts.entity?.text ?? '', parts.panel]);
-            if (section?.key !== key) {
-                const card = document.createElement('div');
-                card.classList.add('vc-diff-section');
+            const entityKey = parts.entity?.title ?? parts.entity?.text ?? '';
+            if (!card || card.entity !== entityKey) {
+                const dom = document.createElement('div');
+                dom.classList.add('vc-diff-section');
                 if (parts.entity) {
-                    card.appendChild(entityTree(parts.entity, parts.icon).dom);
+                    dom.appendChild(entityTree(parts.entity, parts.icon).dom);
                 }
+                wrap.appendChild(dom);
+                card = { entity: entityKey, dom };
+                section = null;
+            }
+            if (!section || section.name !== parts.panel) {
                 const panel = new Panel({ collapsible: true, headerText: parts.panel });
                 panel.class.add('vc-diff-panel');
                 if (parts.icon) {
@@ -372,9 +381,8 @@ editor.once('load', () => {
                     icon.classList.add('component-icon', `type-${parts.icon}`);
                     panel.header.dom.insertBefore(icon, panel.header.dom.querySelector('.pcui-panel-header-title'));
                 }
-                card.appendChild(panel.dom);
-                wrap.appendChild(card);
-                section = { key, panel, subs: new Map() };
+                card.dom.appendChild(panel.dom);
+                section = { name: parts.panel, panel, subs: new Map() };
             }
             const host = hostDom(parts);
             if (!entry.path || wholeEntity(entry)) {

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -301,12 +301,23 @@ editor.once('load', () => {
         return row;
     };
 
+    // entities.<guid>.children (scenes) / data.entities.<guid>.children (templates)
+    const isEntityChildren = (path: string) => {
+        const parts = splitDiffPath(path ?? '');
+        const e = parts[0] === 'data' ? parts.slice(1) : parts;
+        return e.length === 3 && e[0] === 'entities' && e[2] === 'children';
+    };
+
     const sideField = (entry: any, side: 'src' | 'dst') => {
         const value = side === 'src' ? entry.srcValue : entry.dstValue;
         const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
         // a template's source id is an asset reference — show it as the asset name
         if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
             return createValueField('asset', value, nameIndex);
+        }
+        // an entity's children is a list of entity ids — resolve them to leaf names
+        if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
+            return createValueField('children', value, nameIndex);
         }
         const kind = missing ? 'missing' : valueKind(typeFor(entry, side), entry.path ?? '', value);
         return createValueField(kind, value, nameIndex);
@@ -317,8 +328,11 @@ editor.once('load', () => {
         if (!entry.missingInSrc && !entry.missingInDst) {
             return false;
         }
+        // templates prefix the path with `data.`; normalise so a whole template
+        // entity (data.entities.<guid>) reads like a scene's (entities.<guid>)
         const parts = splitDiffPath(entry.path ?? '');
-        return parts.length === 2 && parts[0] === 'entities';
+        const e = parts[0] === 'data' ? parts.slice(1) : parts;
+        return e.length === 2 && e[0] === 'entities';
     };
 
     // banner for whole-item adds/deletes (entries without a path)

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -4,7 +4,7 @@ import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
 import { buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
-import { createValueField, destroyValueFields } from './vc-diff-fields';
+import { createDeltaListField, createValueField, destroyValueFields } from './vc-diff-fields';
 import {
     assetDiffField,
     diffTextChangeCounts,
@@ -24,6 +24,9 @@ const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
 // than sitting among the entity's regular values; values are shown friendlier
 const TEMPLATE_PANEL = 'Template instance';
 const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template', template_ent_ids: 'Entity mapping' };
+// variable-length lists of asset ids (an asset's folder path, the project's
+// script loading order) — render as asset chips, not a vector/json blob
+const ASSET_ID_ARRAY_FIELDS = new Set(['path', 'scripts']);
 
 // loading-state skeleton fragments (mirror the real diff layout: sidebar rows are
 // name + status badge; main panels are a header bar over field rows of label + value)
@@ -290,13 +293,17 @@ editor.once('load', () => {
     };
 
     // note: NOT 'vc-diff-row' — that class belongs to the sidebar buttons and their click delegation
-    const fieldRow = (kind: 'del' | 'add', label: string, title: string, valueEl: HTMLElement) => {
+    const fieldRow = (kind: 'del' | 'add' | 'mod', label: string, title: string, valueEl: HTMLElement) => {
         const row = document.createElement('div');
-        row.classList.add('vc-diff-field-row', kind);
+        row.classList.add('vc-diff-field-row');
+        // 'mod' rows stay neutral; their value carries the per-item add/remove tint
+        if (kind !== 'mod') {
+            row.classList.add(kind);
+        }
         row.title = title;
         const gut = document.createElement('span');
         gut.classList.add('gutter');
-        gut.textContent = kind === 'del' ? '−' : '+';
+        gut.textContent = kind === 'del' ? '−' : kind === 'add' ? '+' : '';
         row.appendChild(gut);
         const lbl = document.createElement('span');
         lbl.classList.add('label');
@@ -323,10 +330,14 @@ editor.once('load', () => {
         if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
             return createValueField('asset', value, nameIndex);
         }
-        // an asset's folder path is a variable-length list of folder ids; render
-        // it as a folder chip list (a move resizes it), not a fixed-size vector
-        if (!missing && entry.path === 'path' && Array.isArray(value)) {
+        // variable-length asset-id lists (folder path, script loading order):
+        // render as asset chips, not a fixed-size vector or a raw json blob
+        if (!missing && Array.isArray(value) && ASSET_ID_ARRAY_FIELDS.has(splitDiffPath(entry.path ?? '').pop() ?? '')) {
             return createValueField('array:asset', value, nameIndex);
+        }
+        // tags are a list of free-text labels — render as plain pills, not a json blob
+        if (!missing && Array.isArray(value) && splitDiffPath(entry.path ?? '').pop() === 'tags') {
+            return createValueField('tags', value, nameIndex);
         }
         // an entity's children is a list of entity ids — resolve them to leaf names
         if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
@@ -416,25 +427,29 @@ editor.once('load', () => {
                 host.appendChild(wholeBanner(conflict, entry, entry.path ? 'entity' : conflict.assetType ?? conflict.itemType ?? 'item'));
                 continue;
             }
-            // children: show only the added/removed entries, not the whole
-            // before+after lists (the unchanged siblings are just noise)
-            if (isEntityChildren(entry.path) && Array.isArray(entry.srcValue) && Array.isArray(entry.dstValue)) {
+            // id-list fields (entity children, asset-id lists like the folder
+            // path or script loading order): show only the delta — removed in
+            // the red row, added in the green — not the whole before+after list
+            // (these run to hundreds of items)
+            const leaf = splitDiffPath(entry.path ?? '').pop() ?? '';
+            const listKind: 'children' | 'array:asset' | 'tags' | null = isEntityChildren(entry.path) ? 'children' :
+                leaf === 'tags' ? 'tags' :
+                    ASSET_ID_ARRAY_FIELDS.has(leaf) ? 'array:asset' : null;
+            if (listKind && Array.isArray(entry.srcValue) && Array.isArray(entry.dstValue)) {
                 const src = new Set(entry.srcValue);
                 const dst = new Set(entry.dstValue);
-                const removed = entry.dstValue.filter((id: string) => !src.has(id));
-                const added = entry.srcValue.filter((id: string) => !dst.has(id));
-                if (removed.length) {
-                    host.appendChild(fieldRow('del', parts.field, parts.title, createValueField('children', removed, nameIndex)));
-                }
-                if (added.length) {
-                    host.appendChild(fieldRow('add', parts.field, parts.title, createValueField('children', added, nameIndex)));
-                }
-                if (!removed.length && !added.length) {
-                    // same members, different order — note it without re-listing every child
+                const removed = entry.dstValue.filter((id: any) => !src.has(id));
+                const added = entry.srcValue.filter((id: any) => !dst.has(id));
+                if (removed.length || added.length) {
+                    // one neutral row; the chips carry the add/remove tint so it
+                    // doesn't read as the whole field (Children/Scripts/Path) being new
+                    host.appendChild(fieldRow('mod', parts.field, parts.title, createDeltaListField(listKind, removed, added, nameIndex)));
+                } else {
+                    // same members, different order — note it without re-listing everything
                     const note = document.createElement('span');
                     note.classList.add('vc-diff-missing');
                     note.textContent = `reordered (${entry.srcValue.length} item${entry.srcValue.length === 1 ? '' : 's'})`;
-                    host.appendChild(fieldRow('add', parts.field, parts.title, note));
+                    host.appendChild(fieldRow('mod', parts.field, parts.title, note));
                 }
                 continue;
             }

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -3,7 +3,7 @@ import { Button, Container, Overlay, Panel, TreeView, TreeViewItem } from '@play
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
-import { buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
+import { arrayFieldKind, buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
 import { createDeltaListField, createValueField, destroyValueFields } from './vc-diff-fields';
 import {
     assetDiffField,
@@ -335,9 +335,10 @@ editor.once('load', () => {
         if (!missing && Array.isArray(value) && ASSET_ID_ARRAY_FIELDS.has(splitDiffPath(entry.path ?? '').pop() ?? '')) {
             return createValueField('array:asset', value, nameIndex);
         }
-        // tags are a list of free-text labels — render as plain pills, not a json blob
-        if (!missing && Array.isArray(value) && splitDiffPath(entry.path ?? '').pop() === 'tags') {
-            return createValueField('tags', value, nameIndex);
+        // any other primitive array (tags, device types, ...) is a free-value list,
+        // not a fixed-size numeric tuple — render as pills instead of a json blob
+        if (!missing && arrayFieldKind(value) === 'pills') {
+            return createValueField('pills', value, nameIndex);
         }
         // an entity's children is a list of entity ids — resolve them to leaf names
         if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
@@ -427,15 +428,18 @@ editor.once('load', () => {
                 host.appendChild(wholeBanner(conflict, entry, entry.path ? 'entity' : conflict.assetType ?? conflict.itemType ?? 'item'));
                 continue;
             }
-            // id-list fields (entity children, asset-id lists like the folder
-            // path or script loading order): show only the delta — removed in
-            // the red row, added in the green — not the whole before+after list
-            // (these run to hundreds of items)
+            // array fields are membership lists, not before/after blobs: show just
+            // the delta. children/asset-id lists resolve to names (and override the
+            // tuple test since asset ids are numeric); any other primitive array
+            // (tags, device types, ...) renders as value pills. numeric vector/colour
+            // tuples (<=4, size-stable) fall through to the positional widget below.
             const leaf = splitDiffPath(entry.path ?? '').pop() ?? '';
-            const listKind: 'children' | 'array:asset' | 'tags' | null = isEntityChildren(entry.path) ? 'children' :
-                leaf === 'tags' ? 'tags' :
-                    ASSET_ID_ARRAY_FIELDS.has(leaf) ? 'array:asset' : null;
-            if (listKind && Array.isArray(entry.srcValue) && Array.isArray(entry.dstValue)) {
+            const bothArrays = Array.isArray(entry.srcValue) && Array.isArray(entry.dstValue);
+            const listKind: 'children' | 'array:asset' | 'pills' | null = !bothArrays ? null :
+                isEntityChildren(entry.path) ? 'children' :
+                    ASSET_ID_ARRAY_FIELDS.has(leaf) ? 'array:asset' :
+                        arrayFieldKind(entry.srcValue) === 'pills' && arrayFieldKind(entry.dstValue) === 'pills' ? 'pills' : null;
+            if (listKind) {
                 const src = new Set(entry.srcValue);
                 const dst = new Set(entry.dstValue);
                 const removed = entry.dstValue.filter((id: any) => !src.has(id));

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -3,7 +3,7 @@ import { Button, Container, Overlay, Panel, TreeView, TreeViewItem } from '@play
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
-import { buildNameIndex, valueKind, type NameIndex } from './vc-diff-data';
+import { buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
 import { createValueField, destroyValueFields } from './vc-diff-fields';
 import {
     diffTextChangeCounts,
@@ -17,6 +17,11 @@ import {
 
 const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
 const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
+
+// entity-level template-instance fields get their own (collapsed) panel rather
+// than sitting among the entity's regular values; values are shown friendlier
+const TEMPLATE_PANEL = 'Template instance';
+const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template', template_ent_ids: 'Entity mapping' };
 
 // loading-state skeleton fragments (mirror the real diff layout: sidebar rows are
 // name + status badge; main panels are a header bar over field rows of label + value)
@@ -176,8 +181,13 @@ editor.once('load', () => {
     const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
 
     const inspectorInfo = (conflict: any, entry: any) => {
+        // template assets carry a scene-shaped entity tree under data.entities;
+        // strip the prefix and render it exactly like a scene
+        const tpl = conflict.assetType === 'template' && entry.path?.startsWith('data.entities.');
+        const path = tpl ? entry.path.slice('data.'.length) : entry.path;
+        const type = tpl ? 'scene' : conflict.itemType;
         const raw = entry.path || conflict.itemName;
-        if (!entry.path || (conflict.itemType !== 'scene' && conflict.itemType !== 'settings')) {
+        if (!path || (type !== 'scene' && type !== 'settings')) {
             return {
                 entityContext: [],
                 section: typeLabel(conflict.itemType ?? 'item'),
@@ -188,12 +198,14 @@ editor.once('load', () => {
             };
         }
 
-        const info = formatDiffPath(entry.path, conflict.itemType, entityName(conflict, entry.path));
+        const info = formatDiffPath(path, type, entityName(conflict, path));
         const labels = info.labels;
         const entity = labels.find(label => label.text.startsWith('Entity: '));
         const comp = labels.findIndex(label => label.text.endsWith(' component'));
+        // entity-level template-instance plumbing routes to its own panel
+        const tplField = TEMPLATE_FIELDS[splitDiffPath(path).pop() ?? ''];
         let entityContext = [];
-        let section = labels[0]?.text ?? typeLabel(conflict.itemType);
+        let section = labels[0]?.text ?? typeLabel(type);
         let context = labels.slice(0, -1);
 
         if (comp >= 0) {
@@ -203,11 +215,11 @@ editor.once('load', () => {
         } else if (labels[0]?.text === 'Scene settings' && labels[1]) {
             section = labels[1].text;
             context = labels.slice(2);
-        } else if (conflict.itemType === 'settings') {
+        } else if (type === 'settings') {
             section = labels[0]?.text ?? 'Project settings';
             context = labels.slice(1);
         } else if (entity) {
-            section = 'Entity';
+            section = tplField ? TEMPLATE_PANEL : 'Entity';
             entityContext = [entity];
             context = labels.filter(label => label !== entity);
         }
@@ -216,7 +228,7 @@ editor.once('load', () => {
             entityContext,
             section,
             context,
-            field: info.field || raw,
+            field: tplField ?? info.field ?? raw,
             title: `${labels.map(label => label.text).join(' / ')} / ${info.field || raw}`,
             type: sectionComponent(section)
         };
@@ -292,6 +304,10 @@ editor.once('load', () => {
     const sideField = (entry: any, side: 'src' | 'dst') => {
         const value = side === 'src' ? entry.srcValue : entry.dstValue;
         const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
+        // a template's source id is an asset reference — show it as the asset name
+        if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
+            return createValueField('asset', value, nameIndex);
+        }
         const kind = missing ? 'missing' : valueKind(typeFor(entry, side), entry.path ?? '', value);
         return createValueField(kind, value, nameIndex);
     };
@@ -634,6 +650,8 @@ editor.once('load', () => {
     const setDiff = (diff: any) => {
         current = diff;
         nameIndex = buildNameIndex(current ?? {});
+        // template assets carry their own entity tree; resolve its names too
+        indexTemplateEntities(nameIndex, current?.conflicts ?? [], (id: any) => editor.call('assets:get', id));
         const summary = summarizeDiff(current ?? {});
         if (!summary.total) {
             meta.textContent = 'No changes';

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -18,6 +18,12 @@ import {
 const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
 const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
 
+// loading-state skeleton fragments (mirror the real diff layout: sidebar rows are
+// name + status badge; main panels are a header bar over field rows of label + value)
+const SKELETON_ROW = '<div class="skeleton-row"><span class="bone line"></span><span class="bone badge"></span></div>';
+const SKELETON_FIELD = '<div class="skeleton-field"><span class="bone label"></span><span class="bone value"></span></div>';
+const SKELETON_PANEL = `<div class="skeleton-panel"><div class="skeleton-phead"><span class="bone line"></span></div>${SKELETON_FIELD.repeat(3)}</div>`;
+
 editor.once('load', () => {
     if (config.project.settings.useLegacyScripts) {
         return;
@@ -597,9 +603,12 @@ editor.once('load', () => {
     };
 
     const renderLoading = () => {
-        meta.textContent = 'Computing changes…';
-        sidebar.innerHTML = `<div class="vc-skeleton">${'<div class="skeleton-row"><span class="bone line"></span></div>'.repeat(6)}</div>`;
-        renderNotice('Computing changes…');
+        trees.forEach(t => t.destroy());
+        trees = [];
+        destroyValueFields(main);
+        meta.textContent = '';
+        sidebar.innerHTML = `<div class="vc-diff-skeleton">${SKELETON_ROW.repeat(6)}</div>`;
+        main.innerHTML = `<div class="vc-diff-skeleton main"><div class="skeleton-head"><span class="bone title"></span><span class="bone badge"></span></div>${SKELETON_PANEL.repeat(2)}</div>`;
     };
 
     const setDiff = (diff: any) => {

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -8,6 +8,7 @@ import { createValueField, destroyValueFields } from './vc-diff-fields';
 import {
     diffTextChangeCounts,
     formatDiffPath,
+    hashChip,
     lineChangeCounts,
     splitDiffPath,
     summarizeDiff,
@@ -71,7 +72,9 @@ editor.once('load', () => {
             return;
         }
         selected = Number(row.dataset.index);
-        render();
+        sidebar.querySelectorAll('.vc-diff-row.selected').forEach(el => el.classList.remove('selected'));
+        row.classList.add('selected');
+        renderMain();
     });
 
     const diffId = (diff: any) => diff?.id ?? diff?.merge_id;
@@ -82,7 +85,8 @@ editor.once('load', () => {
 
     const statusFor = (conflict: any) => {
         const entry = conflict?.data?.[0] ?? {};
-        return entry.missingInDst ? 'added' : entry.missingInSrc ? 'deleted' : 'modified';
+        const whole = !entry.path;
+        return whole && entry.missingInDst ? 'added' : whole && entry.missingInSrc ? 'deleted' : 'modified';
     };
 
     const textEntry = (conflict: any) => (conflict?.data ?? []).find((entry: any) => entry.isTextualMerge || entry.mergedFilePath);
@@ -227,7 +231,7 @@ editor.once('load', () => {
         const field = subMatch?.groups?.kind === 'Script' ? (splitDiffPath(entry.path ?? '').pop() ?? info.field) : info.field;
         return {
             entity: info.entityContext[0] ?? null,
-            panel: info.section,
+            panel: info.section.replace(/ component$/i, ''),
             icon: info.type,
             sub: subMatch?.groups?.name ?? '',
             field,
@@ -286,14 +290,23 @@ editor.once('load', () => {
         return createValueField(kind, value, nameIndex);
     };
 
+    // wholly added/deleted entities arrive as a missing-flagged entry at the entity root
+    const wholeEntity = (entry: any) => {
+        if (!entry.missingInSrc && !entry.missingInDst) {
+            return false;
+        }
+        const parts = splitDiffPath(entry.path ?? '');
+        return parts.length === 2 && parts[0] === 'entities';
+    };
+
     // banner for whole-item adds/deletes (entries without a path)
-    const wholeBanner = (conflict: any, entry: any) => {
+    const wholeBanner = (conflict: any, entry: any, noun: string) => {
         const banner = document.createElement('div');
         banner.classList.add('vc-diff-banner');
         const status = entry.missingInDst ? 'added' : entry.missingInSrc ? 'deleted' : 'modified';
         appendBadge(banner, status);
         const text = document.createElement('span');
-        text.textContent = `This ${conflict.assetType ?? conflict.itemType ?? 'item'} was ${status} since the checkpoint`;
+        text.textContent = `This ${noun} was ${status} since the checkpoint`;
         banner.appendChild(text);
         return banner;
     };
@@ -342,8 +355,8 @@ editor.once('load', () => {
                 section = { key, panel, subs: new Map() };
             }
             const host = hostDom(parts);
-            if (!entry.path) {
-                host.appendChild(wholeBanner(conflict, entry));
+            if (!entry.path || wholeEntity(entry)) {
+                host.appendChild(wholeBanner(conflict, entry, entry.path ? 'entity' : conflict.assetType ?? conflict.itemType ?? 'item'));
                 continue;
             }
             if (!entry.missingInDst) {
@@ -502,14 +515,6 @@ editor.once('load', () => {
         }
         if (showText) {
             detail.appendChild(renderIframe(conflict, text));
-            const token = viewToken;
-            loadTextCounts(text).then((counts) => {
-                if (token !== viewToken || !stats.isConnected) {
-                    return;
-                }
-                stats.innerHTML = '';
-                stats.appendChild(lineStats(counts ?? localTextCounts(text) ?? { added: 0, deleted: 0 }));
-            });
         } else if (!props.length) {
             const empty = document.createElement('div');
             empty.classList.add('vc-diff-empty');
@@ -523,7 +528,11 @@ editor.once('load', () => {
         viewToken++;
         const summary = summarizeDiff(current ?? {});
         const base = current?.destinationCheckpointId || current?.dstCheckpointId;
-        meta.textContent = `${summary.total} change${summary.total === 1 ? '' : 's'}${typeof base === 'string' ? ` · vs ${base.substring(0, 7)}` : ''}`;
+        meta.textContent = `${summary.total} change${summary.total === 1 ? '' : 's'}`;
+        if (typeof base === 'string') {
+            meta.appendChild(document.createTextNode(' · vs '));
+            meta.appendChild(hashChip(base));
+        }
         renderSidebar();
         renderMain();
     };

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -403,6 +403,28 @@ editor.once('load', () => {
                 host.appendChild(wholeBanner(conflict, entry, entry.path ? 'entity' : conflict.assetType ?? conflict.itemType ?? 'item'));
                 continue;
             }
+            // children: show only the added/removed entries, not the whole
+            // before+after lists (the unchanged siblings are just noise)
+            if (isEntityChildren(entry.path) && Array.isArray(entry.srcValue) && Array.isArray(entry.dstValue)) {
+                const src = new Set(entry.srcValue);
+                const dst = new Set(entry.dstValue);
+                const removed = entry.dstValue.filter((id: string) => !src.has(id));
+                const added = entry.srcValue.filter((id: string) => !dst.has(id));
+                if (removed.length) {
+                    host.appendChild(fieldRow('del', parts.field, parts.title, createValueField('children', removed, nameIndex)));
+                }
+                if (added.length) {
+                    host.appendChild(fieldRow('add', parts.field, parts.title, createValueField('children', added, nameIndex)));
+                }
+                if (!removed.length && !added.length) {
+                    // same members, different order — note it without re-listing every child
+                    const note = document.createElement('span');
+                    note.classList.add('vc-diff-missing');
+                    note.textContent = `reordered (${entry.srcValue.length} item${entry.srcValue.length === 1 ? '' : 's'})`;
+                    host.appendChild(fieldRow('add', parts.field, parts.title, note));
+                }
+                continue;
+            }
             if (!entry.missingInDst) {
                 host.appendChild(fieldRow('del', parts.field, parts.title, sideField(entry, 'dst')));
             }

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -584,12 +584,61 @@ editor.once('load', () => {
         }
     });
 
-    editor.method('picker:versioncontrol:diffPicker', (diff: any) => {
+    // single-line message in the main area (loading / empty / error states)
+    const renderNotice = (message: string) => {
+        trees.forEach(t => t.destroy());
+        trees = [];
+        destroyValueFields(main);
+        main.innerHTML = '';
+        const notice = document.createElement('div');
+        notice.classList.add('vc-diff-empty');
+        notice.textContent = message;
+        main.appendChild(notice);
+    };
+
+    const renderLoading = () => {
+        meta.textContent = 'Computing changes…';
+        sidebar.innerHTML = `<div class="vc-skeleton">${'<div class="skeleton-row"><span class="bone line"></span></div>'.repeat(6)}</div>`;
+        renderNotice('Computing changes…');
+    };
+
+    const setDiff = (diff: any) => {
         current = diff;
         nameIndex = buildNameIndex(current ?? {});
         const summary = summarizeDiff(current ?? {});
+        if (!summary.total) {
+            meta.textContent = 'No changes';
+            sidebar.innerHTML = '';
+            renderNotice('No changes since the checkpoint');
+            return;
+        }
         selected = summary.groups[0]?.items[0]?.index ?? 0;
         render();
+    };
+
+    // accepts a resolved diff or a Promise that resolves to one; a pending diff
+    // opens the overlay immediately with a loading state (viewToken guards stale opens)
+    editor.method('picker:versioncontrol:diffPicker', (input: any) => {
+        const token = ++viewToken;
+        current = null;
+        nameIndex = null;
+        selected = 0;
         overlay.hidden = false;
+        if (input && typeof input.then === 'function') {
+            renderLoading();
+            input.then((diff: any) => {
+                if (token === viewToken) {
+                    setDiff(diff);
+                }
+            }).catch((err: any) => {
+                if (token === viewToken) {
+                    meta.textContent = '';
+                    sidebar.innerHTML = '';
+                    renderNotice(`Could not load diff: ${err instanceof Error ? err.message : err}`);
+                }
+            });
+        } else {
+            setDiff(input);
+        }
     });
 });

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -277,7 +277,12 @@ editor.once('load', () => {
 
     // ---- diff viewing ----
     const presentDiff = (diff: any) => {
-        retainDiff(diff);
+        // a pending diff is retained once it resolves; a resolved one immediately
+        if (diff && typeof diff.then === 'function') {
+            diff.then((d: any) => retainDiff(d)).catch(() => {});
+        } else {
+            retainDiff(diff);
+        }
         togglePanels(true);
         showProgress(null);
         requestAnimationFrame(() => {
@@ -318,25 +323,18 @@ editor.once('load', () => {
         runDiff(() => diffCreate({ srcBranchId, srcCheckpointId, dstBranchId, dstCheckpointId }));
     };
 
-    // cached diffs from the panels skip the expensive diffCreate job
+    // always use the modern overlay: a resolved diff renders instantly, a pending
+    // one (or a fresh job) opens with a loading state — no legacy spinner dialog
     detail.on('openDiff', (checkpoint: any, previous: any, cached: any, pending: Promise<any>) => {
-        if (cached && cached.numConflicts) {
-            presentDiff(cached);
-            return;
-        }
-        if (pending) {
-            runDiff(() => pending);
-            return;
-        }
-        viewDiff(viewedBranch.id, checkpoint.id, viewedBranch.id, previous.id);
+        presentDiff(cached ?? pending ?? diffCreate({
+            srcBranchId: viewedBranch.id, srcCheckpointId: checkpoint.id, dstBranchId: viewedBranch.id, dstCheckpointId: previous.id
+        }));
     });
-    changes.summary.on('openDiff', (cached: any) => {
-        if (cached && cached.numConflicts) {
-            presentDiff(cached);
-            return;
-        }
+    changes.summary.on('openDiff', (cached: any, pending: Promise<any>) => {
         const b = config.self.branch;
-        viewDiff(b.id, null, b.id, b.latestCheckpointId);
+        presentDiff(cached ?? pending ?? diffCreate({
+            srcBranchId: b.id, srcCheckpointId: null, dstBranchId: b.id, dstCheckpointId: b.latestCheckpointId
+        }));
     });
 
     // ---- compare mode ----

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -1,5 +1,6 @@
 import { Button, Container } from '@playcanvas/pcui';
 
+import { installEllipsisTooltips } from '@/common/ellipsis-tooltip';
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -51,6 +52,7 @@ editor.once('load', () => {
 
     // ---- layout ----
     const panel = new Container({ class: ['picker-version-control', 'picker-vc'], flex: true });
+    installEllipsisTooltips(panel.dom);
     editor.call('picker:project:registerMenu', 'version control', 'Version Control', panel);
 
     if (!editor.call('permissions:read')) {
@@ -237,7 +239,9 @@ editor.once('load', () => {
     const setViewedBranch = (branch: any) => {
         viewedBranch = branch;
         banner.hidden = isViewingCurrent();
-        (banner.querySelector('.name') as HTMLElement).textContent = branch.name;
+        const bannerName = banner.querySelector('.name') as HTMLElement;
+        bannerName.textContent = branch.name;
+        bannerName.title = branch.name;
         bannerReturn.textContent = `Return to ${config.self.branch.name}`;
         history.setBranch(branch);
         detail.clear();
@@ -344,8 +348,10 @@ editor.once('load', () => {
 
     const renderCompareBar = () => {
         slotA.textContent = compareSlots[0] ? slotLabel(compareSlots[0]) : 'Pick a checkpoint…';
+        slotA.title = slotA.textContent;
         slotA.classList.toggle('full', !!compareSlots[0]);
         slotB.textContent = compareSlots[1] ? slotLabel(compareSlots[1]) : 'Pick another…';
+        slotB.title = slotB.textContent;
         slotB.classList.toggle('full', !!compareSlots[1]);
         btnRunCompare.enabled = compareSlots.length === 2;
     };

--- a/src/editor/pickers/version-control/vc-diff-data.ts
+++ b/src/editor/pickers/version-control/vc-diff-data.ts
@@ -20,7 +20,7 @@ export type NameIndex = {
 };
 
 export type ValueKind = 'missing' | 'boolean' | 'number' | 'string' | 'vector' | 'color' | 'curve' | 'gradient' |
-    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'children' | 'json' | 'object' | `array:${string}`;
+    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'children' | 'tags' | 'json' | 'object' | `array:${string}`;
 
 const settingName = (v: unknown) => {
     if (typeof v === 'string') {

--- a/src/editor/pickers/version-control/vc-diff-data.ts
+++ b/src/editor/pickers/version-control/vc-diff-data.ts
@@ -20,7 +20,7 @@ export type NameIndex = {
 };
 
 export type ValueKind = 'missing' | 'boolean' | 'number' | 'string' | 'vector' | 'color' | 'curve' | 'gradient' |
-    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'children' | 'tags' | 'json' | 'object' | `array:${string}`;
+    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'children' | 'pills' | 'json' | 'object' | `array:${string}`;
 
 const settingName = (v: unknown) => {
     if (typeof v === 'string') {
@@ -135,6 +135,21 @@ export const indexTemplateEntities = (index: NameIndex, conflicts: any[], getAss
 
 const numArray = (value: unknown, min: number, max: number) => {
     return Array.isArray(value) && value.length >= min && value.length <= max && value.every(v => typeof v === 'number');
+};
+
+// how to render an array-valued diff field:
+//   'tuple' — numeric vector/colour (<=4, size-stable): keep the positional widget
+//   'pills' — any other primitive array (strings/numbers, any length): a membership
+//             list, shown as a delta of pills rather than a raw json blob
+//   null    — objects/curves/gradients etc.: leave to valueKind
+export const arrayFieldKind = (value: unknown) => {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+    if (numArray(value, 2, 4)) {
+        return 'tuple';
+    }
+    return value.every(v => v === null || typeof v !== 'object') ? 'pills' : null;
 };
 
 // channel count for curve/curveset values; 0 when not curve-shaped

--- a/src/editor/pickers/version-control/vc-diff-data.ts
+++ b/src/editor/pickers/version-control/vc-diff-data.ts
@@ -99,26 +99,31 @@ export const templateEntityPath = (entities: any, guid: string) => {
 // merge a template asset's entity paths (guid -> Root/.../Name) into the index
 // so template diffs resolve entity guids the way scenes do; pulled from the
 // live asset registry via getAsset (best-effort — missing assets fall back)
+// combined entity map for a template conflict: the live asset's entities (one
+// checkpoint's state) plus the whole-entity objects the diff itself reports —
+// data.entities.<guid> entries whose value is the full entity ({ name, parent }).
+// the diff payload carries no template entities otherwise (formatCheckpoint only
+// emits paths for scenes), so this is the only way entities added/removed on the
+// side that isn't loaded resolve to a name.
+export const templateEntitiesFor = (conflict: any, getAsset: (id: any) => any) => {
+    const entities = { ...(getAsset(conflict?.itemId)?.get?.('data.entities') ?? {}) };
+    for (const entry of conflict?.data ?? []) {
+        const parts = (entry?.path ?? '').split('.');
+        const obj = entry?.srcValue ?? entry?.dstValue;
+        if (parts.length === 3 && parts[0] === 'data' && parts[1] === 'entities' &&
+            obj && typeof obj === 'object' && !entities[parts[2]]) {
+            entities[parts[2]] = obj;
+        }
+    }
+    return entities;
+};
+
 export const indexTemplateEntities = (index: NameIndex, conflicts: any[], getAsset: (id: any) => any) => {
     for (const c of conflicts ?? []) {
         if (c?.assetType !== 'template') {
             continue;
         }
-        // the live asset holds only one checkpoint's entities, and the diff
-        // payload carries no template entities at all (formatCheckpoint only
-        // emits paths for scenes), so layer in the whole-entity objects the
-        // diff itself reports — data.entities.<guid> entries whose value is the
-        // full entity ({ name, parent }) — so entities added/removed on the
-        // other side resolve too, not just those on the loaded side
-        const entities = { ...(getAsset(c.itemId)?.get?.('data.entities') ?? {}) };
-        for (const entry of c.data ?? []) {
-            const parts = (entry?.path ?? '').split('.');
-            const obj = entry?.srcValue ?? entry?.dstValue;
-            if (parts.length === 3 && parts[0] === 'data' && parts[1] === 'entities' &&
-                obj && typeof obj === 'object' && !entities[parts[2]]) {
-                entities[parts[2]] = obj;
-            }
-        }
+        const entities = templateEntitiesFor(c, getAsset);
         for (const guid of Object.keys(entities)) {
             const path = !index.entity.has(guid) && templateEntityPath(entities, guid);
             if (path) {

--- a/src/editor/pickers/version-control/vc-diff-data.ts
+++ b/src/editor/pickers/version-control/vc-diff-data.ts
@@ -1,5 +1,16 @@
 export const REF_KINDS = new Set(['asset', 'entity', 'layer', 'batchGroup', 'sublayer']);
 const COLORISH = /color|tint|gradient/i;
+const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// a plain object mapping entity guids to entity guids (e.g. a template's
+// entity-id remap); rendered as a resolved name list rather than raw json
+export const isEntityIdMap = (value: unknown) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    return entries.length > 0 && entries.every(([k, v]) => GUID_RE.test(k) && typeof v === 'string' && GUID_RE.test(v));
+};
 
 export type NameIndex = {
     asset: Map<string, string>;
@@ -9,7 +20,7 @@ export type NameIndex = {
 };
 
 export type ValueKind = 'missing' | 'boolean' | 'number' | 'string' | 'vector' | 'color' | 'curve' | 'gradient' |
-    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'json' | 'object' | `array:${string}`;
+    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'json' | 'object' | `array:${string}`;
 
 const settingName = (v: unknown) => {
     if (typeof v === 'string') {
@@ -69,6 +80,40 @@ export const buildNameIndex = (diff: DiffCheckpoints): NameIndex => {
     return index;
 };
 
+// an entity's hierarchy path (Root/.../Name) walked from the template's parent
+// links, matching how scene checkpoints store entity names so the breadcrumb
+// tree renders the full hierarchy rather than a single node
+export const templateEntityPath = (entities: any, guid: string) => {
+    const parts = [];
+    const seen = new Set();
+    let cur = guid;
+    while (cur && entities?.[cur] && !seen.has(cur)) {
+        seen.add(cur);
+        const name = entities[cur].name;
+        parts.unshift(typeof name === 'string' ? name : cur);
+        cur = entities[cur].parent;
+    }
+    return parts.length ? parts.join('/') : undefined;
+};
+
+// merge a template asset's entity paths (guid -> Root/.../Name) into the index
+// so template diffs resolve entity guids the way scenes do; pulled from the
+// live asset registry via getAsset (best-effort — missing assets fall back)
+export const indexTemplateEntities = (index: NameIndex, conflicts: any[], getAsset: (id: any) => any) => {
+    for (const c of conflicts ?? []) {
+        if (c?.assetType !== 'template') {
+            continue;
+        }
+        const entities = getAsset(c.itemId)?.get?.('data.entities');
+        for (const guid of Object.keys(entities ?? {})) {
+            const path = !index.entity.has(guid) && templateEntityPath(entities, guid);
+            if (path) {
+                index.entity.set(guid, path);
+            }
+        }
+    }
+};
+
 const numArray = (value: unknown, min: number, max: number) => {
     return Array.isArray(value) && value.length >= min && value.length <= max && value.every(v => typeof v === 'number');
 };
@@ -87,6 +132,9 @@ const curveChannels = (value: any) => {
 export const valueKind = (type: string, path: string, value: unknown): ValueKind => {
     if (value === undefined || value === null) {
         return 'missing';
+    }
+    if (isEntityIdMap(value)) {
+        return 'entityMap';
     }
     if (type.startsWith('array:')) {
         return type as ValueKind;

--- a/src/editor/pickers/version-control/vc-diff-data.ts
+++ b/src/editor/pickers/version-control/vc-diff-data.ts
@@ -20,7 +20,7 @@ export type NameIndex = {
 };
 
 export type ValueKind = 'missing' | 'boolean' | 'number' | 'string' | 'vector' | 'color' | 'curve' | 'gradient' |
-    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'json' | 'object' | `array:${string}`;
+    'asset' | 'entity' | 'layer' | 'batchGroup' | 'sublayer' | 'entityMap' | 'children' | 'json' | 'object' | `array:${string}`;
 
 const settingName = (v: unknown) => {
     if (typeof v === 'string') {
@@ -104,8 +104,22 @@ export const indexTemplateEntities = (index: NameIndex, conflicts: any[], getAss
         if (c?.assetType !== 'template') {
             continue;
         }
-        const entities = getAsset(c.itemId)?.get?.('data.entities');
-        for (const guid of Object.keys(entities ?? {})) {
+        // the live asset holds only one checkpoint's entities, and the diff
+        // payload carries no template entities at all (formatCheckpoint only
+        // emits paths for scenes), so layer in the whole-entity objects the
+        // diff itself reports — data.entities.<guid> entries whose value is the
+        // full entity ({ name, parent }) — so entities added/removed on the
+        // other side resolve too, not just those on the loaded side
+        const entities = { ...(getAsset(c.itemId)?.get?.('data.entities') ?? {}) };
+        for (const entry of c.data ?? []) {
+            const parts = (entry?.path ?? '').split('.');
+            const obj = entry?.srcValue ?? entry?.dstValue;
+            if (parts.length === 3 && parts[0] === 'data' && parts[1] === 'entities' &&
+                obj && typeof obj === 'object' && !entities[parts[2]]) {
+                entities[parts[2]] = obj;
+            }
+        }
+        for (const guid of Object.keys(entities)) {
             const path = !index.entity.has(guid) && templateEntityPath(entities, guid);
             if (path) {
                 index.entity.set(guid, path);

--- a/src/editor/pickers/version-control/vc-diff-fields.ts
+++ b/src/editor/pickers/version-control/vc-diff-fields.ts
@@ -95,6 +95,19 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
             return chip('asset', value, index.asset.get(`${value}`));
         case 'entity':
             return chip('entity', value, index.entity.get(`${value}`));
+        case 'children': {
+            // entity-id list as chips; show only the leaf name (siblings share a path prefix)
+            const ids = Array.isArray(value) ? value : [value];
+            const list = document.createElement('div');
+            list.className = 'vc-diff-array';
+            list.appendChild(el('size', `${ids.length} item${ids.length === 1 ? '' : 's'}`));
+            for (const id of ids) {
+                const full = index.entity.get(`${id}`);
+                const leaf = typeof full === 'string' ? full.split('/').filter(Boolean).pop() : undefined;
+                list.appendChild(chip('entity', id, leaf));
+            }
+            return list;
+        }
         case 'layer':
             return chip('layer', value, index.layer.get(`${value}`));
         case 'batchGroup':

--- a/src/editor/pickers/version-control/vc-diff-fields.ts
+++ b/src/editor/pickers/version-control/vc-diff-fields.ts
@@ -30,7 +30,8 @@ const chip = (kind: string, id: unknown, name?: string, state?: 'added' | 'remov
         c.classList.add(state);
         c.appendChild(el('sign', state === 'added' ? '+' : '−'));
     }
-    // plain pills (e.g. tags) pass an empty kind: the value is the whole label
+    // plain pills (tags, device types, any free-value list) pass an empty kind:
+    // the value is the whole label
     if (kind) {
         c.appendChild(el('tag', kind === 'batchGroup' ? 'batch group' : kind));
     } else {
@@ -129,8 +130,8 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
             }
             return list;
         }
-        case 'tags': {
-            // entity/asset tag list: each tag is its own label, render as plain pills
+        case 'pills': {
+            // free-value list (tags, device types, ...): each entry is its own label
             const items = Array.isArray(value) ? value : [value];
             const list = document.createElement('div');
             list.className = 'vc-diff-array';
@@ -172,7 +173,7 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
 // a list field (entity children / asset-id list) whose membership changed:
 // removed items tinted red, added tinted green, in ONE neutral list so the
 // surrounding row isn't coloured as if the whole property were added/removed
-export const createDeltaListField = (kind: 'children' | 'array:asset' | 'tags', removed: any[], added: any[], index: NameIndex): HTMLElement => {
+export const createDeltaListField = (kind: 'children' | 'array:asset' | 'pills', removed: any[], added: any[], index: NameIndex): HTMLElement => {
     const list = document.createElement('div');
     list.className = 'vc-diff-array';
     if (removed.length + added.length > 1) {
@@ -190,7 +191,7 @@ export const createDeltaListField = (kind: 'children' | 'array:asset' | 'tags', 
         if (kind === 'children') {
             return chip('entity', id, entityLeaf(index, id), state);
         }
-        if (kind === 'tags') {
+        if (kind === 'pills') {
             return chip('', id, `${id}`, state);
         }
         return chip('asset', id, index.asset.get(`${id}`), state);

--- a/src/editor/pickers/version-control/vc-diff-fields.ts
+++ b/src/editor/pickers/version-control/vc-diff-fields.ts
@@ -101,6 +101,14 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
             return chip('batchGroup', value, index.batchGroup.get(`${value}`));
         case 'sublayer':
             return sublayerEl(value, index);
+        case 'entityMap': {
+            // a guid->guid remap conveys nothing actionable inline; show the
+            // count and keep the full mapping on hover for anyone who needs it
+            const n = Object.keys(value as object).length;
+            const summary = el('vc-diff-entity-map', `${n} entit${n === 1 ? 'y' : 'ies'}`);
+            summary.title = JSON.stringify(value, null, 2);
+            return summary;
+        }
         case 'object':
             return missingEl('no preview available');
         case 'json': {

--- a/src/editor/pickers/version-control/vc-diff-fields.ts
+++ b/src/editor/pickers/version-control/vc-diff-fields.ts
@@ -19,15 +19,32 @@ const el = (cls: string, text = '') => {
 
 const missingEl = (text: string) => el('vc-diff-missing', text);
 
-const chip = (kind: string, id: unknown, name?: string) => {
+const chip = (kind: string, id: unknown, name?: string, state?: 'added' | 'removed') => {
     const c = el('vc-diff-chip');
     if (!name) {
         c.classList.add('missing');
     }
-    c.appendChild(el('tag', kind === 'batchGroup' ? 'batch group' : kind));
+    // membership-delta chips tint themselves (red/green) + carry a +/− sign so a
+    // single changed list item doesn't colour its whole row
+    if (state) {
+        c.classList.add(state);
+        c.appendChild(el('sign', state === 'added' ? '+' : '−'));
+    }
+    // plain pills (e.g. tags) pass an empty kind: the value is the whole label
+    if (kind) {
+        c.appendChild(el('tag', kind === 'batchGroup' ? 'batch group' : kind));
+    } else {
+        c.classList.add('pill');
+    }
     c.appendChild(el('name', name ?? `${id}`));
     c.title = `${id}`;
     return c;
+};
+
+// child entities share a path prefix; show only the leaf segment as the name
+const entityLeaf = (index: NameIndex, id: unknown) => {
+    const full = index.entity.get(`${id}`);
+    return typeof full === 'string' ? full.split('/').filter(Boolean).pop() : undefined;
 };
 
 const sublayerEl = (value: any, index: NameIndex) => {
@@ -55,6 +72,9 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
         const list = document.createElement('div');
         list.className = 'vc-diff-array';
         const items = Array.isArray(value) ? value : [value];
+        if (items.length > 1) {
+            list.classList.add('multi');
+        }
         list.appendChild(el('size', `${items.length} item${items.length === 1 ? '' : 's'}`));
         for (const item of items) {
             const itemKind = item === undefined || item === null ? 'missing' :
@@ -100,11 +120,26 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
             const ids = Array.isArray(value) ? value : [value];
             const list = document.createElement('div');
             list.className = 'vc-diff-array';
+            if (ids.length > 1) {
+                list.classList.add('multi');
+            }
             list.appendChild(el('size', `${ids.length} item${ids.length === 1 ? '' : 's'}`));
             for (const id of ids) {
-                const full = index.entity.get(`${id}`);
-                const leaf = typeof full === 'string' ? full.split('/').filter(Boolean).pop() : undefined;
-                list.appendChild(chip('entity', id, leaf));
+                list.appendChild(chip('entity', id, entityLeaf(index, id)));
+            }
+            return list;
+        }
+        case 'tags': {
+            // entity/asset tag list: each tag is its own label, render as plain pills
+            const items = Array.isArray(value) ? value : [value];
+            const list = document.createElement('div');
+            list.className = 'vc-diff-array';
+            if (items.length > 1) {
+                list.classList.add('multi');
+            }
+            list.appendChild(el('size', `${items.length} item${items.length === 1 ? '' : 's'}`));
+            for (const t of items) {
+                list.appendChild(chip('', t, `${t}`));
             }
             return list;
         }
@@ -132,6 +167,41 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
         default:
             return missingEl('no preview available');
     }
+};
+
+// a list field (entity children / asset-id list) whose membership changed:
+// removed items tinted red, added tinted green, in ONE neutral list so the
+// surrounding row isn't coloured as if the whole property were added/removed
+export const createDeltaListField = (kind: 'children' | 'array:asset' | 'tags', removed: any[], added: any[], index: NameIndex): HTMLElement => {
+    const list = document.createElement('div');
+    list.className = 'vc-diff-array';
+    if (removed.length + added.length > 1) {
+        list.classList.add('multi');
+    }
+    const summary = [];
+    if (removed.length) {
+        summary.push(`−${removed.length}`);
+    }
+    if (added.length) {
+        summary.push(`+${added.length}`);
+    }
+    list.appendChild(el('size', summary.join('   ')));
+    const refChip = (id: unknown, state: 'added' | 'removed') => {
+        if (kind === 'children') {
+            return chip('entity', id, entityLeaf(index, id), state);
+        }
+        if (kind === 'tags') {
+            return chip('', id, `${id}`, state);
+        }
+        return chip('asset', id, index.asset.get(`${id}`), state);
+    };
+    for (const id of removed) {
+        list.appendChild(refChip(id, 'removed'));
+    }
+    for (const id of added) {
+        list.appendChild(refChip(id, 'added'));
+    }
+    return list;
 };
 
 // pcui widgets hold timers (curve/gradient resize loops); destroy before discarding their dom

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -1,7 +1,7 @@
 import { Panel } from '@playcanvas/pcui';
 
 import { isEntityIdMap } from './vc-diff-data';
-import { formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
+import { assetDiffField, formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
 
 // compact, text-valued mirror of the full diff's structured renderer
 // (picker-version-control-diff.ts). kept separate so the shipped full diff
@@ -32,6 +32,12 @@ const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
     const path = tpl ? entry.path.slice('data.'.length) : entry.path;
     const type = tpl ? 'scene' : conflict.itemType;
     const raw = entry.path || conflict.itemName;
+    // generic asset property diffs: humanise data.opacityDither -> "Opacity
+    // Dither" and group under the asset-type panel, like the inspector
+    if (!tpl && type === 'asset' && path) {
+        const a = assetDiffField(conflict.assetType, path);
+        return { entityContext: [], section: a.section, context: [], field: a.field, title: a.title, type: '' };
+    }
     if (!path || (type !== 'scene' && type !== 'settings')) {
         return {
             entityContext: [],

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -143,6 +143,8 @@ export const renderPreviewPropertyDiff = (
             span.textContent = '(none)';
         } else {
             span.textContent = fmtVal(value);
+            // fmtVal truncates to 64 chars; hover shows the full value
+            span.title = typeof value === 'string' ? value : JSON.stringify(value);
         }
         return span;
     };

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -18,6 +18,13 @@ type EntityName = (conflict: any, value: string) => string | undefined;
 
 const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
 
+// entities.<guid>.children (scenes) / data.entities.<guid>.children (templates)
+const isEntityChildren = (path: string) => {
+    const parts = splitDiffPath(path ?? '');
+    const e = parts[0] === 'data' ? parts.slice(1) : parts;
+    return e.length === 3 && e[0] === 'entities' && e[2] === 'children';
+};
+
 const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
     // template assets carry a scene-shaped entity tree under data.entities;
     // strip the prefix and render it exactly like a scene
@@ -98,8 +105,11 @@ const wholeEntity = (entry: any) => {
     if (!entry.missingInSrc && !entry.missingInDst) {
         return false;
     }
+    // templates prefix the path with `data.`; normalise so a whole template
+    // entity (data.entities.<guid>) reads like a scene's (entities.<guid>)
     const parts = splitDiffPath(entry.path ?? '');
-    return parts.length === 2 && parts[0] === 'entities';
+    const e = parts[0] === 'data' ? parts.slice(1) : parts;
+    return e.length === 2 && e[0] === 'entities';
 };
 
 const fieldRow = (kind: 'del' | 'add', label: string, title: string, valueEl: HTMLElement) => {
@@ -156,6 +166,11 @@ export const renderPreviewPropertyDiff = (
             // compact summary in the preview; the full diff resolves names
             const n = Object.keys(value).length;
             span.textContent = `${n} entit${n === 1 ? 'y' : 'ies'}`;
+            span.title = JSON.stringify(value, null, 2);
+        } else if (isEntityChildren(entry.path) && Array.isArray(value)) {
+            // compact summary; the full diff resolves these ids to named chips
+            const n = value.length;
+            span.textContent = `${n} child${n === 1 ? '' : 'ren'}`;
             span.title = JSON.stringify(value, null, 2);
         } else {
             span.textContent = fmtVal(value);

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -1,5 +1,6 @@
 import { Panel } from '@playcanvas/pcui';
 
+import { isEntityIdMap } from './vc-diff-data';
 import { formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
 
 // compact, text-valued mirror of the full diff's structured renderer
@@ -9,13 +10,22 @@ import { formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
 const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
 const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
 
+// entity-level template-instance fields route to their own collapsed panel
+const TEMPLATE_PANEL = 'Template instance';
+const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template', template_ent_ids: 'Entity mapping' };
+
 type EntityName = (conflict: any, value: string) => string | undefined;
 
 const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
 
 const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
+    // template assets carry a scene-shaped entity tree under data.entities;
+    // strip the prefix and render it exactly like a scene
+    const tpl = conflict.assetType === 'template' && entry.path?.startsWith('data.entities.');
+    const path = tpl ? entry.path.slice('data.'.length) : entry.path;
+    const type = tpl ? 'scene' : conflict.itemType;
     const raw = entry.path || conflict.itemName;
-    if (!entry.path || (conflict.itemType !== 'scene' && conflict.itemType !== 'settings')) {
+    if (!path || (type !== 'scene' && type !== 'settings')) {
         return {
             entityContext: [],
             section: typeLabel(conflict.itemType ?? 'item'),
@@ -26,12 +36,13 @@ const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
         };
     }
 
-    const info = formatDiffPath(entry.path, conflict.itemType, entityName(conflict, entry.path));
+    const info = formatDiffPath(path, type, entityName(conflict, path));
     const labels = info.labels;
     const entity = labels.find(label => label.text.startsWith('Entity: '));
     const comp = labels.findIndex(label => label.text.endsWith(' component'));
+    const tplField = TEMPLATE_FIELDS[splitDiffPath(path).pop() ?? ''];
     let entityContext = [];
-    let section = labels[0]?.text ?? typeLabel(conflict.itemType);
+    let section = labels[0]?.text ?? typeLabel(type);
     let context = labels.slice(0, -1);
 
     if (comp >= 0) {
@@ -41,11 +52,11 @@ const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
     } else if (labels[0]?.text === 'Scene settings' && labels[1]) {
         section = labels[1].text;
         context = labels.slice(2);
-    } else if (conflict.itemType === 'settings') {
+    } else if (type === 'settings') {
         section = labels[0]?.text ?? 'Project settings';
         context = labels.slice(1);
     } else if (entity) {
-        section = 'Entity';
+        section = tplField ? TEMPLATE_PANEL : 'Entity';
         entityContext = [entity];
         context = labels.filter(label => label !== entity);
     }
@@ -54,7 +65,7 @@ const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
         entityContext,
         section,
         context,
-        field: info.field || raw,
+        field: tplField ?? info.field ?? raw,
         title: `${labels.map(label => label.text).join(' / ')} / ${info.field || raw}`,
         type: sectionComponent(section)
     };
@@ -141,6 +152,11 @@ export const renderPreviewPropertyDiff = (
         if (missing) {
             span.classList.add('vc-diff-missing');
             span.textContent = '(none)';
+        } else if (isEntityIdMap(value)) {
+            // compact summary in the preview; the full diff resolves names
+            const n = Object.keys(value).length;
+            span.textContent = `${n} entit${n === 1 ? 'y' : 'ies'}`;
+            span.title = JSON.stringify(value, null, 2);
         } else {
             span.textContent = fmtVal(value);
             // fmtVal truncates to 64 chars; hover shows the full value

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -1,0 +1,212 @@
+import { Panel } from '@playcanvas/pcui';
+
+import { formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
+
+// compact, text-valued mirror of the full diff's structured renderer
+// (picker-version-control-diff.ts). kept separate so the shipped full diff
+// stays untouched; the routing below intentionally tracks that file.
+
+const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
+const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
+
+type EntityName = (conflict: any, value: string) => string | undefined;
+
+const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
+
+const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
+    const raw = entry.path || conflict.itemName;
+    if (!entry.path || (conflict.itemType !== 'scene' && conflict.itemType !== 'settings')) {
+        return {
+            entityContext: [],
+            section: typeLabel(conflict.itemType ?? 'item'),
+            context: [],
+            field: raw,
+            title: raw,
+            type: sectionComponent(typeLabel(conflict.itemType ?? 'item'))
+        };
+    }
+
+    const info = formatDiffPath(entry.path, conflict.itemType, entityName(conflict, entry.path));
+    const labels = info.labels;
+    const entity = labels.find(label => label.text.startsWith('Entity: '));
+    const comp = labels.findIndex(label => label.text.endsWith(' component'));
+    let entityContext = [];
+    let section = labels[0]?.text ?? typeLabel(conflict.itemType);
+    let context = labels.slice(0, -1);
+
+    if (comp >= 0) {
+        section = labels[comp].text;
+        entityContext = entity ? [entity] : [];
+        context = labels.slice(comp + 1);
+    } else if (labels[0]?.text === 'Scene settings' && labels[1]) {
+        section = labels[1].text;
+        context = labels.slice(2);
+    } else if (conflict.itemType === 'settings') {
+        section = labels[0]?.text ?? 'Project settings';
+        context = labels.slice(1);
+    } else if (entity) {
+        section = 'Entity';
+        entityContext = [entity];
+        context = labels.filter(label => label !== entity);
+    }
+
+    return {
+        entityContext,
+        section,
+        context,
+        field: info.field || raw,
+        title: `${labels.map(label => label.text).join(' / ')} / ${info.field || raw}`,
+        type: sectionComponent(section)
+    };
+};
+
+const sectionParts = (conflict: any, entry: any, entityName: EntityName) => {
+    const info = inspectorInfo(conflict, entry, entityName);
+    const isSettings = conflict.itemType === 'settings' ||
+        (conflict.itemType === 'scene' && splitDiffPath(entry.path ?? '')[0] === 'settings');
+    if (isSettings) {
+        const sub = SETTINGS_ROOT_RE.test(info.section) ? '' :
+            [info.section, ...info.context.map(label => label.text)].join(' · ');
+        return { entity: null, panel: 'Settings', icon: '', sub, field: info.field, title: info.title };
+    }
+    const subMatch = info.context[0]?.text.match(SUB_RE);
+    // the inspector shows raw (unprettified) script attribute names
+    const field = subMatch?.groups?.kind === 'Script' ? (splitDiffPath(entry.path ?? '').pop() ?? info.field) : info.field;
+    return {
+        entity: info.entityContext[0] ?? null,
+        panel: info.section.replace(/ component$/i, ''),
+        icon: info.type,
+        sub: subMatch?.groups?.name ?? '',
+        field,
+        title: info.title
+    };
+};
+
+// wholly added/deleted entities arrive as a missing-flagged entry at the entity root
+const wholeEntity = (entry: any) => {
+    if (!entry.missingInSrc && !entry.missingInDst) {
+        return false;
+    }
+    const parts = splitDiffPath(entry.path ?? '');
+    return parts.length === 2 && parts[0] === 'entities';
+};
+
+const fieldRow = (kind: 'del' | 'add', label: string, title: string, valueEl: HTMLElement) => {
+    const row = document.createElement('div');
+    row.classList.add('vc-diff-field-row', kind);
+    row.title = title;
+    const gut = document.createElement('span');
+    gut.classList.add('gutter');
+    gut.textContent = kind === 'del' ? '−' : '+';
+    row.appendChild(gut);
+    const lbl = document.createElement('span');
+    lbl.classList.add('label');
+    lbl.textContent = label;
+    row.appendChild(lbl);
+    const val = document.createElement('span');
+    val.classList.add('value');
+    val.appendChild(valueEl);
+    row.appendChild(val);
+    return row;
+};
+
+const banner = (status: string, noun: string) => {
+    const el = document.createElement('div');
+    el.classList.add('vc-diff-banner');
+    const badge = document.createElement('span');
+    badge.classList.add('status', status);
+    badge.textContent = status;
+    el.appendChild(badge);
+    const text = document.createElement('span');
+    text.textContent = `This ${noun} was ${status} since the checkpoint`;
+    el.appendChild(text);
+    return el;
+};
+
+// structured property diff for the changes-tab preview: same markup/classes as
+// the full diff, but a text breadcrumb instead of a live tree and string values
+export const renderPreviewPropertyDiff = (
+    conflict: any,
+    entries: any[],
+    helpers: { entityName: EntityName; fmtVal: (v: any) => string }
+) => {
+    const { entityName, fmtVal } = helpers;
+    const wrap = document.createElement('div');
+    wrap.classList.add('vc-diff-inspector', 'compact');
+
+    const valueCell = (entry: any, side: 'src' | 'dst') => {
+        const value = side === 'src' ? entry.srcValue : entry.dstValue;
+        const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
+        const span = document.createElement('span');
+        if (missing) {
+            span.classList.add('vc-diff-missing');
+            span.textContent = '(none)';
+        } else {
+            span.textContent = fmtVal(value);
+        }
+        return span;
+    };
+
+    let section: { key: string; panel: Panel; subs: Map<string, Panel> } = null;
+    const hostDom = (parts: { sub: string; panel: string }) => {
+        if (!parts.sub) {
+            return section.panel.content.dom;
+        }
+        if (!section.subs.has(parts.sub)) {
+            const sub = new Panel({ collapsible: true, headerText: parts.sub });
+            sub.class.add('vc-diff-subpanel');
+            if (parts.panel !== 'Settings') {
+                sub.class.add('inset');
+            }
+            section.panel.append(sub);
+            section.subs.set(parts.sub, sub);
+        }
+        return section.subs.get(parts.sub)!.content.dom;
+    };
+
+    for (const entry of entries) {
+        const parts = sectionParts(conflict, entry, entityName);
+        const key = JSON.stringify([parts.entity?.title ?? parts.entity?.text ?? '', parts.panel]);
+        if (section?.key !== key) {
+            const card = document.createElement('div');
+            card.classList.add('vc-diff-section');
+            if (parts.entity) {
+                const crumb = document.createElement('div');
+                crumb.classList.add('vc-diff-crumb');
+                crumb.textContent = parts.entity.text.replace(/^Entity:\s*/, '').split('/').filter(Boolean).join(' / ');
+                crumb.title = parts.entity.title ?? parts.entity.text;
+                card.appendChild(crumb);
+            }
+            const panel = new Panel({ collapsible: true, headerText: parts.panel });
+            panel.class.add('vc-diff-panel');
+            if (parts.icon) {
+                const icon = document.createElement('span');
+                icon.classList.add('component-icon', `type-${parts.icon}`);
+                panel.header.dom.insertBefore(icon, panel.header.dom.querySelector('.pcui-panel-header-title'));
+            }
+            card.appendChild(panel.dom);
+            wrap.appendChild(card);
+            section = { key, panel, subs: new Map() };
+        }
+        const host = hostDom(parts);
+        if (!entry.path || wholeEntity(entry)) {
+            const status = entry.missingInDst ? 'added' : entry.missingInSrc ? 'deleted' : 'modified';
+            host.appendChild(banner(status, entry.path ? 'entity' : conflict.assetType ?? conflict.itemType ?? 'item'));
+            continue;
+        }
+        if (!entry.missingInDst) {
+            host.appendChild(fieldRow('del', parts.field, parts.title, valueCell(entry, 'dst')));
+        }
+        if (!entry.missingInSrc) {
+            host.appendChild(fieldRow('add', parts.field, parts.title, valueCell(entry, 'src')));
+        }
+    }
+
+    if (!entries.length) {
+        const empty = document.createElement('div');
+        empty.classList.add('vc-diff-empty');
+        empty.textContent = 'No property changes';
+        wrap.appendChild(empty);
+    }
+    return wrap;
+};

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -165,7 +165,10 @@ export const renderPreviewPropertyDiff = (
         return span;
     };
 
-    let section: { key: string; panel: Panel; subs: Map<string, Panel> } = null;
+    // one card per entity (breadcrumb shown once); panels stack inside so an
+    // entity changed across sections isn't drawn as separate repeated parts
+    let card: { entity: string; dom: HTMLElement } = null;
+    let section: { name: string; panel: Panel; subs: Map<string, Panel> } = null;
     const hostDom = (parts: { sub: string; panel: string }) => {
         if (!parts.sub) {
             return section.panel.content.dom;
@@ -184,17 +187,22 @@ export const renderPreviewPropertyDiff = (
 
     for (const entry of entries) {
         const parts = sectionParts(conflict, entry, entityName);
-        const key = JSON.stringify([parts.entity?.title ?? parts.entity?.text ?? '', parts.panel]);
-        if (section?.key !== key) {
-            const card = document.createElement('div');
-            card.classList.add('vc-diff-section');
+        const entityKey = parts.entity?.title ?? parts.entity?.text ?? '';
+        if (!card || card.entity !== entityKey) {
+            const dom = document.createElement('div');
+            dom.classList.add('vc-diff-section');
             if (parts.entity) {
                 const crumb = document.createElement('div');
                 crumb.classList.add('vc-diff-crumb');
                 crumb.textContent = parts.entity.text.replace(/^Entity:\s*/, '').split('/').filter(Boolean).join(' / ');
                 crumb.title = parts.entity.title ?? parts.entity.text;
-                card.appendChild(crumb);
+                dom.appendChild(crumb);
             }
+            wrap.appendChild(dom);
+            card = { entity: entityKey, dom };
+            section = null;
+        }
+        if (!section || section.name !== parts.panel) {
             const panel = new Panel({ collapsible: true, headerText: parts.panel });
             panel.class.add('vc-diff-panel');
             if (parts.icon) {
@@ -202,9 +210,8 @@ export const renderPreviewPropertyDiff = (
                 icon.classList.add('component-icon', `type-${parts.icon}`);
                 panel.header.dom.insertBefore(icon, panel.header.dom.querySelector('.pcui-panel-header-title'));
             }
-            card.appendChild(panel.dom);
-            wrap.appendChild(card);
-            section = { key, panel, subs: new Map() };
+            card.dom.appendChild(panel.dom);
+            section = { name: parts.panel, panel, subs: new Map() };
         }
         const host = hostDom(parts);
         if (!entry.path || wholeEntity(entry)) {

--- a/src/editor/pickers/version-control/vc-helpers.ts
+++ b/src/editor/pickers/version-control/vc-helpers.ts
@@ -61,7 +61,7 @@ export const hashChip = (id: string) => {
 
 type DiffLike = {
     numConflicts?: number;
-    conflicts?: { itemType: string; itemName: string; data?: { missingInSrc?: boolean; missingInDst?: boolean }[] }[];
+    conflicts?: { itemType: string; itemName: string; data?: { path?: string; missingInSrc?: boolean; missingInDst?: boolean }[] }[];
 };
 
 // group label for an item type; 'settings' is already plural
@@ -71,8 +71,10 @@ export const summarizeDiff = (diff: DiffLike): DiffSummary => {
     const groups = new Map<string, { name: string; status: DiffStatus; index: number }[]>();
     (diff.conflicts ?? []).forEach((c, index) => {
         const entry = c.data?.[0] ?? {};
+        // whole-item adds/deletes carry no entry path; pathful missing flags are field-level
+        const whole = !entry.path;
         // dst-missing wins if both flags are ever set: item exists in src only, so 'added'
-        const status: DiffStatus = entry.missingInDst ? 'added' : entry.missingInSrc ? 'deleted' : 'modified';
+        const status: DiffStatus = whole && entry.missingInDst ? 'added' : whole && entry.missingInSrc ? 'deleted' : 'modified';
         if (!groups.has(c.itemType)) {
             groups.set(c.itemType, []);
         }

--- a/src/editor/pickers/version-control/vc-helpers.ts
+++ b/src/editor/pickers/version-control/vc-helpers.ts
@@ -175,6 +175,22 @@ const settingLabel = (s: string) => ({
     scripts: 'Script loading order'
 }[s] ?? prettyPart(s));
 
+// internal version-control plumbing (file backup refs etc.) that never appears
+// in the inspector — keep it out of the diff entirely
+const HIDDEN_DIFF_FIELDS = new Set(['immutable_backup']);
+export const isHiddenDiffField = (path: string) => HIDDEN_DIFF_FIELDS.has(splitDiffPath(path ?? '').pop() ?? '');
+
+// generic asset property diff (material, texture, ...): inspector fields live
+// under data.; strip it and prettify the path so a row reads like the inspector
+// (data.opacityDither -> "Opacity Dither") grouped under the asset-type panel
+export const assetDiffField = (assetType: string, path: string) => {
+    const inner = path.startsWith('data.') ? path.slice('data.'.length) : path;
+    const info = formatDiffPath(inner, 'asset');
+    const section = prettyPart(assetType || 'asset');
+    const field = info.labels.length ? `${info.labels.map(l => l.text).join(' / ')} / ${info.field}` : info.field;
+    return { section, field, title: `${section} / ${field}` };
+};
+
 export const formatDiffPath = (path: string, type: string, entityName?: string) => {
     const parts = splitDiffPath(path);
     if (type === 'scene' && parts[0] === 'entities' && parts[1]) {

--- a/test/common/vc-helpers.test.ts
+++ b/test/common/vc-helpers.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { summarizeDiff } from '../../src/editor/pickers/version-control/vc-helpers';
+
+describe('summarizeDiff', () => {
+    it('labels whole-item adds and deletes from pathless entries', () => {
+        const summary = summarizeDiff({
+            numConflicts: 2,
+            conflicts: [
+                { itemType: 'texture', itemName: 'brick.png', data: [{ missingInDst: true }] },
+                { itemType: 'texture', itemName: 'old.png', data: [{ missingInSrc: true }] }
+            ]
+        });
+        expect(summary.groups[0].items[0].status).to.equal('added');
+        expect(summary.groups[0].items[1].status).to.equal('deleted');
+    });
+
+    it('keeps items modified when only fields carry missing flags', () => {
+        const summary = summarizeDiff({
+            numConflicts: 1,
+            conflicts: [
+                { itemType: 'scene', itemName: 'Main', data: [{ path: 'entities.g.components.light.color', missingInDst: true }] }
+            ]
+        });
+        expect(summary.groups[0].items[0].status).to.equal('modified');
+    });
+});


### PR DESCRIPTION
Fixes #2088

Follow-up polish on the version control **diff viewer** + **changes preview**, plus a **Builds & Publish** caching fix. Builds on the VC migration already on `main` (#2089).

## Highlights
- **Inspector-style diffs** — asset fields show humanised labels (`data.opacityDither` → "Opacity Dither") grouped under their type panel, reusing existing PCUI widgets instead of raw JSON.
- **Name resolution** — entity / template-instance / asset GUIDs resolve to names in both the full diff and the changes tab.
- **Array fields render by shape** — any primitive array (tags, device types, folder path, script order, children, …) shows as a membership **delta of pills/chips** (only changed items, tinted in place) in one neutral row. Numeric vector/colour tuples (≤4) keep their positional widget. One `arrayFieldKind()` classifier, no per-field allowlists.
- **Layout** — loading skeleton + state, overlay no longer underlaps the toolbar, header/close/typography match the picker, cleaned-up breadcrumb connectors, centred chip labels, ellipsis tooltips.
- **Builds & Publish** — caches the apps list so reopening doesn't reflow the UI (filters still clear on close).

## Preview
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/930860cf-3ab6-4a25-9591-6d4a95fdda19" />

<img width="4308" height="2636" alt="image" src="https://github.com/user-attachments/assets/39e11694-099e-4889-a1ff-6ca9136ff94b" />


## Verification
`npm run lint` + SASS compile clean; manual pass over scene/template/asset/settings diffs, whole-entity add/delete, and Builds & Publish reopen.
