### PR TITLE
fix(version-control): dismissable diff dialog + slow-diff feedback (#2099)

### DIFF
--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -233,6 +233,14 @@ $vc-add-edge: #3fb950;
     text-align: center;
 }
 
+// non-blocking "still working" banner above the loading skeleton for slow diffs (#2099)
+.vc-diff-slow-hint {
+    padding: 10px 16px;
+    border-bottom: 1px solid $border-primary;
+    color: $text-dark;
+    font-size: 12px;
+}
+
 // loading skeleton — mirrors the sidebar list (dot + line rows) and the main
 // detail layout (header + panel blocks); reuses the picker's pulse keyframe
 .vc-diff-skeleton {

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -481,6 +481,11 @@
         margin-top: 10px;
     }
 
+    // "still working" note shown after a while when an inline diff is slow (#2099)
+    .vc-slow-hint {
+        margin-top: 10px;
+    }
+
     // ---- history list ----
     .vc-history {
         flex: 1 1 auto;

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -4,7 +4,7 @@ import { config } from '@/editor/config';
 
 import { templateEntitiesFor, templateEntityPath } from './vc-diff-data';
 import { renderPreviewPropertyDiff } from './vc-diff-preview';
-import { diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
+import { DIFF_SLOW_HINT_MS, DIFF_SLOW_HINT_TEXT, diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
 // composer height bounds — drag the top edge to resize; persisted per browser.
@@ -403,7 +403,17 @@ export const createChangesPanel = () => {
             dstCheckpointId: branch.latestCheckpointId
         });
         rawPromise = pending;
+        // large diffs can hang; reassure that it's still working after a while (#2099)
+        const slowHint = setTimeout(() => {
+            if (snap === gen && loading) {
+                const hint = document.createElement('div');
+                hint.classList.add('vc-meta', 'vc-slow-hint');
+                hint.textContent = DIFF_SLOW_HINT_TEXT;
+                (summary.dom.querySelector('.vc-card') ?? summary.dom).appendChild(hint);
+            }
+        }, DIFF_SLOW_HINT_MS);
         pending.then((diff: any) => {
+            clearTimeout(slowHint);
             // single-flight: clear loading even for superseded responses or refresh deadlocks
             loading = false;
             if (snap !== gen) {
@@ -426,6 +436,7 @@ export const createChangesPanel = () => {
             render();
             sidebar.emit('count', current.total);
         }).catch((err) => {
+            clearTimeout(slowHint);
             loading = false;
             if (snap !== gen) {
                 return;

--- a/src/editor/pickers/version-control/panel-detail.ts
+++ b/src/editor/pickers/version-control/panel-detail.ts
@@ -1,6 +1,6 @@
 import { Container } from '@playcanvas/pcui';
 
-import { applyUserThumbnail, diffListEl, hashChip, summarizeDiff } from './vc-helpers';
+import { applyUserThumbnail, DIFF_SLOW_HINT_MS, DIFF_SLOW_HINT_TEXT, diffListEl, hashChip, summarizeDiff } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
 
 type DiffCache = {
@@ -134,7 +134,17 @@ export const createDetailPanel = () => {
                 }
                 return;
             }
+            // large diffs can hang; reassure that it's still working after a while (#2099)
+            const slowHint = setTimeout(() => {
+                if (token === renderToken && !diffCache[key]?.summary) {
+                    const hint = document.createElement('div');
+                    hint.classList.add('vc-meta', 'vc-slow-hint');
+                    hint.textContent = DIFF_SLOW_HINT_TEXT;
+                    body.appendChild(hint);
+                }
+            }, DIFF_SLOW_HINT_MS);
             pending.then(() => {
+                clearTimeout(slowHint);
                 if (token !== renderToken) {
                     return;
                 }
@@ -143,6 +153,7 @@ export const createDetailPanel = () => {
                     fill(next);
                 }
             }).catch(() => {
+                clearTimeout(slowHint);
                 if (token !== renderToken) {
                     return;
                 }

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -7,6 +7,8 @@ import { arrayFieldKind, buildNameIndex, indexTemplateEntities, valueKind, type 
 import { createDeltaListField, createValueField, destroyValueFields } from './vc-diff-fields';
 import {
     assetDiffField,
+    DIFF_SLOW_HINT_MS,
+    DIFF_SLOW_HINT_TEXT,
     diffTextChangeCounts,
     formatDiffPath,
     hashChip,
@@ -654,10 +656,18 @@ editor.once('load', () => {
             overlay.hidden = true;
         }
     };
+    // esc dismisses the diff even mid-load, since the backdrop is non-clickable (#2099)
+    const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && !overlay.hidden) {
+            e.stopPropagation();
+            overlay.hidden = true;
+        }
+    };
 
     overlay.on('show', () => {
         editor.emit('picker:open', 'version-control-diff');
         window.addEventListener('popstate', onPopState);
+        window.addEventListener('keydown', onKey, true);
         if (editor.call('viewport:inViewport')) {
             editor.emit('viewport:hover', false);
         }
@@ -665,6 +675,7 @@ editor.once('load', () => {
 
     overlay.on('hide', () => {
         window.removeEventListener('popstate', onPopState);
+        window.removeEventListener('keydown', onKey, true);
         const id = diffId(current);
         if (typeof id === 'string' && !isRetainedDiff(id)) {
             editor.emit('picker:diffManager:closed', id);
@@ -749,11 +760,23 @@ editor.once('load', () => {
         overlay.hidden = false;
         if (input && typeof input.then === 'function') {
             renderLoading();
+            // large diffs legitimately take minutes; keep the skeleton running and just reassure
+            // (the job still completes via messenger) — the diff renders whenever it resolves (#2099)
+            const slowHint = setTimeout(() => {
+                if (token === viewToken) {
+                    const hint = document.createElement('div');
+                    hint.classList.add('vc-diff-slow-hint');
+                    hint.textContent = DIFF_SLOW_HINT_TEXT;
+                    main.insertBefore(hint, main.firstChild);
+                }
+            }, DIFF_SLOW_HINT_MS);
             input.then((diff: any) => {
+                clearTimeout(slowHint);
                 if (token === viewToken) {
                     setDiff(diff);
                 }
             }).catch((err: any) => {
+                clearTimeout(slowHint);
                 if (token === viewToken) {
                     meta.textContent = '';
                     sidebar.innerHTML = '';

--- a/src/editor/pickers/version-control/vc-helpers.ts
+++ b/src/editor/pickers/version-control/vc-helpers.ts
@@ -2,6 +2,10 @@ const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const LINE_DIFF_CELL_LIMIT = 120000;
 
+// after this long, a still-loading diff shows a non-blocking "this can take a while" hint (#2099)
+export const DIFF_SLOW_HINT_MS = 60000;
+export const DIFF_SLOW_HINT_TEXT = 'Large diffs can take a few minutes — you can keep waiting or come back later.';
+
 export type DiffStatus = 'added' | 'deleted' | 'modified';
 
 export type DiffSummary = {


### PR DESCRIPTION
Fixes #2099.

For large projects the full-diff request can take minutes (or hang), and the diff dialog previously offered no way out but reloading the page.

## Changes
- **Esc-to-close** — the diff overlay can be dismissed with Esc even while loading (the backdrop is non-clickable), alongside the existing ✕ button.
- **Slow-diff hint** — after 60s a still-loading diff shows a non-blocking banner: *"Large diffs can take a few minutes — you can keep waiting or come back later."* It does **not** abort anything; the job keeps running and the diff renders whenever it completes via the messenger job update.
- **Consistent inline feedback** — the same hint appears for the inline loaders too: the **Changes** tab "Compute" and the **History** checkpoint "Show changes". One shared `DIFF_SLOW_HINT_MS` + message text drives all three surfaces.

## Notes
- No diffs are cancelled or timed out — long diffs (5+ min) still finish and display normally; the hint is purely reassurance + a reminder you can bail.
- Builds on the #2098 work already merged to `main`.

## Verification
- `eslint` + `stylelint` clean on changed files
- `type:check` clean for all changed files