### PR TITLE
feat(pickers): fullscreen toggle for project and diff pickers

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -2474,15 +2474,17 @@ strong {
     > .pcui-overlay-content {
         @extend .font-regular;
 
-        width: 100%;
-        max-width: 1060px;
-        height: 100%;
-        flex-shrink: 0;
+        // absolutely centred (rather than flex-centred) so width/height/position
+        // can be tweened when toggling fullscreen; the small-picker box is
+        // 1060x600, overridden below 1060px and in fullscreen
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 1060px;
+        height: 600px;
         border: 1px solid $border-primary;
-
-        @media (min-width: 1060px) {
-            height: 600px;
-        }
+        transform: translate(-50%, -50%);
+        transition: width 200ms ease, height 200ms ease, transform 200ms ease;
 
         .pcui-container.project {
             height: 100%;
@@ -2749,6 +2751,74 @@ strong {
                             box-shadow: none;
                         }
                     }
+
+                    .fullscreen-toggle {
+                        position: absolute;
+                        top: 0;
+                        right: 30px;
+                        width: 28px;
+                        padding: 0;
+                        color: $text-secondary;
+                        background-color: transparent;
+                        border-color: transparent;
+
+                        // windows-style maximise square; morphs into the restore
+                        // glyph (two squares) when fullscreen is on
+                        &::before {
+                            content: '';
+                            position: absolute;
+                            top: 50%;
+                            left: 50%;
+                            box-sizing: border-box;
+                            width: 11px;
+                            height: 10px;
+                            border: 1.5px solid currentcolor;
+                            border-radius: 1px;
+                            transform: translate(-50%, -50%);
+                            transition: width 200ms ease, height 200ms ease, transform 200ms ease;
+                        }
+
+                        // back square of the restore glyph — fades/scales in when active
+                        &::after {
+                            content: '';
+                            position: absolute;
+                            top: 50%;
+                            left: 50%;
+                            box-sizing: border-box;
+                            width: 9px;
+                            height: 9px;
+                            border-top: 1.5px solid currentcolor;
+                            border-right: 1.5px solid currentcolor;
+                            border-radius: 1px;
+                            opacity: 0;
+                            transform: translate(-38%, -62%) scale(0.6);
+                            transition: opacity 200ms ease, transform 200ms ease;
+                        }
+
+                        &:hover,
+                        &:focus {
+                            color: $text-primary;
+                            background-color: transparent;
+                            box-shadow: none;
+                        }
+
+                        &.active {
+                            color: $text-active;
+
+                            // front square nudged down-left
+                            &::before {
+                                width: 9px;
+                                height: 9px;
+                                transform: translate(-62%, -38%);
+                            }
+
+                            // back square peeking up-right (top + right edges only)
+                            &::after {
+                                opacity: 1;
+                                transform: translate(-38%, -62%) scale(1);
+                            }
+                        }
+                    }
                 }
 
                 > .pcui-panel-content {
@@ -2761,6 +2831,30 @@ strong {
                     }
                 }
             }
+        }
+    }
+
+    // fullscreen: fill the viewport to the right of the 40px left toolbar (z-index
+    // 400 > this overlay's 300, so the toolbar would otherwise be painted over).
+    // explicit width/height + a 20px centre shift keep it tweenable from the
+    // small-picker box; net span is [40px, right edge] x [top, bottom]
+    &.fullscreen > .pcui-overlay-content {
+        width: calc(100% - 40px);
+        height: 100%;
+        transform: translate(calc(-50% + 20px), -50%);
+    }
+
+    // below the small-picker breakpoint the picker is force-fullscreen, so apply
+    // the same toolbar offset and hide the manual toggle (can't shrink further)
+    @media (max-width: 1059px) {
+        > .pcui-overlay-content {
+            width: calc(100% - 40px);
+            height: 100%;
+            transform: translate(calc(-50% + 20px), -50%);
+        }
+
+        .fullscreen-toggle {
+            display: none;
         }
     }
 }

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -8,12 +8,39 @@ $vc-add-edge: #3fb950;
 .vc-diff-overlay {
     z-index: 300;
 
+    // absolutely centred small box (1060x600) that tweens to fullscreen; mirrors
+    // .pcui-overlay.picker-project
     > .pcui-overlay-content {
         position: absolute;
-
-        // sit right of the 40px left toolbar (#layout-root grid column) instead of underlapping it
-        inset: 0 0 0 40px;
+        left: 50%;
+        top: 50%;
+        width: 1060px;
+        height: 600px;
         display: flex;
+        transform: translate(-50%, -50%);
+        transition: width 200ms ease, height 200ms ease, transform 200ms ease;
+    }
+
+    // fullscreen: fill the viewport to the right of the 40px left toolbar
+    // (#layout-root grid column) instead of underlapping it; net span is
+    // [40px, right edge] x [top, bottom]
+    &.fullscreen > .pcui-overlay-content {
+        width: calc(100% - 40px);
+        height: 100%;
+        transform: translate(calc(-50% + 20px), -50%);
+    }
+
+    // below the small-picker breakpoint: force fullscreen and hide the toggle
+    @media (max-width: 1059px) {
+        > .pcui-overlay-content {
+            width: calc(100% - 40px);
+            height: 100%;
+            transform: translate(calc(-50% + 20px), -50%);
+        }
+
+        .vc-diff-fullscreen-toggle {
+            display: none;
+        }
     }
 }
 
