### PR TITLE
test(version-control): update UI suite for the rewritten picker

### DIFF
--- a/test-suite/test/ui/version-control.test.ts
+++ b/test-suite/test/ui/version-control.test.ts
@@ -15,6 +15,103 @@ test.describe.configure({
     mode: 'serial'
 });
 
+// the version control picker was rewritten (#2098/#2099/#2100): a branch
+// switcher dropdown, Changes/History tabs, a detail pane, an inline checkpoint
+// composer, compare mode + a dedicated diff overlay, and vc-dialog dialogs.
+// the merge conflict resolution still routes through the (unchanged) legacy
+// `picker-conflict-manager`, so those selectors below are preserved.
+
+// the main vc panel (`picker-version-control` is shared with the graph panel)
+const VC_PANEL = '.picker-vc';
+
+// vc operations reload the editor via an async, ~1s-delayed messenger event
+// (branch.createEnded / branch.switch / merge / restore). a fixed wait races
+// that reload; instead mark the document, trigger the op, then wait for a fresh
+// document with the editor reloaded.
+const armReload = (page: Page) => page.evaluate(() => {
+    (window as any).__vcReload = true;
+});
+const waitReload = async (page: Page) => {
+    await page.waitForFunction(() => {
+        const w = window as any;
+        return w.__vcReload === undefined && !!w.editor?.api?.globals?.branchId;
+    }, undefined, { timeout: 90000 });
+    await page.waitForLoadState('networkidle');
+};
+
+/** open the version control picker via the project logo menu (idempotent) */
+const openVc = async (page: Page) => {
+    if (await page.locator(VC_PANEL).isVisible().catch(() => false)) {
+        return;
+    }
+    await page.locator('.pcui-element.font-regular.logo').click();
+    await page.locator('span').filter({ hasText: /^Version Control$/ }).first().click();
+    await page.locator(VC_PANEL).waitFor({ state: 'visible' });
+};
+
+/** open the branch switcher dropdown */
+const openSwitcher = async (page: Page) => {
+    await page.locator('.vc-branch-button').click();
+    await page.locator('.vc-branch-panel').waitFor({ state: 'visible' });
+};
+
+/** change the branch list filter (Open / Favorites / Closed) */
+const setBranchFilter = async (page: Page, label: 'Open' | 'Favorites' | 'Closed') => {
+    await page.locator('.vc-branch-filter .pcui-select-input-value').click();
+    await page.locator('.vc-branch-filter .pcui-select-input-list').getByText(label, { exact: true }).click();
+};
+
+/** run a kebab-menu action on a branch row (row actions are hover-revealed) */
+const branchMenuAction = async (page: Page, branchId: string, action: RegExp) => {
+    const row = page.locator(`#branch-${branchId}`);
+    await row.waitFor({ state: 'visible' });
+    await row.hover();
+    await row.locator('.kebab').click();
+    await page.locator('.pcui-menu-item').filter({ hasText: action }).first().click();
+};
+
+/** select a checkpoint in the History list and wait for its detail pane */
+const selectCheckpoint = async (page: Page, checkpointId: string) => {
+    const row = page.locator(`#checkpoint-${checkpointId}`);
+    await row.waitFor({ state: 'visible' });
+    await row.click();
+    await page.locator('.vc-detail-actions').first().waitFor({ state: 'visible' });
+};
+
+/** branch from a checkpoint via the detail pane; resolves to the new branch id */
+const createBranchFromCheckpoint = async (page: Page, checkpointId: string, name: string) => {
+    await selectCheckpoint(page, checkpointId);
+    await page.locator('.vc-detail-actions').getByText('New Branch', { exact: true }).click();
+    await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+    await dialogInput(page).fill(name);
+    await armReload(page);
+    await dialogConfirm(page).click();
+    // branch create switches to the new branch via the delayed reload
+    await waitReload(page);
+    return page.evaluate(() => window.editor.api.globals.branchId);
+};
+
+const dialogConfirm = (page: Page) => page.locator('.vc-dialog .pcui-button.confirm');
+const dialogInput = (page: Page) => page.locator('.vc-dialog input');
+const toggleDialogCheck = (page: Page, label: string) => {
+    return page.locator('.vc-dialog-check').filter({ hasText: label }).locator('.pcui-boolean-input').click();
+};
+
+/** create a checkpoint via the inline composer and confirm it lands in history */
+const createCheckpoint = async (page: Page, description: string) => {
+    await page.locator('.vc-top-actions').getByText('Checkpoint', { exact: true }).click();
+    const textarea = page.locator('.vc-checkpoint-form textarea');
+    await textarea.waitFor({ state: 'visible' });
+    // pcui's keyChange input re-gates the Create button on keyup, which fill()
+    // does not emit; type the value so the button enables
+    await textarea.click();
+    await textarea.pressSequentially(description);
+    await page.locator('.vc-create-checkpoint').click();
+    // the new row lands in History via messenger; switch tabs to confirm it
+    await page.locator('.vc-tab').filter({ hasText: /^History$/ }).click();
+    await page.locator('.vc-history').getByText(description, { exact: true }).waitFor({ state: 'visible' });
+};
+
 test.describe('branch/checkpoint/diff/merge', () => {
     const projectName = uniqueName('ui-vc');
     let projectId: number;
@@ -100,20 +197,9 @@ test.describe('branch/checkpoint/diff/merge', () => {
 
     test('create red branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
-
-            // create red branch
-            await page.locator(`#checkpoint-${mainCheckpointId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('.pcui-menu-item').filter({ hasText: /^New Branch$/ }).first().click();
-            await page.getByRole('textbox').nth(3).fill('red');
-            await page.getByText('Create New Branch').click();
-
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
-            redBranchId = await page.evaluate(() => window.editor.api.globals.branchId);
+            // open version control and branch from the base checkpoint of main
+            await openVc(page);
+            redBranchId = await createBranchFromCheckpoint(page, mainCheckpointId, 'red');
 
             // set material color RED
             await page.evaluate(async (materialId) => {
@@ -121,33 +207,22 @@ test.describe('branch/checkpoint/diff/merge', () => {
                 material.set('data.diffuse', [1, 0, 0]);
             }, materialId);
 
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).first().click();
-
             // create checkpoint
-            await page.getByText('Checkpoint', { exact: true }).click();
-            await page.getByRole('textbox').nth(3).fill('RED');
-            await page.getByText('Create Checkpoint', { exact: true }).click();
-            await page.getByText('RED', { exact: true }).waitFor({ state: 'visible' });
+            await openVc(page);
+            await createCheckpoint(page, 'RED');
         })).toStrictEqual([]);
     });
 
     test('create green branch', async () => {
         expect(await capture('editor', page, async () => {
-            // select main branch
-            await page.getByText('main', { exact: true }).click();
+            // open version control (currently on the red branch)
+            await openVc(page);
 
-            // create green branch
-            await page.locator(`#checkpoint-${mainCheckpointId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('.pcui-menu-item').filter({ hasText: /^New Branch$/ }).first().click();
-            await page.getByRole('textbox').nth(3).fill('green');
-            await page.getByText('Create New Branch').click();
-
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
-            greenBranchId = await page.evaluate(() => window.editor.api.globals.branchId);
+            // view main and branch green from its base checkpoint too
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            await page.locator(`#branch-${mainBranchId} .name`).click();
+            greenBranchId = await createBranchFromCheckpoint(page, mainCheckpointId, 'green');
 
             // set material color GREEN
             await page.evaluate(async (materialId) => {
@@ -155,15 +230,9 @@ test.describe('branch/checkpoint/diff/merge', () => {
                 material.set('data.diffuse', [0, 1, 0]);
             }, materialId);
 
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).first().click();
-
             // create checkpoint
-            await page.getByText('Checkpoint', { exact: true }).click();
-            await page.getByRole('textbox').nth(3).fill('GREEN');
-            await page.getByText('Create Checkpoint', { exact: true }).click();
-            await page.getByText('GREEN', { exact: true }).waitFor({ state: 'visible' });
+            await openVc(page);
+            await createCheckpoint(page, 'GREEN');
 
             // capture green checkpoint id
             greenCheckpointId = await page.evaluate(async () => {
@@ -178,67 +247,70 @@ test.describe('branch/checkpoint/diff/merge', () => {
 
     test('diff between green and main branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).first().click();
+            // open version control (currently on the green branch)
+            await openVc(page);
 
-            // click view diff
-            await page.locator('.branch-actions').getByText('View Diff').click();
+            // enter compare mode and pick the green checkpoint (slot A)
+            await page.locator('.vc-top-actions').getByText('Compare', { exact: true }).click();
+            await page.locator(`#checkpoint-${greenCheckpointId}`).click();
 
-            // select green checkpoint (left) via diff-mode checkbox
-            await page.locator(`#checkpoint-${greenCheckpointId} .ui-checkbox.tick`).click();
-
-            // switch to main branch and wait for its checkpoints to load
-            await page.getByText('main', { exact: true }).click();
+            // view main and pick its base checkpoint (slot B)
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            await page.locator(`#branch-${mainBranchId} .name`).click();
             await page.locator(`#checkpoint-${mainCheckpointId}`).waitFor({ state: 'visible' });
-
-            // select main checkpoint (right) via diff-mode checkbox
-            await page.locator(`#checkpoint-${mainCheckpointId} .ui-checkbox.tick`).click();
+            await page.locator(`#checkpoint-${mainCheckpointId}`).click();
 
             // compare
-            await page.locator('.pcui-button.compare:not(.pcui-disabled)').click();
+            await page.locator('.vc-compare-bar .pcui-button:not(.pcui-disabled)').click();
 
-            // wait for diff to load
-            await page.waitForSelector('.picker-conflict-manager.diff');
+            // wait for the diff overlay to load
+            await page.locator('.vc-diff-overlay').waitFor({ state: 'visible' });
+            await page.locator('.vc-diff-sidebar .vc-diff-row').first().waitFor({ state: 'visible' });
 
             // close diff viewer
-            await page.locator('.picker-conflict-manager .close').click();
+            await page.locator('.vc-diff-close').click();
+            await page.locator('.vc-diff-overlay').waitFor({ state: 'hidden' });
         })).toStrictEqual([]);
     });
 
     test('switch to main branch', async () => {
         expect(await capture('editor', page, async () => {
-            // select main branch and open its dropdown
-            await page.locator(`#branch-${mainBranchId}`).click();
-            await page.locator(`#branch-${mainBranchId}`).locator('.pcui-button.dropdown').click();
-            await page.getByText('Switch To This Branch').click();
+            // open version control (currently on the green branch)
+            await openVc(page);
 
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
+            // switch to main via the branch row action
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            const mainRow = page.locator(`#branch-${mainBranchId}`);
+            await mainRow.waitFor({ state: 'visible' });
+            await mainRow.hover();
+            await armReload(page);
+            await mainRow.locator('.switch').click();
+
+            // wait for the editor to reload onto main
+            await waitReload(page);
         })).toStrictEqual([]);
     });
 
     test('merge red branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // start merge
-            await page.locator('li').filter({ hasText: redBranchId }).locator('.pcui-button.dropdown').click();
-            await page.getByText('Merge Into Current Branch').click();
+            // start merge of red into main
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            await branchMenuAction(page, redBranchId, /^Merge Into Current Branch$/);
 
-            // uncheck checkpoint create
-            await page.locator('.merge-branches .version-control-side-panel-box:last-child .checkpoint-checkbox .tick').click();
+            // skip pre-merge checkpoints and close the source branch after merging
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await toggleDialogCheck(page, 'Take a checkpoint of red');
+            await toggleDialogCheck(page, 'Take a checkpoint of main');
+            await toggleDialogCheck(page, 'Close red after merging');
+            await dialogConfirm(page).click();
 
-            // check close branch
-            await page.locator('.merge-branches .checkpoint-checkbox').filter({ hasText: 'Close branch' }).locator('.tick').click();
-
-            // create merge
-            await page.getByText('START MERGE').click();
-
-            // apply merge
+            // clean merge -> goes straight to the apply view
             await page.waitForSelector([
                 '.picker-conflict-manager.diff',
                 '.content',
@@ -248,31 +320,31 @@ test.describe('branch/checkpoint/diff/merge', () => {
                 '.content',
                 '.confirm:not(.hidden)'
             ].join(' > '));
+            await armReload(page);
             await page.getByText('COMPLETE MERGE').click();
 
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
+            // wait for the editor to reload
+            await waitReload(page);
         })).toStrictEqual([]);
     });
 
     test('merge green branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // start merge
-            await page.locator('li').filter({ hasText: greenBranchId }).locator('.pcui-button.dropdown').click();
-            await page.getByText('Merge Into Current Branch').click();
+            // start merge of green into main
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            await branchMenuAction(page, greenBranchId, /^Merge Into Current Branch$/);
 
-            // uncheck checkpoint create
-            await page.locator('.merge-branches .version-control-side-panel-box:last-child .checkpoint-checkbox .tick').click();
+            // skip pre-merge checkpoints
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await toggleDialogCheck(page, 'Take a checkpoint of green');
+            await toggleDialogCheck(page, 'Take a checkpoint of main');
+            await dialogConfirm(page).click();
 
-            // create merge
-            await page.getByText('START MERGE').click();
-
-            // review conflicts
+            // review conflicts (material color conflicts with the merged red change)
             await page.waitForSelector([
                 '.picker-conflict-manager',
                 '.content',
@@ -308,100 +380,93 @@ test.describe('branch/checkpoint/diff/merge', () => {
                 '.content',
                 '.confirm:not(.hidden)'
             ].join(' > '));
+            await armReload(page);
             await page.getByText('COMPLETE MERGE').click();
 
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
+            // wait for the editor to reload
+            await waitReload(page);
         })).toStrictEqual([]);
     });
 
     test('restore checkpoint', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // start restore checkpoint
-            await page.locator(`#checkpoint-${mainCheckpointId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('.pcui-menu-item').filter({ hasText: /^Restore$/ }).first().click();
+            // start restore of the base checkpoint
+            await selectCheckpoint(page, mainCheckpointId);
+            await page.locator('.vc-detail-actions').getByText('Restore', { exact: true }).click();
 
-            // uncheck checkpoint create
-            await page.locator('.restore-checkpoint .checkpoint-checkbox .tick').click();
+            // skip the pre-restore checkpoint and restore
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await toggleDialogCheck(page, 'Take a checkpoint of the current state first');
+            await armReload(page);
+            await dialogConfirm(page).click();
 
-            // restore checkpoint
-            await page.getByText('Restore Checkpoint', { exact: true }).click();
-
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
+            // wait for the editor to reload
+            await waitReload(page);
         })).toStrictEqual([]);
     });
 
     test('hard reset checkpoint', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // start hard reset
-            await page.locator(`#checkpoint-${mainCheckpointId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('.pcui-menu-item').filter({ hasText: /^Hard Reset$/ }).first().click();
+            // start hard reset of the base checkpoint
+            await selectCheckpoint(page, mainCheckpointId);
+            await page.locator('.vc-detail-actions').getByText('Hard Reset', { exact: false }).click();
 
-            // confirm hard reset
-            await page.locator('div').filter({ hasText: /^ARE YOU SURE\?Type "hard reset" to confirm$/ })
-            .getByRole('textbox').fill('hard reset');
+            // confirm by typing the checkpoint id (first 7 chars), then hard reset
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await dialogInput(page).fill(mainCheckpointId.substring(0, 7));
+            await armReload(page);
+            await dialogConfirm(page).click();
 
-            // hard reset
-            await page.getByText('Hard Reset To Checkpoint', { exact: true }).click();
-
-            // wait for page to reload
-            await wait(5000);
-            await page.waitForLoadState('networkidle');
+            // wait for the editor to reload
+            await waitReload(page);
         })).toStrictEqual([]);
     });
 
     test('delete red branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // change filter to closed branches
-            await page.locator('.pcui-select-input-value').filter({ hasText: 'Favorite Branches' }).click();
-            await page.getByText('Closed Branches').click();
+            // red was closed during merge -> find it under the Closed filter
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Closed');
+            await branchMenuAction(page, redBranchId, /^Delete This Branch$/);
 
-            // start delete red branch
-            await page.locator(`#branch-${redBranchId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('div').filter({ hasText: 'Delete This Branch' }).nth(4).click();
+            // confirm by typing the branch name, then delete
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await dialogInput(page).fill('red');
+            await dialogConfirm(page).click();
 
-            // confirm delete
-            await page.getByRole('textbox').nth(3).fill('red');
-
-            // delete branch
-            await page.getByText('Delete Branch', { exact: true }).click();
-
-            // reload page
-            // FIXME: branch list currently not updated on delete
-            await page.reload({ waitUntil: 'networkidle' });
+            // branch delete updates the list in place (no reload); let the job settle
+            await page.locator('.vc-dialog').waitFor({ state: 'hidden' });
+            await wait(2000);
         })).toStrictEqual([]);
     });
 
     test('delete green branch', async () => {
         expect(await capture('editor', page, async () => {
-            // open version control dialog
-            await page.locator('.pcui-element.font-regular.logo').click();
-            await page.locator('span').filter({ hasText: /^Version Control$/ }).click();
+            // open version control (currently on the main branch)
+            await openVc(page);
 
-            // start delete green branch
-            await page.locator(`#branch-${greenBranchId}`).locator('.pcui-button.dropdown').click();
-            await page.locator('div').filter({ hasText: 'Delete This Branch' }).nth(4).click();
+            // green is still open -> find it under the Open filter
+            await openSwitcher(page);
+            await setBranchFilter(page, 'Open');
+            await branchMenuAction(page, greenBranchId, /^Delete This Branch$/);
 
-            // confirm delete
-            await page.getByRole('textbox').nth(3).fill('green');
+            // confirm by typing the branch name, then delete
+            await page.locator('.vc-dialog').waitFor({ state: 'visible' });
+            await dialogInput(page).fill('green');
+            await dialogConfirm(page).click();
 
-            // delete branch
-            await page.getByText('Delete Branch', { exact: true }).click();
+            // branch delete updates the list in place (no reload); let the job settle
+            await page.locator('.vc-dialog').waitFor({ state: 'hidden' });
+            await wait(2000);
         })).toStrictEqual([]);
     });
 });


