### PR TITLE
fix(pickers): scale version control panes to fullscreen

### DIFF
--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -518,6 +518,8 @@ editor.once('load', () => {
         overlay.class[fullscreen ? 'add' : 'remove']('fullscreen');
         btnFullscreen.class[fullscreen ? 'add' : 'remove']('active');
         btnFullscreen.dom.setAttribute('title', fullscreen ? 'Exit fullscreen' : 'Fullscreen');
+        // let hosted panels (e.g. version control) resize their panes to the larger viewport
+        editor.emit('picker:project:fullscreen', fullscreen);
     };
     btnFullscreen.on('click', () => {
         fullscreen = !fullscreen;
@@ -526,6 +528,9 @@ editor.once('load', () => {
     });
     rightPanel.header.append(btnFullscreen);
     applyFullscreen();
+
+    // hosted panels read the current state on show (this picker loads before them)
+    editor.method('picker:project:isFullscreen', () => fullscreen);
 
     // LOCAL UTILS
 

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -13,6 +13,9 @@ const COMPOSER_KEY = 'editor:vc:composer:height';
 const COMPOSER_DEFAULT_H = 160;
 const COMPOSER_MIN_H = 140;
 const COMPOSER_MAX_H = 420;
+// fullscreen lifts the composer cap to the viewport height minus the picker chrome
+// (project header 33 + tabs 38) and a minimum changes-list height it must not eat into
+const COMPOSER_FULL_RESERVE = 33 + 38 + 160;
 
 export const createChangesPanel = () => {
     const sidebar = new Container({ class: 'vc-changes' });
@@ -477,6 +480,17 @@ export const createChangesPanel = () => {
         },
         focusForm: () => {
             setTimeout(() => description.focus());
+        },
+        // raise the resize cap to the viewport in fullscreen so the composer can grow;
+        // clamp the persisted height back into the small-box cap when restored
+        setComposerMax: (full: boolean) => {
+            const max = full ? Math.max(COMPOSER_MAX_H, window.innerHeight - COMPOSER_FULL_RESERVE) : COMPOSER_MAX_H;
+            form.resizeMax = max;
+            const h = editor.call('localStorage:get', COMPOSER_KEY) || COMPOSER_DEFAULT_H;
+            if (h > max) {
+                form.height = max;
+                editor.call('localStorage:set', COMPOSER_KEY, max);
+            }
         }
     });
     // Object.assign snapshots getter values; live getters must be defined directly
@@ -496,6 +510,7 @@ export const createChangesPanel = () => {
             resetForm: () => void;
             setBusy: (on: boolean) => void;
             focusForm: () => void;
+            setComposerMax: (full: boolean) => void;
             count: number | null;
         },
         summary

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -11,6 +11,16 @@ import { createDetailPanel } from './panel-detail';
 import { createHistoryPanel } from './panel-history';
 import { checkpointCreate as checkpointCreateJob, diffCreate } from '../../messenger/jobs';
 
+// sidebar width bounds — these caps suit the small 1060px box; fullscreen lifts the
+// max (derived from the viewport so the main pane keeps room), reverting clamps back
+const SIDEBAR_KEY = 'editor:vc:sidebar:width';
+const SIDEBAR_DEFAULT_W = 300;
+const SIDEBAR_MIN_W = 260;
+const SIDEBAR_MAX_W = 720;
+// fullscreen fills the viewport right of the 40px left toolbar; keep at least this for main
+const VC_MAIN_MIN_W = 480;
+const FULLSCREEN_TOOLBAR_W = 40;
+
 editor.once('load', () => {
     if (config.project.settings.useLegacyScripts) {
         return;
@@ -90,13 +100,13 @@ editor.once('load', () => {
 
     const sidebar = new Container({
         class: 'vc-sidebar',
-        width: editor.call('localStorage:get', 'editor:vc:sidebar:width') || 300,
+        width: editor.call('localStorage:get', SIDEBAR_KEY) || SIDEBAR_DEFAULT_W,
         resizable: 'right',
-        resizeMin: 260,
-        resizeMax: 720
+        resizeMin: SIDEBAR_MIN_W,
+        resizeMax: SIDEBAR_MAX_W
     });
     sidebar.on('resize', () => {
-        editor.call('localStorage:set', 'editor:vc:sidebar:width', sidebar.width);
+        editor.call('localStorage:set', SIDEBAR_KEY, sidebar.width);
     });
     body.append(sidebar);
 
@@ -143,6 +153,21 @@ editor.once('load', () => {
     tabContent.append(history);
     main.append(changes.summary);
     main.append(detail);
+
+    // the picker can toggle fullscreen (picker-project); lift the sidebar + composer
+    // resize caps to the wider viewport while fullscreen, and clamp any oversized pane
+    // back into the small box when restored. driven by inline width/height, so the
+    // persisted value is the source of truth for clamping (the live getter reads 0 when hidden)
+    const applyResizeBounds = (full: boolean) => {
+        const sidebarMax = full ? Math.max(SIDEBAR_MAX_W, window.innerWidth - FULLSCREEN_TOOLBAR_W - VC_MAIN_MIN_W) : SIDEBAR_MAX_W;
+        sidebar.resizeMax = sidebarMax;
+        const w = editor.call('localStorage:get', SIDEBAR_KEY) || SIDEBAR_DEFAULT_W;
+        if (w > sidebarMax) {
+            sidebar.width = sidebarMax;
+            editor.call('localStorage:set', SIDEBAR_KEY, sidebarMax);
+        }
+        changes.sidebar.setComposerMax(full);
+    };
 
     // compare bar
     const compareBar = new Container({ class: 'vc-compare-bar', hidden: true });
@@ -738,6 +763,10 @@ editor.once('load', () => {
     // ---- messenger list maintenance ----
     panel.on('show', () => {
         setViewedBranch(config.self.branch);
+        // size the panes for the current fullscreen state (picker-project is loaded by
+        // now) and track live toggles; the subscription is dropped with events on hide
+        applyResizeBounds(editor.call('picker:project:isFullscreen') === true);
+        events.push(editor.on('picker:project:fullscreen', applyResizeBounds));
         changes.sidebar.invalidate();
         setCompareMode(false);
         setTab(showNewCheckpointOnLoad ? 'changes' : 'history');


### PR DESCRIPTION
## Problem

The fullscreen toggle added in #2111 expands the project picker, but the **version-control picker** hosted inside it keeps the resize caps that were tuned for the small 1060×600 box — and nothing tells it the mode changed:

- **Sidebar** (`vc-sidebar`) caps at `720px`
- **Checkpoint composer** (`vc-checkpoint-form`) caps at `420px`

So in fullscreen you can't size either pane to match the larger viewport.

## Fix

- **`picker-project.ts`** emits `picker:project:fullscreen` on toggle and exposes `picker:project:isFullscreen` (it loads before the VC picker, so the getter is safe to read on show).
- **`picker-version-control.ts`** reads the state on show and subscribes to live toggles (auto-unbound via the existing `events` drain on hide). `applyResizeBounds` lifts the sidebar cap to `innerWidth − 40 − 480` in fullscreen, clamping back into `720` on restore.
- **`panel-changes.ts`** `setComposerMax` lifts the composer cap to `innerHeight − chrome` in fullscreen, clamping back into `420` on restore.

Caps scale **only in fullscreen**; reverting to the small box clamps any oversized pane back down (avoids the shrink-to-small overflow). Defaults are unchanged (300px / 160px). Clamping reads the persisted localStorage value rather than the live getter, which reads `0` while the pane is hidden behind another tab.

## Testing

- ESLint clean on all 3 files; `type:check` introduces no new errors (the pre-existing ones in `picker-project.ts` are loose-typing issues present on `main`).
- Manual: open the Version Control tab, toggle fullscreen, drag the sidebar/composer wider, then restore and confirm both snap back into the small box.