### PR TITLE
fix: modernize project settings picker

### DIFF
--- a/sass/common/_ui-common.scss
+++ b/sass/common/_ui-common.scss
@@ -90,7 +90,7 @@
 
     display: block;
     background-size: 100%;
-    background-image: url('//playcanvas.com/static-assets/platform/images/loader.gif');
+    background-image: url('https://playcanvas.com/static-assets/platform/images/loader.gif');
     background-repeat: no-repeat;
     opacity: 0;
     animation: fade-in ease-in 1;

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -6352,13 +6352,28 @@ strong {
 }
 
 .picker-project-main {
-    height: 100%;
-    overflow: hidden;
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 16px 20px 0 !important;
+    color: $text-primary;
+
+    &:not(.pcui-hidden) {
+        display: flex;
+        flex-direction: column;
+    }
 
     & > .project-settings {
-        display: flex;
-        gap: 10px;
-        padding: 25px;
+        margin: 0 0 12px;
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
+
+        &:not(.pcui-hidden) {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
 
         .pcui-disabled {
             cursor: not-allowed !important;
@@ -6372,17 +6387,74 @@ strong {
         span {
             @extend .font-regular;
 
-            color: $text-primary;
+            color: $text-secondary;
             margin-bottom: 0;
         }
 
         > .settings-group {
-            .form-input {
-                input,
-                textarea {
-                    font-size: 14px;
-                    line-height: 22px;
+            &:not(.pcui-hidden) {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+            }
+
+            > .pcui-label {
+                @extend .font-bold;
+
+                margin: 0;
+                color: $text-secondary;
+                font-size: 12px;
+                line-height: 16px;
+            }
+
+            > .pcui-text-input,
+            > .pcui-text-area-input {
+                width: 100%;
+                margin: 0;
+                border: 1px solid $bcg-darkest;
+                border-radius: 4px;
+                background-color: $bcg-dark;
+                box-sizing: border-box;
+                transition: background-color 100ms, box-shadow 100ms;
+
+                &:hover {
+                    background-color: $bcg-darker;
+                    box-shadow: $element-shadow-hover;
                 }
+
+                &:focus-within {
+                    background-color: $bcg-darkest;
+                    box-shadow: $element-shadow-active;
+                }
+            }
+
+            > .pcui-text-input {
+                height: 34px;
+                line-height: 32px;
+
+                > input {
+                    @extend .font-regular;
+
+                    color: $text-primary;
+                    font-size: 14px;
+                    line-height: 32px;
+                }
+            }
+
+            > .pcui-text-area-input > textarea {
+                @extend .font-regular;
+
+                display: block;
+                width: calc(100% - 20px);
+                margin: 0;
+                padding: 10px;
+                border: none;
+                background-color: transparent;
+                color: $text-primary;
+                font-size: 14px;
+                line-height: 20px;
+                outline: none;
+                box-shadow: none;
             }
         }
 
@@ -6391,21 +6463,205 @@ strong {
             width: 100%;
             align-items: center;
             justify-content: space-between;
+            gap: 12px;
+            margin: 0;
+            padding: 12px 0 0;
+            border-top: 1px solid $border-primary;
+
+            > .pcui-label {
+                margin: 0;
+                color: $text-primary;
+                font-size: 13px;
+                line-height: 18px;
+            }
+
+            > .pcui-button {
+                @extend .font-bold;
+
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                height: 34px;
+                margin: 0;
+                padding: 0 18px;
+                border: 1px solid $bcg-darkest;
+                border-radius: 6px;
+                color: $text-secondary;
+                background-color: $bcg-dark;
+                font-size: 13px;
+                box-shadow: none;
+                transition: color 100ms, background-color 100ms, box-shadow 100ms;
+
+                &[data-icon]::before {
+                    font-size: 14px;
+                    line-height: 1;
+                }
+
+                &.copy-url-button::before {
+                    content: '';
+                    width: 13px;
+                    height: 13px;
+                    margin-right: 8px;
+                    background-color: currentcolor;
+                    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z'/%3E%3Cpath d='M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                }
+
+                &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+                &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                    color: $text-primary;
+                    background-color: $bcg-dark;
+                    box-shadow: $element-shadow-hover;
+                }
+
+                &:not(.disabled, .pcui-disabled, .pcui-readonly):active {
+                    background-color: $bcg-darkest;
+                    box-shadow: none;
+                }
+
+                &.copy-url-button.copied {
+                    color: #6fd088;
+
+                    &::before {
+                        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 1 1 1.06-1.06l2.72 2.72 6.72-6.72a.75.75 0 0 1 1.06 0Z'/%3E%3C/svg%3E");
+                    }
+                }
+
+                > .pcui-label {
+                    margin: 0;
+                    color: inherit;
+                    font-size: inherit;
+                    line-height: 32px;
+                }
+            }
         }
     }
 
-    & > .locked-container { padding: 25px; }
+    & > .locked-container {
+        margin: 0 0 12px;
+        padding: 14px 16px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
+
+        &:not(.pcui-hidden) {
+            display: flex;
+            flex-flow: row wrap;
+            align-items: center;
+            gap: 12px;
+        }
+
+        > .locked-text {
+            flex: 1 1 280px;
+            margin: 0;
+            color: $text-primary;
+            font-size: 13px;
+            line-height: 18px;
+
+            a {
+                color: #9dd4ff;
+                text-decoration: none;
+
+                &:hover,
+                &:focus {
+                    text-decoration: underline;
+                }
+            }
+        }
+
+        > .pcui-button {
+            @extend .font-bold;
+
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 34px;
+            margin: 0;
+            padding: 0 18px;
+            border: 1px solid transparent;
+            border-radius: 6px;
+            color: $text-primary;
+            background-color: $text-active;
+            font-size: 13px;
+            box-shadow: none;
+            transition: color 100ms, background-color 100ms, box-shadow 100ms;
+
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                background-color: color.adjust($text-active, $lightness: -7%);
+                box-shadow: $element-shadow-hover;
+            }
+        }
+    }
 
     & > .action-buttons {
-        position: absolute;
-        left: 0;
-        right: 0;
+        position: sticky;
         bottom: 0;
-        height: min-content;
-        padding: 25px;
+        z-index: 1;
+        margin: auto -20px 0;
+        padding: 12px 20px;
+        border-top: 1px solid $border-primary;
+        background-color: $bcg-primary;
 
-        & > .full-width-button {
-            margin-bottom: 0;
+        &:not(.pcui-hidden) {
+            display: flex;
+            flex-flow: row wrap;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 10px;
+        }
+
+        > .pcui-container {
+            flex: 0 0 auto;
+            margin: 0;
+        }
+
+        .full-width-button {
+            @extend .font-bold;
+
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 34px;
+            min-width: 150px;
+            margin: 0;
+            padding: 0 18px;
+            border: 1px solid transparent;
+            border-radius: 6px;
+            color: $text-primary;
+            background-color: $text-active;
+            font-size: 13px;
+            line-height: 32px;
+            box-shadow: none;
+            transition: color 100ms, background-color 100ms, opacity 100ms, box-shadow 100ms;
+
+            &[data-icon]::before {
+                font-size: 14px;
+                line-height: 1;
+            }
+
+            > .pcui-label {
+                margin: 0;
+                color: inherit;
+                font-size: inherit;
+                line-height: 32px;
+            }
+
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                background-color: color.adjust($text-active, $lightness: -7%);
+                box-shadow: $element-shadow-hover;
+            }
+
+            &:not(.disabled, .pcui-disabled, .pcui-readonly):active {
+                background-color: color.adjust($text-active, $lightness: -12%);
+                box-shadow: none;
+            }
+
+            &.disabled,
+            &.pcui-disabled {
+                opacity: $element-opacity-disabled;
+                cursor: default;
+            }
         }
 
         .loader {
@@ -6420,47 +6676,11 @@ strong {
 
             &:hover:not(.pcui-disabled) {
                 background-color: $error-secondary;
-                border: none;
-                box-shadow: initial;
+                box-shadow: $element-shadow-hover;
             }
 
             &.pcui-disabled {
                 cursor: not-allowed;
-            }
-        }
-    }
-
-    & > .copied-url-popup {
-        position: absolute;
-        left: 50%;
-        bottom: 0;
-        transform: translate(-50%, 40px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: min-content;
-        padding: 5px;
-        background-color: $text-active;
-        opacity: 0;
-        transition: all 0.25s ease-in-out;
-
-        &.open {
-            transform: translate(-50%, 0);
-            opacity: 1;
-        }
-
-        & > span {
-            @extend .font-regular;
-
-            color: $text-primary;
-
-            &::before {
-                @extend .font-icon;
-
-                content: '\E400';
-                line-height: 1.1em;
-                margin-right: 5px;
             }
         }
     }

--- a/src/editor/pickers/picker-project-main.ts
+++ b/src/editor/pickers/picker-project-main.ts
@@ -23,9 +23,9 @@ editor.once('load', () => {
         const isCurrentProject = currentProject && currentProject.id === config.project.id;
         const hasVersionControl = isCurrentProject && !config.project.settings.useLegacyScripts;
         if (hasVersionControl) {
-            return `EXPORT PROJECT (${config.self.branch.name})`;
+            return `Export Project (${config.self.branch.name})`;
         }
-        return 'EXPORT PROJECT';
+        return 'Export Project';
     };
 
     // displays or hides the AJAX loader UI when exporting project
@@ -79,7 +79,7 @@ editor.once('load', () => {
 
     const unlockButton = new Button({
         icon: 'E340',
-        text: 'UNLOCK'
+        text: 'Unlock'
     });
     lockedContainer.append(unlockButton);
     lockedContainer.style.display = 'none';  // hide by default
@@ -202,18 +202,16 @@ editor.once('load', () => {
     projectURLSettings.dom.appendChild(projectUrlLabel.dom);
 
     const projectURLButton = new Button({
-        icon: 'E357',
+        class: 'copy-url-button',
         text: 'Copy URL'
     });
     projectURLSettings.dom.appendChild(projectURLButton.dom);
 
     projectURLButton.on('click', () => {
-        navigator.clipboard.writeText(`${config.url.home}/editor/project/${currentProject.id}`);
-
-        copiedURLPopup.class.add('open');
-        setTimeout(() => {
-            copiedURLPopup.class.remove('open');
-        }, 3000);
+        navigator.clipboard.writeText(`${config.url.home}/editor/project/${currentProject.id}`).then(() => {
+            projectURLButton.class.add('copied');
+            setTimeout(() => projectURLButton.class.remove('copied'), 1500);
+        }, () => {});
     });
 
     // action buttons container
@@ -249,7 +247,7 @@ editor.once('load', () => {
     const deleteProjectButton = new Button({
         class: 'full-width-button',
         icon: 'E124',
-        text: 'DELETE PROJECT',
+        text: 'Delete Project',
         enabled: false,
         hidden: true
     });
@@ -259,17 +257,6 @@ editor.once('load', () => {
     deleteProjectButton.on('click', () => {
         editor.call('picker:project:modal:deleteProjectConfirmation', currentProject);
     });
-
-    // copied URL to clipboard popup box
-    const copiedURLPopup = new Container({
-        class: 'copied-url-popup'
-    });
-    panel.append(copiedURLPopup);
-
-    const copiedURLText = new Label({
-        text: 'URL Copied to the clipboard!'
-    });
-    copiedURLPopup.append(copiedURLText);
 
     // CONTROLLERS
 
@@ -409,8 +396,6 @@ editor.once('load', () => {
         if (projectSettingsChanged) {
             editor.call('picker:project:cms:refreshProjects');
         }
-
-        copiedURLPopup.class.remove('open');  // close clipboard popup
 
         editor.call('picker:project:hideAlerts');
         editor.call('picker:project:hideThumbnailControls');


### PR DESCRIPTION
### What's Changed
- Modernizes the Project Settings picker to match the newer scene/builds picker chrome.
- Keeps Copy URL as a text button while reusing the existing copy/check SVG mask icons.
- Loads the shared spinner over HTTPS to avoid the mixed-content warning.

### Preview
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/23c78984-bcfa-4210-9ebd-4e7cfa215482" />

### Manual smoke test
1. Open the editor over HTTPS with `?use_local_frontend`, then open Project Settings. Expected: the settings panel uses the modern bordered form styling and action bar.
2. Click Copy URL. Expected: the button keeps its label and shape, the icon changes from copy to green check briefly, and the project URL is copied.
3. Trigger a project export from Project Settings. Expected: the spinner loads without a mixed-content warning.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
