### PR TITLE
feat(version-control): diff picker sidebar filter, themed chrome & draggable divider

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -2725,6 +2725,9 @@ strong {
                 min-width: 0;
 
                 > .pcui-panel-header {
+                    // fixed height matching the reserved body offset (calc(100% - 33px))
+                    // so it lines up exactly with the diff picker's .vc-diff-top (also 33px)
+                    height: 33px;
                     border-bottom: 1px solid $border-primary;
 
                     .pcui-panel-header-title {
@@ -2738,11 +2741,12 @@ strong {
 
                         font-size: 14px;
                         position: absolute;
-                        top: 0;
+                        top: 50%;
                         right: 0;
                         color: $text-secondary;
                         background-color: transparent;
                         border-color: transparent;
+                        transform: translateY(-50%);
 
                         &:hover,
                         &:focus {
@@ -2754,13 +2758,14 @@ strong {
 
                     .fullscreen-toggle {
                         position: absolute;
-                        top: 0;
+                        top: 50%;
                         right: 30px;
                         width: 28px;
                         padding: 0;
                         color: $text-secondary;
                         background-color: transparent;
                         border-color: transparent;
+                        transform: translateY(-50%);
 
                         // windows-style maximise square; morphs into the restore
                         // glyph (two squares) when fullscreen is on

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -57,13 +57,12 @@ $vc-add-edge: #3fb950;
 }
 
 .vc-diff-top {
+    position: relative;
     display: flex;
     flex: none;
     align-items: center;
     gap: 12px;
-
-    // right padding equals the close button's vertical centring gap ((33 − 28) / 2) so its corner spacing is symmetric
-    padding: 0 2.5px 0 16px;
+    padding: 0 0 0 16px;
 
     // match the picker-project panel header height (its content is offset by 33px)
     height: 33px;
@@ -82,16 +81,20 @@ $vc-add-edge: #3fb950;
         font-size: 11px;
     }
 
-    // fullscreen toggle — windows-style maximise/restore icon, mirrors the
-    // project picker's .fullscreen-toggle; auto-left pushes it + the close right
+    // fullscreen toggle — windows-style maximise/restore icon, positioned exactly
+    // like the project picker's .fullscreen-toggle (absolute, right: 30px) so the
+    // two pickers' window controls line up
     > .vc-diff-fullscreen-toggle {
-        position: relative;
-        margin: 0 0 0 auto;
+        position: absolute;
+        top: 50%;
+        right: 30px;
+        margin: 0;
         width: 28px;
         padding: 0;
         background: transparent;
         border: 0;
         color: $text-secondary;
+        transform: translateY(-50%);
 
         &:hover {
             border: 0;
@@ -148,9 +151,13 @@ $vc-add-edge: #3fb950;
     }
 
     > .vc-diff-close {
-        // negative left margin cancels the .vc-diff-top 12px flex gap so the close
-        // sits flush against the fullscreen toggle as one window-control cluster
-        margin: 0 0 0 -12px;
+        // flush to the right edge like the project picker's header close, vertically
+        // centred in the 33px bar (the 28px button would otherwise top-align)
+        position: absolute;
+        top: 50%;
+        right: 0;
+        margin: 0;
+        transform: translateY(-50%);
         background: transparent;
         border: 0;
 
@@ -473,53 +480,68 @@ $vc-add-edge: #3fb950;
             flex: 1 1 auto;
             height: 10px;
         }
+
+        // the sub line under the name, matching .vc-diff-row's 'material · 1 change'
+        &.sub {
+            order: 3;
+            flex-basis: 100%;
+            max-width: 110px;
+            height: 8px;
+            margin-top: 2px;
+        }
     }
 
-    // sidebar rows: name + status badge (no leading icon, matching .vc-diff-row)
+    // sidebar rows: name + status badge over a sub line (matching .vc-diff-row)
     > .skeleton-row {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
-        gap: 10px;
-        padding: 11px 12px;
+        gap: 4px 10px;
+        padding: 9px 12px;
         border-bottom: 1px solid $border-primary;
     }
 
     &.main {
-        padding: 12px 16px;
-
+        // header bar matches .vc-diff-detail-head; the body is padded like .vc-diff-detail
         > .skeleton-head {
             display: flex;
             align-items: center;
             gap: 10px;
-            margin-bottom: 14px;
+            padding: 10px 16px;
+            background-color: $bcg-dark;
+            border-bottom: 1px solid $border-primary;
         }
 
-        // panel: header bar over field rows, like .vc-diff-panel
-        > .skeleton-panel {
-            margin-bottom: 10px;
-            border: 1px solid $border-primary;
-            border-radius: 3px;
-            overflow: hidden;
+        > .skeleton-body {
+            padding: 10px 14px;
 
-            > .skeleton-phead {
-                padding: 10px 12px;
-                background-color: $bcg-dark;
-                border-bottom: 1px solid $border-primary;
+            // panel: header bar over field rows, like .vc-diff-detail .vc-diff-panel
+            > .skeleton-panel {
+                margin-bottom: 10px;
+                border: 1px solid rgba($border-primary, 0.6);
+                border-radius: 3px;
+                overflow: hidden;
 
-                > .bone.line {
-                    max-width: 120px;
+                > .skeleton-phead {
+                    padding: 10px 12px;
+                    background-color: $bcg-darker;
+                    border-bottom: 1px solid $border-primary;
+
+                    > .bone.line {
+                        max-width: 120px;
+                    }
                 }
-            }
 
-            > .skeleton-field {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                padding: 9px 12px;
-                border-bottom: 1px solid $border-primary;
+                > .skeleton-field {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                    padding: 9px 12px;
+                    border-bottom: 1px solid $border-primary;
 
-                &:last-child {
-                    border-bottom: none;
+                    &:last-child {
+                        border-bottom: none;
+                    }
                 }
             }
         }

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -49,7 +49,11 @@ $vc-add-edge: #3fb950;
     flex: 1;
     flex-direction: column;
     min-width: 0;
-    background-color: $bcg-darkest;
+
+    // lighter $bcg-primary base (matching the version-control picker) so panels read
+    // clearly. headers/bars sit one step darker ($bcg-dark), insets + the scrollbar
+    // track sit darkest ($bcg-darkest) — ~10+ tonal steps between every region
+    background-color: $bcg-primary;
 }
 
 .vc-diff-top {
@@ -144,8 +148,9 @@ $vc-add-edge: #3fb950;
     }
 
     > .vc-diff-close {
-        // header padding alone sets the corner gap (the toggle carries the auto-left)
-        margin: 0;
+        // negative left margin cancels the .vc-diff-top 12px flex gap so the close
+        // sits flush against the fullscreen toggle as one window-control cluster
+        margin: 0 0 0 -12px;
         background: transparent;
         border: 0;
 
@@ -170,35 +175,122 @@ $vc-add-edge: #3fb950;
 // ---- sidebar ----
 .vc-diff-sidebar {
     flex: none;
+    display: flex;
+    flex-direction: column;
     width: 280px;
-    overflow-y: auto;
-    background-color: $bcg-darker;
+    background-color: $bcg-primary;
     border-right: 1px solid $border-primary;
 
     > .vc-diff-sidebar-head {
         @extend .font-bold;
 
+        flex: none;
         padding: 10px 12px;
+        background-color: $bcg-dark;
         color: $text-primary;
         font-size: 13px;
         border-bottom: 1px solid $border-primary;
     }
 
-    > .vc-diff-group {
+    // header bar treatment matching the branch picker's .vc-branch-filter; the
+    // $bcg-dark bar sits one step darker than the $bcg-primary base, keeping regions
+    // distinct. relative + z-index lifts the open type dropdown above the sticky bars
+    > .vc-diff-filter {
+        position: relative;
+        z-index: 2;
+        flex: none;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px;
+        border-bottom: 1px solid $border-primary;
+        background-color: $bcg-dark;
+
+        > .pcui-text-input {
+            @extend .font-regular;
+
+            flex: 1 1 auto;
+            margin: 0;
+            border: 1px solid $border-primary;
+            border-radius: 4px;
+            background-color: $bcg-darkest;
+            font-size: 13px;
+
+            > input::placeholder {
+                color: $text-darkest;
+            }
+        }
+
+        // type select mirrors the picker's top-bar action buttons (.vc-top-actions
+        // .pcui-button): rounded $bcg-dark chip with a $bcg-darkest outline that lifts
+        // to primary text + shadow on hover
+        > .pcui-select-input {
+            @extend .font-bold;
+
+            flex: none;
+            width: 110px;
+            margin: 0;
+            border: 1px solid $bcg-darkest;
+            border-radius: 6px;
+            color: $text-secondary;
+            font-size: 12px;
+            box-shadow: none;
+            transition: color 100ms, box-shadow 100ms;
+
+            // pcui paints the fill (and clips corners) on the inner value box
+            .pcui-select-input-container-value {
+                border-radius: 6px;
+                background-color: $bcg-dark;
+            }
+
+            .pcui-select-input-value {
+                color: $text-secondary;
+            }
+
+            &:not(.pcui-disabled):hover,
+            &:not(.pcui-disabled):focus {
+                color: $text-primary;
+                box-shadow: $element-shadow-hover;
+            }
+        }
+    }
+
+    > .vc-diff-list {
+        flex: 1;
+        overflow-y: auto;
+    }
+
+    > .vc-diff-list > .vc-diff-no-match {
+        padding: 16px 12px;
+        color: $text-dark;
+        font-size: 12px;
+        text-align: center;
+    }
+
+    // section bars stick to the top of the scrolling list as you pass them, the way
+    // the history day headers do. the $bcg-dark bar reads as a darker band against the
+    // $bcg-primary rows; opaque so rows never bleed through when stuck
+    > .vc-diff-list > .vc-diff-group {
         @extend .font-bold;
 
-        // match the picker's section bars (.vc-group): bold + dark bar so the
-        // header reads distinctly from the $text-dark sub line below it
-        padding: 5px 12px;
-        background-color: rgb(0 0 0 / 12%);
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        padding: 6px 12px;
+        background-color: $bcg-dark;
+        border-top: 1px solid $border-primary;
         border-bottom: 1px solid $border-primary;
-        color: $text-secondary;
+        color: $text-primary;
         font-size: 10px;
         letter-spacing: 0.4px;
         text-transform: uppercase;
+
+        &:first-child {
+            border-top: none;
+        }
     }
 
-    > .vc-diff-row {
+    > .vc-diff-list > .vc-diff-row {
         @extend .font-regular;
 
         appearance: none;
@@ -218,12 +310,14 @@ $vc-add-edge: #3fb950;
         cursor: pointer;
         transition: background-color 100ms ease;
 
+        // white tints rather than the editor's #354144 — that fixed colour is
+        // invisible against the lighter $bcg-primary base, a tint reads on any tone
         &:hover {
-            background-color: #354144;
+            background-color: rgb(255 255 255 / 6%);
         }
 
         &.selected {
-            background-color: #354144;
+            background-color: rgb(255 255 255 / 10%);
             box-shadow: inset 2px 0 0 $text-active;
         }
 
@@ -275,6 +369,11 @@ $vc-add-edge: #3fb950;
     flex: 1;
     flex-direction: column;
     min-width: 0;
+
+    // shows the shell's $bcg-primary base — clearly lighter than the $bcg-darkest
+    // scrollbar track (which previously blended straight into it) and the $bcg-dark
+    // detail/section header bars
+    background-color: $bcg-primary;
 }
 
 .vc-diff-detail-head {
@@ -466,6 +565,7 @@ $vc-add-edge: #3fb950;
 }
 
 .vc-diff-panel {
+    border: 1px solid rgba($border-primary, 0.6);
     border-radius: 3px;
     overflow: hidden;
 
@@ -477,6 +577,9 @@ $vc-add-edge: #3fb950;
     // script/slot/clip sub-panels are inset like the inspector's per-script panels
     .vc-diff-subpanel.inset {
         margin: 6px;
+        border: 1px solid rgba($border-primary, 0.6);
+        border-radius: 3px;
+        overflow: hidden;
     }
 }
 
@@ -506,8 +609,16 @@ $vc-add-edge: #3fb950;
     &:has(.vc-diff-array.multi) {
         align-items: flex-start;
 
+        // breathing room under the last pill so it isn't flush to the card edge
+        padding-bottom: 8px;
+
         > .gutter,
         > .label {
+            margin-top: 6px;
+        }
+
+        // align the delta count with the label rather than jamming it at the top
+        > .value {
             margin-top: 6px;
         }
     }
@@ -674,6 +785,7 @@ $vc-add-edge: #3fb950;
     min-width: 0;
 
     > .size {
+        margin-bottom: 6px;
         color: $text-dark;
         font-size: 10px;
     }

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -787,6 +787,13 @@
             padding: 11px 12px;
             border-bottom: 1px solid $border-primary;
 
+            // the last row sits flush against the wrapping .vc-field-diff / .vc-diff-list
+            // bottom border (like .vc-field-row / .vc-item do) — drop its border to avoid
+            // doubling up while the diff is loading
+            &:last-child {
+                border-bottom: none;
+            }
+
             > .bone {
                 border-radius: 4px;
                 background-color: rgb(255 255 255 / 8%);

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -25,6 +25,15 @@ const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
 // 'editor:picker:project:fullscreen'. defaults to the small box (matching the project picker)
 const FULLSCREEN_KEY = 'editor:picker:vcdiff:fullscreen';
 
+// resizable sidebar bounds — mirror the version-control picker: caps suit the small
+// 1060px box, fullscreen lifts the max off the viewport keeping room for the main pane
+const SIDEBAR_KEY = 'editor:vcdiff:sidebar:width';
+const SIDEBAR_DEFAULT_W = 280;
+const SIDEBAR_MIN_W = 240;
+const SIDEBAR_MAX_W = 720;
+const DIFF_MAIN_MIN_W = 480;
+const FULLSCREEN_TOOLBAR_W = 40;
+
 // entity-level template-instance fields get their own (collapsed) panel rather
 // than sitting among the entity's regular values; values are shown friendlier
 const TEMPLATE_PANEL = 'Template instance';
@@ -76,6 +85,7 @@ editor.once('load', () => {
         fullscreen = !fullscreen;
         editor.call('localStorage:set', FULLSCREEN_KEY, fullscreen);
         applyFullscreen();
+        applyResizeBounds(fullscreen);
     });
     top.append(fullscreenToggle);
 
@@ -90,15 +100,25 @@ editor.once('load', () => {
     const body = new Container({ class: 'vc-diff-body' });
     shell.append(body);
 
-    const sidebar = document.createElement('div');
-    sidebar.classList.add('vc-diff-sidebar');
-    body.dom.appendChild(sidebar);
+    // resizable container with a draggable right edge (the divider), matching the
+    // version-control picker; persisted width survives reopen, bounds clamp on restore
+    const sidebar = new Container({
+        class: 'vc-diff-sidebar',
+        resizable: 'right',
+        resizeMin: SIDEBAR_MIN_W,
+        resizeMax: SIDEBAR_MAX_W,
+        width: editor.call('localStorage:get', SIDEBAR_KEY) || SIDEBAR_DEFAULT_W
+    });
+    sidebar.on('resize', () => {
+        editor.call('localStorage:set', SIDEBAR_KEY, sidebar.width);
+    });
+    body.append(sidebar);
 
     // persistent sidebar chrome — head (count) and the filter bar survive list
     // re-renders so the text input keeps focus while typing
     const head = document.createElement('div');
     head.classList.add('vc-diff-sidebar-head');
-    sidebar.appendChild(head);
+    sidebar.dom.appendChild(head);
 
     const filterBar = document.createElement('div');
     filterBar.classList.add('vc-diff-filter');
@@ -108,13 +128,26 @@ editor.once('load', () => {
     filterBar.appendChild(filter.dom);
     const typeSelect = new SelectInput({ type: 'string', value: 'all', options: [{ v: 'all', t: 'All types' }] });
     filterBar.appendChild(typeSelect.dom);
-    sidebar.appendChild(filterBar);
+    sidebar.dom.appendChild(filterBar);
     filter.on('change', () => renderSidebar());
     typeSelect.on('change', () => renderSidebar());
 
     const list = document.createElement('div');
     list.classList.add('vc-diff-list');
-    sidebar.appendChild(list);
+    sidebar.dom.appendChild(list);
+
+    // lift the resize cap to the viewport while fullscreen (keeping room for the main
+    // pane) and clamp an oversized persisted width back into the small box on restore
+    const applyResizeBounds = (full: boolean) => {
+        const sidebarMax = full ? Math.max(SIDEBAR_MAX_W, window.innerWidth - FULLSCREEN_TOOLBAR_W - DIFF_MAIN_MIN_W) : SIDEBAR_MAX_W;
+        sidebar.resizeMax = sidebarMax;
+        const w = editor.call('localStorage:get', SIDEBAR_KEY) || SIDEBAR_DEFAULT_W;
+        if (w > sidebarMax) {
+            sidebar.width = sidebarMax;
+            editor.call('localStorage:set', SIDEBAR_KEY, sidebarMax);
+        }
+    };
+    applyResizeBounds(fullscreen);
 
     const main = document.createElement('div');
     main.classList.add('vc-diff-main');
@@ -127,13 +160,13 @@ editor.once('load', () => {
     let trees: TreeView[] = [];
     const fileStats = new Map<string, Promise<{ deleted: number; added: number } | null>>();
 
-    sidebar.addEventListener('click', (evt) => {
+    sidebar.dom.addEventListener('click', (evt) => {
         const row = (evt.target as HTMLElement).closest('.vc-diff-row') as HTMLElement;
         if (!row?.dataset.index) {
             return;
         }
         selected = Number(row.dataset.index);
-        sidebar.querySelectorAll('.vc-diff-row.selected').forEach(el => el.classList.remove('selected'));
+        sidebar.dom.querySelectorAll('.vc-diff-row.selected').forEach(el => el.classList.remove('selected'));
         row.classList.add('selected');
         renderMain();
     });

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -34,8 +34,9 @@ const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template'
 const ASSET_ID_ARRAY_FIELDS = new Set(['path', 'scripts']);
 
 // loading-state skeleton fragments (mirror the real diff layout: sidebar rows are
-// name + status badge; main panels are a header bar over field rows of label + value)
-const SKELETON_ROW = '<div class="skeleton-row"><span class="bone line"></span><span class="bone badge"></span></div>';
+// name + status badge over a sub line; the main pane is a header bar over bordered
+// panels of label + value field rows)
+const SKELETON_ROW = '<div class="skeleton-row"><span class="bone line"></span><span class="bone badge"></span><span class="bone sub"></span></div>';
 const SKELETON_FIELD = '<div class="skeleton-field"><span class="bone label"></span><span class="bone value"></span></div>';
 const SKELETON_PANEL = `<div class="skeleton-panel"><div class="skeleton-phead"><span class="bone line"></span></div>${SKELETON_FIELD.repeat(3)}</div>`;
 
@@ -812,7 +813,7 @@ editor.once('load', () => {
         meta.textContent = '';
         clearSidebar();
         list.innerHTML = `<div class="vc-diff-skeleton">${SKELETON_ROW.repeat(6)}</div>`;
-        main.innerHTML = `<div class="vc-diff-skeleton main"><div class="skeleton-head"><span class="bone title"></span><span class="bone badge"></span></div>${SKELETON_PANEL.repeat(2)}</div>`;
+        main.innerHTML = `<div class="vc-diff-skeleton main"><div class="skeleton-head"><span class="bone title"></span><span class="bone badge"></span></div><div class="skeleton-body">${SKELETON_PANEL.repeat(2)}</div></div>`;
     };
 
     const setDiff = (diff: any) => {

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -1,4 +1,4 @@
-import { Button, Container, Overlay, Panel, TreeView, TreeViewItem } from '@playcanvas/pcui';
+import { Button, Container, Overlay, Panel, SelectInput, TextInput, TreeView, TreeViewItem } from '@playcanvas/pcui';
 
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
@@ -92,6 +92,28 @@ editor.once('load', () => {
     const sidebar = document.createElement('div');
     sidebar.classList.add('vc-diff-sidebar');
     body.dom.appendChild(sidebar);
+
+    // persistent sidebar chrome — head (count) and the filter bar survive list
+    // re-renders so the text input keeps focus while typing
+    const head = document.createElement('div');
+    head.classList.add('vc-diff-sidebar-head');
+    sidebar.appendChild(head);
+
+    const filterBar = document.createElement('div');
+    filterBar.classList.add('vc-diff-filter');
+    // native placeholder; pcui's [placeholder] renders an out-of-place chip (matches branch-switcher)
+    const filter = new TextInput({ keyChange: true, renderChanges: false });
+    (filter.dom.querySelector('input') as HTMLInputElement).placeholder = 'Filter changes';
+    filterBar.appendChild(filter.dom);
+    const typeSelect = new SelectInput({ type: 'string', value: 'all', options: [{ v: 'all', t: 'All types' }] });
+    filterBar.appendChild(typeSelect.dom);
+    sidebar.appendChild(filterBar);
+    filter.on('change', () => renderSidebar());
+    typeSelect.on('change', () => renderSidebar());
+
+    const list = document.createElement('div');
+    list.classList.add('vc-diff-list');
+    sidebar.appendChild(list);
 
     const main = document.createElement('div');
     main.classList.add('vc-diff-main');
@@ -542,19 +564,53 @@ editor.once('load', () => {
         }
     };
 
-    const renderSidebar = () => {
-        sidebar.innerHTML = '';
-        const summary = summarizeDiff(current ?? {});
-        const head = document.createElement('div');
-        head.classList.add('vc-diff-sidebar-head');
-        head.textContent = `${summary.total} change${summary.total === 1 ? '' : 's'}`;
-        sidebar.appendChild(head);
+    // empties the list and hides the filter bar — for loading/empty/error states
+    const clearSidebar = () => {
+        head.textContent = '';
+        filterBar.hidden = true;
+        list.innerHTML = '';
+    };
 
-        for (const group of summary.groups) {
+    const renderSidebar = () => {
+        filterBar.hidden = false;
+        list.innerHTML = '';
+        const summary = summarizeDiff(current ?? {});
+        const type = typeSelect.value;
+        const query = filter.value.trim();
+        // fuzzy match by name across all items; order maps conflict index -> rank
+        const order = query ?
+            new Map<number, number>(editor.call('search:items', summary.groups.flatMap(g => g.items.map(it => [it.name, it.index])), query).map((idx: number, i: number) => [idx, i])) :
+            null;
+
+        let shown = 0;
+        const groups = summary.groups
+        .filter(g => type === 'all' || g.type === type)
+        .map(g => ({
+            type: g.type,
+            items: order ? g.items.filter(it => order.has(it.index)).sort((a, b) => order.get(a.index)! - order.get(b.index)!) : g.items
+        }))
+        .filter(g => g.items.length);
+        groups.forEach((g) => {
+            shown += g.items.length;
+        });
+
+        const active = type !== 'all' || query !== '';
+        const plural = summary.total === 1 ? '' : 's';
+        head.textContent = active ? `${shown} of ${summary.total} change${plural}` : `${summary.total} change${plural}`;
+
+        if (!groups.length) {
+            const empty = document.createElement('div');
+            empty.classList.add('vc-diff-no-match');
+            empty.textContent = 'No changes match your filter';
+            list.appendChild(empty);
+            return;
+        }
+
+        for (const group of groups) {
             const groupHead = document.createElement('div');
             groupHead.classList.add('vc-diff-group');
             groupHead.textContent = `${typeLabel(group.type)} · ${group.items.length}`;
-            sidebar.appendChild(groupHead);
+            list.appendChild(groupHead);
 
             for (const item of group.items) {
                 const conflict = current.conflicts[item.index];
@@ -586,7 +642,7 @@ editor.once('load', () => {
                 row.appendChild(counts);
 
                 appendBadge(row, item.status);
-                sidebar.appendChild(row);
+                list.appendChild(row);
             }
         }
     };
@@ -653,13 +709,17 @@ editor.once('load', () => {
             meta.appendChild(document.createTextNode(' · vs '));
             meta.appendChild(hashChip(base));
         }
+        // type options reflect only the types present in this diff; reset filters
+        typeSelect.options = [{ v: 'all', t: 'All types' }, ...summary.groups.map(g => ({ v: g.type, t: typeLabel(g.type).replace(/^./, c => c.toUpperCase()) }))];
+        typeSelect.value = 'all';
+        filter.value = '';
         renderSidebar();
         renderMain();
     };
 
     const cleanup = () => {
         viewToken++;
-        sidebar.innerHTML = '';
+        clearSidebar();
         trees.forEach(t => t.destroy());
         trees = [];
         destroyValueFields(main);
@@ -750,7 +810,8 @@ editor.once('load', () => {
         trees = [];
         destroyValueFields(main);
         meta.textContent = '';
-        sidebar.innerHTML = `<div class="vc-diff-skeleton">${SKELETON_ROW.repeat(6)}</div>`;
+        clearSidebar();
+        list.innerHTML = `<div class="vc-diff-skeleton">${SKELETON_ROW.repeat(6)}</div>`;
         main.innerHTML = `<div class="vc-diff-skeleton main"><div class="skeleton-head"><span class="bone title"></span><span class="bone badge"></span></div>${SKELETON_PANEL.repeat(2)}</div>`;
     };
 
@@ -762,7 +823,7 @@ editor.once('load', () => {
         const summary = summarizeDiff(current ?? {});
         if (!summary.total) {
             meta.textContent = 'No changes';
-            sidebar.innerHTML = '';
+            clearSidebar();
             renderNotice('No changes since the checkpoint');
             return;
         }
@@ -799,7 +860,7 @@ editor.once('load', () => {
                 clearTimeout(slowHint);
                 if (token === viewToken) {
                     meta.textContent = '';
-                    sidebar.innerHTML = '';
+                    clearSidebar();
                     renderNotice(`Could not load diff: ${err instanceof Error ? err.message : err}`);
                 }
             });


### PR DESCRIPTION
### What's Changed

Enhancements to the full-overlay **Diff picker** (`picker-version-control-diff`), bringing it in line with the Version Control picker.

- **Sidebar filtering** — added a filter bar under the Changes list: a fuzzy text filter (reuses `search:items`) plus a *type* dropdown (All / Assets / Settings / Scene). The head shows filtered counts ("12 of 186 changes").
- **Lighter theming** — re-themed the picker onto the `$bcg-primary` base (matching the VC picker) with `$bcg-dark` bars and `$bcg-darkest` insets, sticky ASSETS/SETTINGS section headers, bordered panels, and a refreshed loading skeleton that mirrors the new colours and shape.
- **Header window controls** — pinned the shared project-picker panel header to an explicit `33px` so it lines up with the diff picker's `.vc-diff-top`, and centred both pickers' close / fullscreen-toggle controls (`top: 50%` + `translateY(-50%)`).
- **Draggable divider** — the divider between the changes list and the diff detail is now draggable, using the same PCUI `resizable: 'right'` mechanism as the VC picker. Width persists to `localStorage`, and the resize cap lifts to the viewport in fullscreen (clamping back into the small box on restore).

### Preview
<img width="2120" height="1200" alt="image" src="https://github.com/user-attachments/assets/2fda1e4d-24d9-416d-b9f9-7f3dffdb6979" />

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)