### PR TITLE
fix(version-control): on-demand checkpoint diffs + roomier composer (#2098)

### DIFF
--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -368,6 +368,9 @@
     // card title row: heading left, compact meta right
     .vc-card-head {
         display: flex;
+
+        // wrap the meta/button below the title when the main pane is narrow (#2098)
+        flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
         gap: 10px;
@@ -376,6 +379,7 @@
         > h3 {
             @extend .font-bold;
 
+            min-width: 0;
             margin: 0;
             color: $text-primary;
             font-size: 13px;
@@ -383,12 +387,28 @@
 
         > .side {
             display: flex;
-            flex: none;
+
+            // shrink so the button can ellipsize instead of overflowing a narrow pane (#2098)
+            flex: 0 1 auto;
+            min-width: 0;
+            flex-wrap: wrap;
             align-items: center;
             gap: 12px;
 
             > .vc-meta {
                 font-size: 11px;
+            }
+
+            // truncate the label to a single line + ellipsis rather than wrapping (#2098)
+            > .vc-button:not([hidden]) {
+                box-sizing: border-box;
+                display: block;
+                min-width: 0;
+                overflow: hidden;
+                line-height: 26px;
+                white-space: nowrap;
+                text-align: center;
+                text-overflow: ellipsis;
             }
         }
     }
@@ -679,8 +699,11 @@
                     @extend .font-regular;
 
                     display: block;
-                    width: calc(100% - 20px);
-                    height: 56px;
+                    box-sizing: border-box;
+                    width: 100%;
+
+                    // grows upward as you type; js caps the height to the rail (#2098)
+                    min-height: 120px;
                     margin: 0;
                     padding: 10px;
                     border: none;
@@ -689,6 +712,7 @@
                     font-size: 13px;
                     outline: none;
                     box-shadow: none;
+                    overflow-y: auto;
                     resize: none;
 
                     &::placeholder {

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -693,6 +693,10 @@
             background-color: $bcg-dark;
 
             > .pcui-text-area-input {
+                display: flex;
+                flex: 1 1 auto;
+                flex-direction: column;
+                min-height: 0;
                 width: 100%;
                 margin: 0 0 8px;
                 border: 1px solid $border-primary;
@@ -705,10 +709,11 @@
 
                     display: block;
                     box-sizing: border-box;
-                    width: 100%;
 
-                    // grows upward as you type; js caps the height to the rail (#2098)
-                    min-height: 120px;
+                    // fill the resizable composer; drag its top edge to change the height (#2098)
+                    flex: 1 1 auto;
+                    min-height: 0;
+                    width: 100%;
                     margin: 0;
                     padding: 10px;
                     border: none;

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -476,6 +476,11 @@
         }
     }
 
+    // on-demand compute action sits below the "not computed yet" note (#2098)
+    .vc-compute {
+        margin-top: 10px;
+    }
+
     // ---- history list ----
     .vc-history {
         flex: 1 1 auto;

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -19,6 +19,10 @@ editor.once('load', () => {
         title: 'Editor',
         description: 'Editor settings such as camera near/far clip, zoom sensitivity, and more.'
     }, {
+        name: 'settings:versionControl',
+        title: 'Version Control',
+        description: 'Version control preferences that affect only you, such as automatically loading checkpoint diffs.'
+    }, {
         name: 'settings:snap',
         description: 'Set the increment for gizmo snapping. Hold Shift or use the Snap toggle on the toolbar to enable snapping while using gizmos.'
     }, {
@@ -88,6 +92,9 @@ editor.once('load', () => {
     }, {
         name: 'settings:lightmapperAutoBake',
         description: 'Enable or disable automatic lightmap baking.'
+    }, {
+        name: 'settings:vcAutoLoadDiffs',
+        description: 'Automatically compute and show diffs in the Version Control panel. Turn off on very large projects where diff generation is slow.'
     }, {
         name: 'settings:codeEditor',
         description: 'The code editor to use when you edit scripts.'

--- a/src/editor/inspector/settings-panel.ts
+++ b/src/editor/inspector/settings-panel.ts
@@ -21,6 +21,7 @@ import { PhysicsSettingsPanel } from './settings-panels/physics';
 import { RenderingSettingsPanel } from './settings-panels/rendering';
 import { ScriptsSettingsPanel } from './settings-panels/scripts';
 import { ProjectHistorySettingsPanel } from './settings-panels/settings-history';
+import { VersionControlSettingsPanel } from './settings-panels/version-control';
 
 
 const CLASS_ROOT = 'settings';
@@ -28,6 +29,7 @@ const CLASS_ROOT = 'settings';
 const SETTINGS_PANELS = [
     EngineSettingsPanel,
     EditorSettingsPanel,
+    VersionControlSettingsPanel,
     AssetImportSettingsPanel,
     PhysicsSettingsPanel,
     RenderingSettingsPanel,

--- a/src/editor/inspector/settings-panels/version-control.ts
+++ b/src/editor/inspector/settings-panels/version-control.ts
@@ -1,0 +1,27 @@
+import { BaseSettingsPanel, type BaseSettingsPanelArgs } from './base';
+import type { Attribute } from '../attribute.type.d';
+
+const ATTRIBUTES: Attribute[] = [
+    {
+        observer: 'settings',
+        label: 'Auto-Load Diffs',
+        path: 'editor.vcAutoLoadDiffs',
+        alias: 'vcAutoLoadDiffs',
+        reference: 'settings:vcAutoLoadDiffs',
+        type: 'boolean'
+    }
+];
+
+class VersionControlSettingsPanel extends BaseSettingsPanel {
+    constructor(args: BaseSettingsPanelArgs) {
+        args = Object.assign({}, args);
+        args.headerText = 'VERSION CONTROL';
+        args.attributes = ATTRIBUTES;
+        args.userOnlySettings = true;
+        args._tooltipReference = 'settings:versionControl';
+
+        super(args);
+    }
+}
+
+export { VersionControlSettingsPanel };

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -7,6 +7,10 @@ import { renderPreviewPropertyDiff } from './vc-diff-preview';
 import { diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
+// composer resting height and the slice of the change list kept visible above it
+const COMPOSER_MIN_H = 120;
+const COMPOSER_LIST_FLOOR = 80;
+
 export const createChangesPanel = () => {
     const sidebar = new Container({ class: 'vc-changes' });
     const summary = new Container({ class: 'vc-changes-summary' });
@@ -47,7 +51,8 @@ export const createChangesPanel = () => {
 
     // native placeholder; pcui's [placeholder] renders an out-of-place chip
     const description = new TextAreaInput({ blurOnEnter: false, keyChange: true, renderChanges: false });
-    (description.dom.querySelector('textarea') as HTMLTextAreaElement).placeholder = 'Describe this checkpoint…';
+    const textarea = description.dom.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.placeholder = 'Describe this checkpoint…';
     form.appendChild(description.dom);
 
     const create = document.createElement('button');
@@ -77,6 +82,16 @@ export const createChangesPanel = () => {
     tip.classList.add('vc-form-tip');
     tip.textContent = 'Tip: Cmd/Ctrl+Enter creates the checkpoint.';
     form.appendChild(tip);
+
+    // bottom-pinned composer: a taller textarea grows the form upward into the change
+    // list, so cap it to the rail to keep the list and Create button on screen (#2098)
+    const autoGrow = () => {
+        textarea.style.height = 'auto';
+        const chrome = form.offsetHeight - textarea.offsetHeight;
+        const cap = Math.max(COMPOSER_MIN_H, sidebar.dom.clientHeight - chrome - COMPOSER_LIST_FLOOR);
+        textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, COMPOSER_MIN_H), cap)}px`;
+    };
+    textarea.addEventListener('input', autoGrow);
 
     const select = (index: number) => {
         selIdx = index;
@@ -410,6 +425,7 @@ export const createChangesPanel = () => {
         },
         resetForm: () => {
             description.value = '';
+            textarea.style.height = '';
             create.disabled = true;
             create.classList.remove('busy');
             create.textContent = 'Create Checkpoint';

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -301,7 +301,13 @@ export const createChangesPanel = () => {
             openBtn.type = 'button';
             openBtn.classList.add('vc-button');
             openBtn.textContent = 'Open Full Diff';
-            openBtn.addEventListener('click', () => summary.emit('openDiff', !loading && rawDiffLive ? raw : null, rawPromise));
+            openBtn.addEventListener('click', () => {
+                // also load the diff into the panel so returning from the full diff shows the changes (#2098)
+                if (!rawDiffLive && !loading) {
+                    refresh(true, true);
+                }
+                summary.emit('openDiff', !loading && rawDiffLive ? raw : null, rawPromise);
+            });
             side.appendChild(openBtn);
         }
 

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -7,9 +7,12 @@ import { renderPreviewPropertyDiff } from './vc-diff-preview';
 import { diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
-// composer resting height and the slice of the change list kept visible above it
-const COMPOSER_MIN_H = 120;
-const COMPOSER_LIST_FLOOR = 80;
+// composer height bounds — drag the top edge to resize; persisted per browser.
+// the min keeps the textarea usable above the Create button + tip chrome
+const COMPOSER_KEY = 'editor:vc:composer:height';
+const COMPOSER_DEFAULT_H = 160;
+const COMPOSER_MIN_H = 140;
+const COMPOSER_MAX_H = 420;
 
 export const createChangesPanel = () => {
     const sidebar = new Container({ class: 'vc-changes' });
@@ -45,22 +48,33 @@ export const createChangesPanel = () => {
     list.classList.add('vc-changes-list');
     sidebar.dom.appendChild(list);
 
-    const form = document.createElement('div');
-    form.classList.add('vc-checkpoint-form');
-    sidebar.dom.appendChild(form);
+    // drag the top edge to resize; the textarea fills the form, growing upward into the list
+    const form = new Container({
+        class: 'vc-checkpoint-form',
+        flex: true,
+        flexDirection: 'column',
+        resizable: 'top',
+        resizeMin: COMPOSER_MIN_H,
+        resizeMax: COMPOSER_MAX_H,
+        height: Math.min(COMPOSER_MAX_H, Math.max(COMPOSER_MIN_H, editor.call('localStorage:get', COMPOSER_KEY) || COMPOSER_DEFAULT_H))
+    });
+    form.on('resize', () => {
+        editor.call('localStorage:set', COMPOSER_KEY, form.height);
+    });
+    sidebar.append(form);
 
     // native placeholder; pcui's [placeholder] renders an out-of-place chip
     const description = new TextAreaInput({ blurOnEnter: false, keyChange: true, renderChanges: false });
     const textarea = description.dom.querySelector('textarea') as HTMLTextAreaElement;
     textarea.placeholder = 'Describe this checkpoint…';
-    form.appendChild(description.dom);
+    form.dom.appendChild(description.dom);
 
     const create = document.createElement('button');
     create.type = 'button';
     create.classList.add('vc-create-checkpoint');
     create.textContent = 'Create Checkpoint';
     create.disabled = true;
-    form.appendChild(create);
+    form.dom.appendChild(create);
 
     const gateCreate = () => {
         create.disabled = create.classList.contains('busy') || !description.value.trim() || !editor.call('permissions:write');
@@ -81,17 +95,7 @@ export const createChangesPanel = () => {
     const tip = document.createElement('div');
     tip.classList.add('vc-form-tip');
     tip.textContent = 'Tip: Cmd/Ctrl+Enter creates the checkpoint.';
-    form.appendChild(tip);
-
-    // bottom-pinned composer: a taller textarea grows the form upward into the change
-    // list, so cap it to the rail to keep the list and Create button on screen (#2098)
-    const autoGrow = () => {
-        textarea.style.height = 'auto';
-        const chrome = form.offsetHeight - textarea.offsetHeight;
-        const cap = Math.max(COMPOSER_MIN_H, sidebar.dom.clientHeight - chrome - COMPOSER_LIST_FLOOR);
-        textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, COMPOSER_MIN_H), cap)}px`;
-    };
-    textarea.addEventListener('input', autoGrow);
+    form.dom.appendChild(tip);
 
     const select = (index: number) => {
         selIdx = index;
@@ -450,7 +454,6 @@ export const createChangesPanel = () => {
         },
         resetForm: () => {
             description.value = '';
-            textarea.style.height = '';
             create.disabled = true;
             create.classList.remove('busy');
             create.textContent = 'Create Checkpoint';

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -295,7 +295,7 @@ export const createChangesPanel = () => {
             side.appendChild(meta);
         }
 
-        // show while loading and whenever there are changes; hide only once we know there are none
+        // show while loading, when not yet computed (so Open Full Diff works directly), and when there are changes (#2098)
         if (branch.latestCheckpointId && (loading || !current || current.total)) {
             const openBtn = document.createElement('button');
             openBtn.type = 'button';
@@ -337,6 +337,15 @@ export const createChangesPanel = () => {
             none.classList.add('vc-meta');
             none.textContent = current ? 'No changes since your last checkpoint' : 'Changes not computed yet';
             card.appendChild(none);
+            // not computed (gated or errored): let the user pull the diff on demand (#2098)
+            if (!current) {
+                const compute = document.createElement('button');
+                compute.type = 'button';
+                compute.classList.add('vc-button', 'vc-compute');
+                compute.textContent = 'Compute';
+                compute.addEventListener('click', () => refresh(true, true));
+                card.appendChild(compute);
+            }
         }
 
         summary.dom.appendChild(card);
@@ -347,7 +356,7 @@ export const createChangesPanel = () => {
         renderSummary();
     };
 
-    function refresh(force?: boolean) {
+    function refresh(force?: boolean, viaUser?: boolean) {
         const branch = config.self.branch;
         if (loading || (!stale && !force)) {
             render();
@@ -362,6 +371,16 @@ export const createChangesPanel = () => {
             stale = false;
             render();
             sidebar.emit('count', 0);
+            return;
+        }
+        // gated by the user setting: only the explicit Compute action fires the diff (#2098)
+        if (editor.call('settings:projectUser').get('editor.vcAutoLoadDiffs') === false && !viaUser) {
+            releaseRawDiff();
+            current = null;
+            raw = null;
+            selIdx = null;
+            render();
+            sidebar.emit('count', null);
             return;
         }
         loading = true;
@@ -452,7 +471,7 @@ export const createChangesPanel = () => {
 
     return {
         sidebar: sidebar as Container & {
-            refresh: (force?: boolean) => void;
+            refresh: (force?: boolean, viaUser?: boolean) => void;
             invalidate: () => void;
             resetForm: () => void;
             setBusy: (on: boolean) => void;

--- a/src/editor/pickers/version-control/panel-detail.ts
+++ b/src/editor/pickers/version-control/panel-detail.ts
@@ -1,6 +1,6 @@
 import { Container } from '@playcanvas/pcui';
 
-import { diffListEl, hashChip, summarizeDiff, userThumbnail } from './vc-helpers';
+import { applyUserThumbnail, diffListEl, hashChip, summarizeDiff } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
 type DiffCache = {
@@ -184,11 +184,7 @@ export const createDetailPanel = () => {
             const avatar = document.createElement('img');
             avatar.classList.add('avatar');
             avatar.alt = '';
-            userThumbnail(checkpoint.user.id, 40).then((src) => {
-                if (src) {
-                    avatar.src = src;
-                }
-            });
+            applyUserThumbnail(avatar, checkpoint.user.id, 40);
             heroInner.appendChild(avatar);
 
             const body = document.createElement('div');

--- a/src/editor/pickers/version-control/panel-detail.ts
+++ b/src/editor/pickers/version-control/panel-detail.ts
@@ -122,14 +122,15 @@ export const createDetailPanel = () => {
             body.appendChild(diffListEl(summary));
         };
 
-        const cached = diffCache[key];
-        if (cached?.summary) {
-            fill(cached.summary);
-        } else {
+        const show = () => {
             body.innerHTML = `<div class="vc-diff-list"><div class="vc-skeleton">${'<div class="skeleton-row"><span class="bone line"></span></div>'.repeat(3)}</div></div>`;
             const pending = loadDiff().promise;
             if (!pending) {
-                return card;
+                const ready = diffCache[key]?.summary;
+                if (ready) {
+                    fill(ready);
+                }
+                return;
             }
             pending.then(() => {
                 if (token !== renderToken) {
@@ -145,6 +146,21 @@ export const createDetailPanel = () => {
                 }
                 body.innerHTML = '<div class="vc-meta">Failed to compute changes</div>';
             });
+        };
+
+        const cached = diffCache[key];
+        if (cached?.summary) {
+            fill(cached.summary);
+        } else if (editor.call('settings:projectUser').get('editor.vcAutoLoadDiffs') !== false) {
+            show();
+        } else {
+            // diff is expensive / times out on large projects (#2098): load only on request
+            const showBtn = document.createElement('button');
+            showBtn.type = 'button';
+            showBtn.classList.add('vc-button');
+            showBtn.textContent = 'Show changes';
+            showBtn.addEventListener('click', show);
+            body.appendChild(showBtn);
         }
 
         return card;

--- a/src/editor/pickers/version-control/panel-detail.ts
+++ b/src/editor/pickers/version-control/panel-detail.ts
@@ -98,6 +98,8 @@ export const createDetailPanel = () => {
         link.classList.add('vc-button');
         link.textContent = 'Open Full Diff';
         link.addEventListener('click', () => {
+            // also fill the inline summary so it shows on return from the full diff (#2098)
+            show();
             const cached = loadDiff();
             panel.emit('openDiff', checkpoint, previous, cached.diff, cached.promise);
         });

--- a/src/editor/pickers/version-control/panel-history.ts
+++ b/src/editor/pickers/version-control/panel-history.ts
@@ -3,7 +3,7 @@ import { Container } from '@playcanvas/pcui';
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
-import { formatDayGroup, formatRelativeDate, hashChip, userThumbnail } from './vc-helpers';
+import { applyUserThumbnail, formatDayGroup, formatRelativeDate, hashChip } from './vc-helpers';
 
 const PAGE_SIZE = 50;
 const MAX_COMPARE = 2;
@@ -81,11 +81,7 @@ export const createHistoryPanel = () => {
             avatar.classList.add('avatar');
             avatar.alt = '';
             if (checkpoint) {
-                userThumbnail(checkpoint.user.id, 28).then((src) => {
-                    if (src) {
-                        avatar.src = src;
-                    }
-                });
+                applyUserThumbnail(avatar, checkpoint.user.id, 28);
             } else {
                 avatar.src = `${config.url.static}/platform/images/common/blank_project.png`;
             }
@@ -119,9 +115,11 @@ export const createHistoryPanel = () => {
         row.addEventListener('click', () => {
             if (compareMode) {
                 toggleSlot(checkpoint);
-            } else if (checkpoint) {
+            } else if (checkpoint && checkpoint.id !== selectedId) {
+                // move the highlight in place rather than rebuilding rows, so avatars don't reload/flicker (#2098)
                 selectedId = checkpoint.id;
-                render();
+                panel.dom.querySelectorAll('.vc-row.selected').forEach(r => r.classList.remove('selected'));
+                row.classList.add('selected');
                 panel.emit('select', checkpoint);
             }
         });

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -88,7 +88,16 @@ editor.once('load', () => {
     const body = new Container({ class: 'vc-body' });
     panel.append(body);
 
-    const sidebar = new Container({ class: 'vc-sidebar' });
+    const sidebar = new Container({
+        class: 'vc-sidebar',
+        width: editor.call('localStorage:get', 'editor:vc:sidebar:width') || 300,
+        resizable: 'right',
+        resizeMin: 260,
+        resizeMax: 720
+    });
+    sidebar.on('resize', () => {
+        editor.call('localStorage:set', 'editor:vc:sidebar:width', sidebar.width);
+    });
     body.append(sidebar);
 
     // viewing-other-branch banner

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -268,12 +268,13 @@ editor.once('load', () => {
     });
 
     // ---- history selection -> detail ----
-    history.on('select', (checkpoint: any) => {
+    let selectedCheckpoint: any = null;
+    const renderDetail = (checkpoint: any) => {
+        selectedCheckpoint = checkpoint;
         if (!checkpoint) {
             detail.clear();
             return;
         }
-        clearStaleProgress();
         const all = history.checkpoints || [];
         const index = all.findIndex((c: any) => c.id === checkpoint.id);
         const previous = index >= 0 && index < all.length - 1 ? all[index + 1] : null;
@@ -282,6 +283,12 @@ editor.once('load', () => {
             isCurrentBranch: isViewingCurrent(),
             canWrite: editor.call('permissions:write')
         });
+    };
+    history.on('select', (checkpoint: any) => {
+        if (checkpoint) {
+            clearStaleProgress();
+        }
+        renderDetail(checkpoint);
     });
 
     // ---- diff viewing ----
@@ -745,6 +752,14 @@ editor.once('load', () => {
             // setBranch clears both the selection highlight and the detail pane
             if (history.branch) {
                 history.setBranch(history.branch);
+            }
+        }));
+
+        // live-apply the auto-load-diffs setting to whatever is on screen (#2098)
+        events.push(projectUserSettings.on('editor.vcAutoLoadDiffs:set', () => {
+            renderDetail(selectedCheckpoint);
+            if (activeTab === 'changes') {
+                changes.sidebar.refresh();
             }
         }));
 

--- a/src/editor/pickers/version-control/vc-helpers.ts
+++ b/src/editor/pickers/version-control/vc-helpers.ts
@@ -40,15 +40,36 @@ export const formatDayGroup = (value: string | Date, now = new Date()) => {
 // one network fetch per user/size per session, regardless of server cache headers;
 // resolves to an object url, or '' on failure (callers skip assignment)
 const thumbCache = new Map<string, Promise<string>>();
+// resolved object urls kept for synchronous reuse, so re-created avatars don't flash empty
+const thumbResolved = new Map<string, string>();
 export const userThumbnail = (userId: string | number, size: number) => {
     const key = `${userId}:${size}`;
     if (!thumbCache.has(key)) {
         thumbCache.set(key, fetch(`/api/users/${userId}/thumbnail?size=${size}`)
         .then(res => (res.ok ? res.blob() : Promise.reject(new Error(`${res.status}`))))
         .then(blob => URL.createObjectURL(blob))
+        .then((url) => {
+            thumbResolved.set(key, url);
+            return url;
+        })
         .catch(() => ''));
     }
     return thumbCache.get(key);
+};
+
+// assign the avatar src synchronously when cached, so a freshly created <img> paints
+// the (already-loaded) blob immediately instead of flashing empty for a frame (#2098)
+export const applyUserThumbnail = (img: HTMLImageElement, userId: string | number, size: number) => {
+    const cached = thumbResolved.get(`${userId}:${size}`);
+    if (cached) {
+        img.src = cached;
+        return;
+    }
+    userThumbnail(userId, size).then((src) => {
+        if (src) {
+            img.src = src;
+        }
+    });
 };
 
 // verbatim-styled short checkpoint hash


### PR DESCRIPTION
Fixes #2098.

Two parts, addressing both points raised in the issue.

## On-demand diffs (primary)
Large projects time out generating checkpoint diffs, so a new per-user **Auto-Load Diffs** setting (Version Control settings panel, default **on**) lets users opt out. When off, diffs load only when explicitly requested:

- **History detail** → "Show changes" button for the inline summary; "Open Full Diff" still opens directly.
- **Changes tab** → "Compute" / "Open Full Diff" instead of auto-computing; stays gated through checkpoint creation so the daily-checkpoint workflow never triggers the timeout.
- Default-on means no behavior change for existing users; a graceful fallback treats the setting as on if the schema isn't present yet.

## Composer + layout (secondary)
- Checkpoint composer auto-grows upward (capped to the rail) instead of a fixed 56px box.
- The Changes sidebar partition is draggable (260–720px), width persisted to `localStorage`.
- Diff summary card head wraps and the "Open Full Diff" label ellipsizes on a narrow main pane.

## Preview
<img width="728" height="124" alt="image" src="https://github.com/user-attachments/assets/a5973202-4fae-4aba-9d76-332027db7b50" />

## Verification
- `eslint` + `stylelint` clean on changed files
- `type:check` clean for all changed files (pre-existing worker/sibling-VC errors unaffected)
- SASS compiles