### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.19.5",
+        "playcanvas": "2.19.7",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8751,9 +8751,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.5.tgz",
-      "integrity": "sha512-oc97+uMc2GZ7CuogQAhpXLhCXY0QDFMFUChSuOIxIplIabSUc72URLKc1ppev2qHslmPjze3E0YrMrknDSi10A==",
+      "version": "2.19.7",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.7.tgz",
+      "integrity": "sha512-AuGy5CuCj03FAEBE1qbhgA7ibvBjzG07j4MneT4nd3FEhfvW9IgUbdhRYZ8G6obXcdaIvHezEAhr7qjq0FkxHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.19.5",
+    "playcanvas": "2.19.7",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
Updates the PlayCanvas engine to the latest patch release within the current minor.

- `playcanvas` `2.19.5` → `2.19.7` (latest `2.19.x` patch / npm `latest` tag)
- Lockfile regenerated. `npm install` rewrote the `playcanvas` `resolved` URL to a local registry mirror; this was corrected back to the canonical `https://registry.npmjs.org/...` URL to match every other entry in the lockfile (integrity hash is identical, so the resolved tarball content is unchanged).

### Verification
- `npm run build` passes (exit 0, all bundles emitted)
- `npm run type:check` produces an identical error set to the `2.19.5` baseline — no new type errors introduced by the bump