### PR TITLE
fix(version-control): changes-panel loading, dialog checkboxes & rich value rendering

### DIFF
--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -712,6 +712,12 @@ $vc-add-edge: #3fb950;
     &.pcui-color-input {
         flex: none;
     }
+
+    // the swatch is read-only here, but keep the inspector's corner triangle that
+    // readonly otherwise hides so it reads as a colour field
+    &.pcui-color-input.pcui-readonly::after {
+        display: block;
+    }
 }
 
 .vc-diff-missing {

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -32,6 +32,36 @@
     }
 }
 
+// rounded checkbox shared by the history compare list and the vc dialogs
+%vc-checkbox {
+    flex: none;
+    appearance: none;
+    position: relative;
+    width: 16px;
+    height: 16px;
+    border: 1px solid $border-primary;
+    border-radius: 3px;
+    background-color: $bcg-darkest;
+    box-sizing: border-box;
+    cursor: pointer;
+    transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
+
+    &:hover {
+        border-color: rgb(255 102 0 / 55%);
+        background-color: rgb(255 102 0 / 8%);
+    }
+
+    &:focus {
+        outline: none;
+        box-shadow: $element-shadow-active;
+    }
+
+    &:checked {
+        border-color: $text-active;
+        background: $text-active url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.2 6.5 11 12.5 4.5' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") center / 13px 13px no-repeat;
+    }
+}
+
 .pcui-container.picker-vc {
     height: 100%;
     overflow: hidden;
@@ -540,33 +570,9 @@
             }
 
             > .check {
-                flex: none;
-                appearance: none;
-                position: relative;
-                width: 16px;
-                height: 16px;
+                @extend %vc-checkbox;
+
                 margin-top: 3px;
-                border: 1px solid $border-primary;
-                border-radius: 3px;
-                background-color: $bcg-darkest;
-                box-sizing: border-box;
-                cursor: pointer;
-                transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
-
-                &:hover {
-                    border-color: rgb(255 102 0 / 55%);
-                    background-color: rgb(255 102 0 / 8%);
-                }
-
-                &:focus {
-                    outline: none;
-                    box-shadow: $element-shadow-active;
-                }
-
-                &:checked {
-                    border-color: $text-active;
-                    background: $text-active url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.2 6.5 11 12.5 4.5' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") center / 13px 13px no-repeat;
-                }
             }
 
             > .body {
@@ -1418,16 +1424,15 @@
                 align-items: center;
                 gap: 8px;
                 margin-top: 10px;
+                cursor: pointer;
 
-                > .pcui-label {
-                    margin: 0;
-                    font-size: 12px;
-                    color: $text-primary;
+                > .check {
+                    @extend %vc-checkbox;
                 }
 
-                > .pcui-boolean-input {
-                    margin: 0;
-                    flex: none;
+                > .label {
+                    font-size: 12px;
+                    color: $text-primary;
                 }
             }
 

--- a/src/editor/pickers/version-control/dialogs.ts
+++ b/src/editor/pickers/version-control/dialogs.ts
@@ -1,4 +1,4 @@
-import { BooleanInput, Button, Container, Label, TextInput } from '@playcanvas/pcui';
+import { Button, Container, TextInput } from '@playcanvas/pcui';
 
 export type VcDialogOpts = {
     title: string;
@@ -70,15 +70,22 @@ export const showVcDialog = (opts: VcDialogOpts): VcDialogHandle => {
     const checks: Record<string, boolean> = {};
     for (const c of opts.checkboxes ?? []) {
         checks[c.key] = !!c.value;
-        const row = document.createElement('div');
+        // a <label> row so clicking the text toggles the native checkbox; the
+        // checkbox shares the compare-list .check style (see %vc-checkbox)
+        const row = document.createElement('label');
         row.classList.add('vc-dialog-check');
-        const box = new BooleanInput({ value: !!c.value });
-        box.on('change', (v: boolean) => {
-            checks[c.key] = v;
+        const box = document.createElement('input');
+        box.type = 'checkbox';
+        box.classList.add('check');
+        box.checked = !!c.value;
+        box.addEventListener('change', () => {
+            checks[c.key] = box.checked;
         });
-        row.appendChild(box.dom);
-        const label = new Label({ text: c.label });
-        row.appendChild(label.dom);
+        row.appendChild(box);
+        const label = document.createElement('span');
+        label.classList.add('label');
+        label.textContent = c.label;
+        row.appendChild(label);
         bd.appendChild(row);
     }
 

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -2,7 +2,8 @@ import { Container, TextAreaInput } from '@playcanvas/pcui';
 
 import { config } from '@/editor/config';
 
-import { templateEntitiesFor, templateEntityPath } from './vc-diff-data';
+import { buildNameIndex, indexTemplateEntities, templateEntitiesFor, templateEntityPath, type NameIndex } from './vc-diff-data';
+import { destroyValueFields } from './vc-diff-fields';
 import { renderPreviewPropertyDiff } from './vc-diff-preview';
 import { DIFF_SLOW_HINT_MS, DIFF_SLOW_HINT_TEXT, diffTextChangeCounts, hashChip, isHiddenDiffField, lineChangeCounts, splitDiffPath, summarizeDiff, typeLabel, type DiffSummary } from './vc-helpers';
 import { diffCreate } from '../../messenger/jobs';
@@ -32,6 +33,8 @@ export const createChangesPanel = () => {
     // .then/.catch discard results when the generation has moved on (stale-response guard)
     let gen = 0;
     let rawDiffLive = false;
+    // resolves asset/entity/layer ids to names for the value fields; rebuilt with `raw`
+    let nameIndex: NameIndex = null;
     // the in-flight diff job, so Open Full Diff works before the summary finishes loading
     let rawPromise: Promise<any> = null;
     const fileStats = new Map<string, Promise<{ deleted: number; added: number } | null>>();
@@ -44,6 +47,7 @@ export const createChangesPanel = () => {
             editor.call('picker:versioncontrol:releaseDiff', id);
         }
         rawDiffLive = false;
+        nameIndex = null;
         fileStats.clear();
     };
 
@@ -142,14 +146,6 @@ export const createChangesPanel = () => {
                 list.appendChild(row);
             }
         }
-    };
-
-    const fmtVal = (v: any) => {
-        if (v === undefined || v === null) {
-            return '—';
-        }
-        const s = typeof v === 'string' ? `"${v}"` : JSON.stringify(v);
-        return s.length > 64 ? `${s.substring(0, 61)}…` : s;
     };
 
     const appendLineCounts = (vals: HTMLElement, counts: { deleted: number; added: number }) => {
@@ -267,7 +263,7 @@ export const createChangesPanel = () => {
         const props = data.filter((e: any) => !(fileName(conflict, e, 'src') || fileName(conflict, e, 'dst')));
 
         if (props.length) {
-            wrap.appendChild(renderPreviewPropertyDiff(conflict, props, { entityName, fmtVal }));
+            wrap.appendChild(renderPreviewPropertyDiff(conflict, props, { entityName, index: nameIndex }));
         }
         if (files.length) {
             wrap.appendChild(renderFileRows(conflict, files));
@@ -276,6 +272,8 @@ export const createChangesPanel = () => {
     };
 
     const renderSummary = () => {
+        // value fields hold pcui widgets (curve/gradient timers); destroy before discarding
+        destroyValueFields(summary.dom);
         summary.dom.innerHTML = '';
         const card = document.createElement('div');
         card.classList.add('vc-card');
@@ -436,6 +434,8 @@ export const createChangesPanel = () => {
             raw = next;
             rawDiffLive = typeof nextId === 'string';
             current = summarizeDiff(raw);
+            nameIndex = buildNameIndex(raw);
+            indexTemplateEntities(nameIndex, raw.conflicts ?? [], (id: any) => editor.call('assets:get', id));
             fileStats.clear();
             // indices shift on every recompute; default to the first change
             selIdx = current.total ? current.groups[0].items[0].index : null;

--- a/src/editor/pickers/version-control/panel-changes.ts
+++ b/src/editor/pickers/version-control/panel-changes.ts
@@ -420,6 +420,9 @@ export const createChangesPanel = () => {
             // single-flight: clear loading even for superseded responses or refresh deadlocks
             loading = false;
             if (snap !== gen) {
+                // a refresh landed while this fetch was in flight (e.g. the double
+                // invalidate() after creating a checkpoint) and was dropped — run it now
+                refresh();
                 return;
             }
             rawPromise = null;
@@ -442,6 +445,8 @@ export const createChangesPanel = () => {
             clearTimeout(slowHint);
             loading = false;
             if (snap !== gen) {
+                // superseded by a dropped refresh (see .then above) — run it now
+                refresh();
                 return;
             }
             rawPromise = null;

--- a/src/editor/pickers/version-control/picker-version-control-diff.ts
+++ b/src/editor/pickers/version-control/picker-version-control-diff.ts
@@ -3,8 +3,8 @@ import { Button, Container, Overlay, Panel, SelectInput, TextInput, TreeView, Tr
 import { handleCallback } from '@/common/utils';
 import { config } from '@/editor/config';
 
-import { arrayFieldKind, buildNameIndex, indexTemplateEntities, valueKind, type NameIndex } from './vc-diff-data';
-import { createDeltaListField, createValueField, destroyValueFields } from './vc-diff-fields';
+import { arrayFieldKind, buildNameIndex, indexTemplateEntities, type NameIndex } from './vc-diff-data';
+import { ASSET_ID_ARRAY_FIELDS, createDeltaListField, createSideValueField, destroyValueFields, isEntityChildren } from './vc-diff-fields';
 import {
     assetDiffField,
     DIFF_SLOW_HINT_MS,
@@ -38,9 +38,6 @@ const FULLSCREEN_TOOLBAR_W = 40;
 // than sitting among the entity's regular values; values are shown friendlier
 const TEMPLATE_PANEL = 'Template instance';
 const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template', template_ent_ids: 'Entity mapping' };
-// variable-length lists of asset ids (an asset's folder path, the project's
-// script loading order) — render as asset chips, not a vector/json blob
-const ASSET_ID_ARRAY_FIELDS = new Set(['path', 'scripts']);
 
 // loading-state skeleton fragments (mirror the real diff layout: sidebar rows are
 // name + status badge over a sub line; the main pane is a header bar over bordered
@@ -259,8 +256,6 @@ editor.once('load', () => {
         return badge;
     };
 
-    const typeFor = (entry: any, side: 'src' | 'dst') => entry[`${side}Type`] ?? entry.type ?? '';
-
     const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
 
     const inspectorInfo = (conflict: any, entry: any) => {
@@ -394,37 +389,7 @@ editor.once('load', () => {
         return row;
     };
 
-    // entities.<guid>.children (scenes) / data.entities.<guid>.children (templates)
-    const isEntityChildren = (path: string) => {
-        const parts = splitDiffPath(path ?? '');
-        const e = parts[0] === 'data' ? parts.slice(1) : parts;
-        return e.length === 3 && e[0] === 'entities' && e[2] === 'children';
-    };
-
-    const sideField = (entry: any, side: 'src' | 'dst') => {
-        const value = side === 'src' ? entry.srcValue : entry.dstValue;
-        const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
-        // a template's source id is an asset reference — show it as the asset name
-        if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
-            return createValueField('asset', value, nameIndex);
-        }
-        // variable-length asset-id lists (folder path, script loading order):
-        // render as asset chips, not a fixed-size vector or a raw json blob
-        if (!missing && Array.isArray(value) && ASSET_ID_ARRAY_FIELDS.has(splitDiffPath(entry.path ?? '').pop() ?? '')) {
-            return createValueField('array:asset', value, nameIndex);
-        }
-        // any other primitive array (tags, device types, ...) is a free-value list,
-        // not a fixed-size numeric tuple — render as pills instead of a json blob
-        if (!missing && arrayFieldKind(value) === 'pills') {
-            return createValueField('pills', value, nameIndex);
-        }
-        // an entity's children is a list of entity ids — resolve them to leaf names
-        if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
-            return createValueField('children', value, nameIndex);
-        }
-        const kind = missing ? 'missing' : valueKind(typeFor(entry, side), entry.path ?? '', value);
-        return createValueField(kind, value, nameIndex);
-    };
+    const sideField = (entry: any, side: 'src' | 'dst', conflict: any) => createSideValueField(entry, side, nameIndex, conflict);
 
     // wholly added/deleted entities arrive as a missing-flagged entry at the entity root
     const wholeEntity = (entry: any) => {
@@ -536,10 +501,10 @@ editor.once('load', () => {
                 continue;
             }
             if (!entry.missingInDst) {
-                host.appendChild(fieldRow('del', parts.field, parts.title, sideField(entry, 'dst')));
+                host.appendChild(fieldRow('del', parts.field, parts.title, sideField(entry, 'dst', conflict)));
             }
             if (!entry.missingInSrc) {
-                host.appendChild(fieldRow('add', parts.field, parts.title, sideField(entry, 'src')));
+                host.appendChild(fieldRow('add', parts.field, parts.title, sideField(entry, 'src', conflict)));
             }
         }
 

--- a/src/editor/pickers/version-control/picker-version-control.ts
+++ b/src/editor/pickers/version-control/picker-version-control.ts
@@ -449,13 +449,12 @@ editor.once('load', () => {
     };
 
     // inline (no overlay) checkpoint creation from the pinned form;
-    // the new row lands in history via messenger:checkpoint.createEnded
+    // the new row lands in history and the changes list refreshes via
+    // messenger:checkpoint.createEnded (which also updates latestCheckpointId first)
     changes.sidebar.on('create', (description: string) => {
         changes.sidebar.setBusy(true);
         checkpointCreateJob({ projectId: config.project.id, branchId: config.self.branch.id, description }).then(() => {
             changes.sidebar.resetForm();
-            changes.sidebar.invalidate();
-            changes.sidebar.refresh(true);
         }).catch((err) => {
             changes.sidebar.setBusy(false);
             log.error(err);

--- a/src/editor/pickers/version-control/vc-diff-fields.ts
+++ b/src/editor/pickers/version-control/vc-diff-fields.ts
@@ -1,12 +1,16 @@
-import { BooleanInput, NumericInput, TextAreaInput, TextInput, VectorInput, ColorPicker } from '@playcanvas/pcui';
+import { BooleanInput, NumericInput, TextAreaInput, TextInput, VectorInput } from '@playcanvas/pcui';
 
+import { ColorInput } from '@/common/pcui/element/element-color-input';
 import { CurveInput } from '@/common/pcui/element/element-curve-input';
 import { GradientInput } from '@/common/pcui/element/element-gradient-input';
 
-import { REF_KINDS, valueKind, type NameIndex, type ValueKind } from './vc-diff-data';
+import { arrayFieldKind, REF_KINDS, valueKind, type NameIndex, type ValueKind } from './vc-diff-data';
+import { splitDiffPath } from './vc-helpers';
 
 const AXES = ['X', 'Y', 'Z', 'W'];
 const JSON_FIELD_HEIGHT = 100;
+// fields whose value is a variable-length list of asset ids (rendered as chips)
+export const ASSET_ID_ARRAY_FIELDS = new Set(['path', 'scripts']);
 
 const el = (cls: string, text = '') => {
     const span = document.createElement('span');
@@ -102,7 +106,8 @@ export const createValueField = (kind: ValueKind, value: any, index: NameIndex):
         case 'vector':
             return pcuiDom(new VectorInput({ value, dimensions: value.length, placeholder: AXES.slice(0, value.length), readOnly: true }));
         case 'color':
-            return pcuiDom(new ColorPicker({ value, channels: value.length, readOnly: true }));
+            // the editor's ColorInput (the inspector's swatch), not pcui's ColorPicker
+            return pcuiDom(new ColorInput({ value, channels: value.length, readOnly: true }));
         case 'curve':
             return curveField(value);
         case 'gradient': {
@@ -203,6 +208,59 @@ export const createDeltaListField = (kind: 'children' | 'array:asset' | 'pills',
         list.appendChild(refChip(id, 'added'));
     }
     return list;
+};
+
+// entities.<guid>.children (scenes) / data.entities.<guid>.children (templates)
+export const isEntityChildren = (path: string) => {
+    const parts = splitDiffPath(path ?? '');
+    const e = parts[0] === 'data' ? parts.slice(1) : parts;
+    return e.length === 3 && e[0] === 'entities' && e[2] === 'children';
+};
+
+const typeFor = (entry: any, side: 'src' | 'dst') => entry[`${side}Type`] ?? entry.type ?? '';
+
+// material/asset colour fields (diffuse, emissive, …) aren't named "color", so the
+// path heuristic misses them — the asset schema's editor type is authoritative
+const assetColorType = (conflict: any, path: string) => {
+    if (conflict?.assetType && path?.startsWith('data.')) {
+        return editor.call('schema:asset:getDataType', conflict.assetType, path);
+    }
+    return '';
+};
+
+// the single value-cell renderer shared by the full diff and the changes-tab
+// preview so both parse colours/vectors/tags/refs the same way
+export const createSideValueField = (entry: any, side: 'src' | 'dst', index: NameIndex, conflict?: any): HTMLElement => {
+    const value = side === 'src' ? entry.srcValue : entry.dstValue;
+    const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
+    // a template's source id is an asset reference — show it as the asset name
+    if (!missing && splitDiffPath(entry.path ?? '').pop() === 'template_id') {
+        return createValueField('asset', value, index);
+    }
+    // variable-length asset-id lists (folder path, script loading order):
+    // render as asset chips, not a fixed-size vector or a raw json blob
+    if (!missing && Array.isArray(value) && ASSET_ID_ARRAY_FIELDS.has(splitDiffPath(entry.path ?? '').pop() ?? '')) {
+        return createValueField('array:asset', value, index);
+    }
+    // any other primitive array (tags, device types, ...) is a free-value list,
+    // not a fixed-size numeric tuple — render as pills instead of a json blob
+    if (!missing && arrayFieldKind(value) === 'pills') {
+        return createValueField('pills', value, index);
+    }
+    // an entity's children is a list of entity ids — resolve them to leaf names
+    if (!missing && isEntityChildren(entry.path) && Array.isArray(value)) {
+        return createValueField('children', value, index);
+    }
+    let kind = missing ? 'missing' : valueKind(typeFor(entry, side), entry.path ?? '', value);
+    // a 3/4-number tuple read as a vector may really be a colour (material
+    // diffuse/emissive/…); trust the asset schema rather than the field name
+    if (kind === 'vector') {
+        const at = assetColorType(conflict, entry.path);
+        if (at === 'rgb' || at === 'rgba') {
+            kind = 'color';
+        }
+    }
+    return createValueField(kind, value, index);
 };
 
 // pcui widgets hold timers (curve/gradient resize loops); destroy before discarding their dom

--- a/src/editor/pickers/version-control/vc-diff-preview.ts
+++ b/src/editor/pickers/version-control/vc-diff-preview.ts
@@ -1,11 +1,13 @@
 import { Panel } from '@playcanvas/pcui';
 
-import { isEntityIdMap } from './vc-diff-data';
+import { type NameIndex } from './vc-diff-data';
+import { createSideValueField } from './vc-diff-fields';
 import { assetDiffField, formatDiffPath, splitDiffPath, typeLabel } from './vc-helpers';
 
-// compact, text-valued mirror of the full diff's structured renderer
-// (picker-version-control-diff.ts). kept separate so the shipped full diff
-// stays untouched; the routing below intentionally tracks that file.
+// compact mirror of the full diff's structured renderer
+// (picker-version-control-diff.ts): the section/breadcrumb routing tracks that
+// file, while value cells go through the shared createSideValueField so colours,
+// vectors, tags and refs parse the same way in both.
 
 const SUB_RE = /^(?<kind>Script|Sound slot|Clip): (?<name>.+)$/;
 const SETTINGS_ROOT_RE = /^(?:scene |project )?settings$/i;
@@ -17,13 +19,6 @@ const TEMPLATE_FIELDS: Record<string, string> = { template_id: 'Source template'
 type EntityName = (conflict: any, value: string) => string | undefined;
 
 const sectionComponent = (value: string) => value.match(/^(.+) component$/i)?.[1]?.replace(/\s+/g, '').toLowerCase() ?? '';
-
-// entities.<guid>.children (scenes) / data.entities.<guid>.children (templates)
-const isEntityChildren = (path: string) => {
-    const parts = splitDiffPath(path ?? '');
-    const e = parts[0] === 'data' ? parts.slice(1) : parts;
-    return e.length === 3 && e[0] === 'entities' && e[2] === 'children';
-};
 
 const inspectorInfo = (conflict: any, entry: any, entityName: EntityName) => {
     // template assets carry a scene-shaped entity tree under data.entities;
@@ -151,40 +146,18 @@ const banner = (status: string, noun: string) => {
 };
 
 // structured property diff for the changes-tab preview: same markup/classes as
-// the full diff, but a text breadcrumb instead of a live tree and string values
+// the full diff, but a text breadcrumb instead of a live tree
 export const renderPreviewPropertyDiff = (
     conflict: any,
     entries: any[],
-    helpers: { entityName: EntityName; fmtVal: (v: any) => string }
+    helpers: { entityName: EntityName; index: NameIndex }
 ) => {
-    const { entityName, fmtVal } = helpers;
+    const { entityName, index } = helpers;
     const wrap = document.createElement('div');
     wrap.classList.add('vc-diff-inspector', 'compact');
 
-    const valueCell = (entry: any, side: 'src' | 'dst') => {
-        const value = side === 'src' ? entry.srcValue : entry.dstValue;
-        const missing = side === 'src' ? entry.missingInSrc : entry.missingInDst;
-        const span = document.createElement('span');
-        if (missing) {
-            span.classList.add('vc-diff-missing');
-            span.textContent = '(none)';
-        } else if (isEntityIdMap(value)) {
-            // compact summary in the preview; the full diff resolves names
-            const n = Object.keys(value).length;
-            span.textContent = `${n} entit${n === 1 ? 'y' : 'ies'}`;
-            span.title = JSON.stringify(value, null, 2);
-        } else if (isEntityChildren(entry.path) && Array.isArray(value)) {
-            // compact summary; the full diff resolves these ids to named chips
-            const n = value.length;
-            span.textContent = `${n} child${n === 1 ? '' : 'ren'}`;
-            span.title = JSON.stringify(value, null, 2);
-        } else {
-            span.textContent = fmtVal(value);
-            // fmtVal truncates to 64 chars; hover shows the full value
-            span.title = typeof value === 'string' ? value : JSON.stringify(value);
-        }
-        return span;
-    };
+    // same value rendering as the full diff (colours, vectors, tags, refs)
+    const valueCell = (entry: any, side: 'src' | 'dst') => createSideValueField(entry, side, index, conflict);
 
     // one card per entity (breadcrumb shown once); panels stack inside so an
     // entity changed across sections isn't drawn as separate repeated parts


### PR DESCRIPTION
A few related fixes/polish to the version-control picker.

## Changes

### 1. Changes list no longer strands a skeleton after creating a checkpoint
Creating a checkpoint fired `invalidate()` + `refresh(true)` from **two** paths (the create handler's promise and the `messenger:checkpoint.createEnded` handler). They raced: the second `refresh` was dropped by the in-flight `loading` guard, and the superseded fetch cleared `loading` without re-rendering — leaving the changes list stuck on skeleton loaders until a manual refresh (switching tabs). Now a settled fetch that finds itself superseded re-runs the dropped refresh, and the redundant call in the create handler is removed (the messenger handler is the single refresh path, and it updates `latestCheckpointId` first).

### 2. Dialog checkboxes match the compare-mode style
The merge / new-branch / restore dialogs used pcui `BooleanInput` ticks. They now use the same rounded checkbox as the history compare list, shared via a `%vc-checkbox` SASS placeholder.

### 3. Changes panel renders values like the full diff
The changes-tab preview showed field values as raw JSON (colours/vectors as `[1,0,0]`). Both the preview and the full diff now route through one shared `createSideValueField`, so colours, vectors, tags and refs parse identically. Notable bits:
- Material/asset colours (diffuse, emissive, …) aren't name-matched, so they're detected via the asset schema (`schema:asset:getDataType`) — the same call the conflict manager uses. Only upgrades a 3/4-tuple `vector` → `color`, so positions/scales stay vectors.
- Colours render with the editor's `ColorInput` (the inspector swatch), and the read-only swatch keeps its corner triangle.
- pcui widgets are destroyed before each re-render.

## Testing
- `npm run lint` (eslint + stylelint) and `npm run type:check` clean for all touched files (pre-existing errors in unrelated `src/workers/*` and legacy VC files remain).
- Full SASS compile passes.
- No unit tests added (UI/picker-only changes).