### PR DESCRIPTION
## Summary

The version control UI was rewritten (#2098 / #2099 / #2100) into a branch switcher, Changes/History tabs, a detail pane, an inline checkpoint composer, compare-mode + a dedicated `.vc-diff-overlay` diff viewer, and `vc-dialog` dialogs. The existing `test-suite/test/ui/version-control.test.ts` targeted the old DOM (`.branch-actions`, `.picker-conflict-manager.diff`, `.merge-branches`, `.checkpoint-checkbox`, `.pcui-button.compare`, …) and no longer matched, so its locators timed out.

This reworks the UI suite to drive the new picker:

| Flow | New interaction |
|------|-----------------|
| New branch | select checkpoint → detail pane **New Branch** → `vc-dialog` → **Create Branch** |
| Create checkpoint | top **Checkpoint** → inline composer → `.vc-create-checkpoint`, verified in the History tab |
| Branch diff | **Compare** mode → row checkboxes → compare bar → `.vc-diff-overlay` → `.vc-diff-close` |
| Switch branch | branch switcher → row **Switch** action |
| Merge / Delete | branch switcher kebab → **Merge Into Current Branch** / **Delete This Branch** |
| Restore / Hard reset | detail pane buttons; hard reset now confirms by typing the checkpoint id (first 7 chars) |

Branch ops set the switcher filter (default is **Favorites**) to find non-current branches. Merge conflict resolution still routes through the unchanged legacy `picker-conflict-manager`, so those selector chains and button texts are preserved verbatim.

## Verification

- `eslint` clean
- `tsc -p tsconfig.json` reports no errors for this file
- Adding the `run: test-suite` label to exercise the live suite