@@ -51,9 +78,74 @@ $vc-add-edge: #3fb950;
         font-size: 11px;
     }
 
-    > .vc-diff-close {
-        // reset PCUI's default 6px margin so the header padding alone sets the corner gap; auto-left keeps it pushed right
+    // fullscreen toggle — windows-style maximise/restore icon, mirrors the
+    // project picker's .fullscreen-toggle; auto-left pushes it + the close right
+    > .vc-diff-fullscreen-toggle {
+        position: relative;
         margin: 0 0 0 auto;
+        width: 28px;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        color: $text-secondary;
+
+        &:hover {
+            border: 0;
+            box-shadow: none;
+            color: $text-primary;
+        }
+
+        // maximise square; morphs into the restore glyph (two squares) when active
+        &::before {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            box-sizing: border-box;
+            width: 11px;
+            height: 10px;
+            border: 1.5px solid currentcolor;
+            border-radius: 1px;
+            transform: translate(-50%, -50%);
+            transition: width 200ms ease, height 200ms ease, transform 200ms ease;
+        }
+
+        // back square of the restore glyph — fades/scales in when active
+        &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            box-sizing: border-box;
+            width: 9px;
+            height: 9px;
+            border-top: 1.5px solid currentcolor;
+            border-right: 1.5px solid currentcolor;
+            border-radius: 1px;
+            opacity: 0;
+            transform: translate(-38%, -62%) scale(0.6);
+            transition: opacity 200ms ease, transform 200ms ease;
+        }
+
+        &.active {
+            color: $text-active;
+
+            &::before {
+                width: 9px;
+                height: 9px;
+                transform: translate(-62%, -38%);
+            }
+
+            &::after {
+                opacity: 1;
+                transform: translate(-38%, -62%) scale(1);
+            }
+        }
+    }
+
+    > .vc-diff-close {
+        // header padding alone sets the corner gap (the toggle carries the auto-left)
+        margin: 0;
         background: transparent;
         border: 0;
 

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -311,7 +311,12 @@ $vc-add-edge: #3fb950;
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 12px 16px;
+    padding: 10px 14px;
+
+    // match the editor inspector's field sizing: the attributes panel overrides
+    // to 12px, but this overlay sits outside it and otherwise inherits body's
+    // 14px, rendering every label/value/json oversized
+    font-size: 12px;
 
     &.has-frame {
         display: flex;
@@ -437,6 +442,11 @@ $vc-add-edge: #3fb950;
         margin-bottom: 6px;
         pointer-events: none;
 
+        // keep the breadcrumb tree at the hierarchy panel's size (body 14px): the
+        // pcui treeview dot/spine alignment is calibrated for it, so inheriting the
+        // .vc-diff-detail 12px decentres the dots
+        font-size: 14px;
+
         // the root's own spine is the leftmost vertical and never connects to
         // anything (each child draws its own spine + elbow), so collapse it in
         // every case. top: only relocates the stub; height: 0 removes it.
@@ -487,8 +497,8 @@ $vc-add-edge: #3fb950;
     display: flex;
     align-items: center;
     gap: 8px;
-    min-height: 32px;
-    padding: 3px 10px 3px 6px;
+    min-height: 28px;
+    padding: 2px 10px 2px 6px;
 
     // a tall multi-item list pins the gutter + field name to the top (with a
     // little breathing room) instead of floating them in the centre; single

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -18,6 +18,7 @@ editor.once('load', () => {
 
     const IS_EMPTY_STATE = !config.project.id;
     const EMPTY_THUMBNAIL_IMAGE = 'url(\'/static/platform/images/home/blank_project.png\')';
+    const FULLSCREEN_KEY = 'editor:picker:project:fullscreen';
 
     // UI
 
@@ -504,6 +505,27 @@ editor.once('load', () => {
         }
     });
     rightPanel.header.append(btnClose);
+
+    // fullscreen toggle — expands the picker to fill the viewport (right of the
+    // 40px left toolbar) even when the window is large enough for the small
+    // centered picker; hidden by css below the 1060px breakpoint where the
+    // picker is force-fullscreen anyway
+    let fullscreen = editor.call('localStorage:get', FULLSCREEN_KEY) === true;
+    const btnFullscreen = new Button({
+        class: 'fullscreen-toggle'
+    });
+    const applyFullscreen = () => {
+        overlay.class[fullscreen ? 'add' : 'remove']('fullscreen');
+        btnFullscreen.class[fullscreen ? 'add' : 'remove']('active');
+        btnFullscreen.dom.setAttribute('title', fullscreen ? 'Exit fullscreen' : 'Fullscreen');
+    };
+    btnFullscreen.on('click', () => {
+        fullscreen = !fullscreen;
+        editor.call('localStorage:set', FULLSCREEN_KEY, fullscreen);
+        applyFullscreen();
+    });
+    rightPanel.header.append(btnFullscreen);
+    applyFullscreen();
 
     // LOCAL UTILS
 

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -21,6 +21,9 @@ import {
 
 const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
 const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
+// own key — this overlay stacks on top of .pcui-overlay.picker-project, which uses
+// 'editor:picker:project:fullscreen'. defaults to the small box (matching the project picker)
+const FULLSCREEN_KEY = 'editor:picker:vcdiff:fullscreen';
 
 // entity-level template-instance fields get their own (collapsed) panel rather
 // than sitting among the entity's regular values; values are shown friendlier
@@ -60,11 +63,28 @@ editor.once('load', () => {
     meta.classList.add('vc-diff-meta');
     top.dom.appendChild(meta);
 
+    // fullscreen toggle — mirrors the project picker; persisted under its own key
+    let fullscreen = editor.call('localStorage:get', FULLSCREEN_KEY) === true;
+    const fullscreenToggle = new Button({ class: 'vc-diff-fullscreen-toggle' });
+    const applyFullscreen = () => {
+        overlay.class[fullscreen ? 'add' : 'remove']('fullscreen');
+        fullscreenToggle.class[fullscreen ? 'add' : 'remove']('active');
+        fullscreenToggle.dom.setAttribute('title', fullscreen ? 'Exit fullscreen' : 'Fullscreen');
+    };
+    fullscreenToggle.on('click', () => {
+        fullscreen = !fullscreen;
+        editor.call('localStorage:set', FULLSCREEN_KEY, fullscreen);
+        applyFullscreen();
+    });
+    top.append(fullscreenToggle);
+
     const close = new Button({ icon: 'E132', class: 'vc-diff-close' });
     close.on('click', () => {
         overlay.hidden = true;
     });
     top.append(close);
+
+    applyFullscreen();
 
     const body = new Container({ class: 'vc-diff-body' });
     shell.append(body);


### PR DESCRIPTION
## Summary

Adds a fullscreen toggle to the project/builds picker and the version-control diff picker, and aligns the diff's rendered-field sizing with the editor inspector.

- **Fullscreen toggle** — a Windows-style maximise/restore button (left of the close button) lets users switch the picker between a centred small box and a fullscreen view that sits right of the 40px left toolbar (so the toolbar is no longer painted over it). The choice persists in `localStorage` under separate keys per picker (`editor:picker:project:fullscreen`, `editor:picker:vcdiff:fullscreen`), since the diff overlay stacks on top of the project picker.
- **Animation** — toggling tweens the panel's size/position (200ms) and morphs the icon (maximise square ↔ restore double-square).
- **Defaults** — project picker opens to the small box; diff picker also defaults to the small box. Below 1060px both are force-fullscreen and the toggle is hidden.
- **Diff field sizing** — the diff overlay sits outside the attributes panel, so its rendered content was inheriting `body`'s 14px instead of the inspector's 12px, rendering labels/values/JSON oversized. Set the rendered-diff container to 12px and tightened field rows to the inspector's input pitch. The breadcrumb entity tree stays at 14px so the pcui treeview dots stay centred on their spines.

## Files

- `src/editor/pickers/picker-project.ts` — toggle button + persistence
- `src/editor/pickers/version-control/picker-version-control-diff.ts` — toggle button + persistence
- `sass/editor/_editor-main.scss` — project picker fullscreen tween, toolbar offset, Windows icon
- `sass/editor/_editor-version-control-diff.scss` — diff picker fullscreen tween, Windows icon, field sizing

## Test plan

- [x] **Project/builds picker** (window ≥1060px): toggle expands to fullscreen (flush right, toolbar visible) and back; size + icon animate; choice persists across reopen.
- [x] **Window <1060px**: picker is force-fullscreen, toggle hidden, toolbar not overlapped.
- [x] **Diff picker**: defaults to the small centred box; toggle works independently of the project picker's state; rendered fields match the inspector's size; treeview dots are centred.
- [x] `npm run lint` passes.