### PR TITLE
fix: modernize team picker

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -7029,9 +7029,18 @@ strong {
                     border-radius: 4px;
                     background-color: rgb(0 0 0 / 10%);
 
+                    &.pcui-open {
+                        z-index: 2;
+                    }
+
                     .pcui-select-input-container-value {
                         height: 22px;
                         border-radius: 4px;
+                    }
+
+                    .pcui-select-input-shadow {
+                        top: initial;
+                        bottom: 0;
                     }
 
                     .pcui-select-input-value,
@@ -7046,6 +7055,32 @@ strong {
                         color: $text-dark;
                         font-size: 10px;
                         text-transform: uppercase;
+                    }
+
+                    .pcui-select-input-list {
+                        top: initial;
+                        bottom: 100%;
+                        border: 1px solid $border-primary;
+                        border-radius: 4px;
+                        background-color: $bcg-darker;
+                        box-shadow: $element-shadow-hover;
+                        overflow: hidden auto;
+
+                        > .pcui-label {
+                            @extend .font-regular;
+
+                            height: 24px;
+                            color: $text-secondary;
+                            font-size: 12px;
+                            line-height: 24px;
+                            background-color: $bcg-darker;
+
+                            &:hover,
+                            &.pcui-select-input-label-highlighted {
+                                color: $text-primary;
+                                background-color: $bcg-darkest;
+                            }
+                        }
                     }
                 }
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -7021,59 +7021,53 @@ strong {
                 }
 
                 .role-select {
-                    width: auto;
-                    min-width: 112px;
+                    @extend .font-bold;
+
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    width: 112px;
                     height: 22px;
                     margin: 0;
+                    padding: 0 7px;
                     border: 1px solid $border-primary;
                     border-radius: 4px;
+                    color: $text-dark;
                     background-color: rgb(0 0 0 / 10%);
+                    font-size: 10px;
+                    line-height: 20px;
+                    text-transform: uppercase;
+                    box-shadow: none;
+                    cursor: pointer;
+                    transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
 
-                    &.pcui-open {
-                        z-index: 2;
+                    &::after {
+                        content: '';
+                        width: 8px;
+                        height: 8px;
+                        margin-left: 6px;
+                        background-color: currentcolor;
+                        mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 6h8l-4 4-4-4Z'/%3E%3C/svg%3E") center / contain no-repeat;
+                        transition: transform 100ms;
                     }
 
-                    .pcui-select-input-container-value {
-                        height: 22px;
-                        border-radius: 4px;
-                    }
-
-                    .pcui-select-input-value,
-                    .pcui-select-input-icon {
-                        height: 22px;
-                        line-height: 20px;
-                    }
-
-                    .pcui-select-input-value {
-                        @extend .font-bold;
-
-                        color: $text-dark;
-                        font-size: 10px;
-                        text-transform: uppercase;
-                    }
-
-                    .pcui-select-input-list {
-                        border: 1px solid $border-primary;
-                        border-radius: 4px;
-                        background-color: $bcg-darker;
+                    &:hover,
+                    &:focus {
+                        color: $text-primary;
+                        background-color: $bcg-dark;
+                        border-color: $bcg-darkest;
                         box-shadow: $element-shadow-hover;
-                        overflow: hidden auto;
+                    }
 
-                        > .pcui-label {
-                            @extend .font-regular;
+                    &.active {
+                        color: $text-primary;
+                        background-color: $bcg-darkest;
+                        border-color: $border-primary;
+                        box-shadow: $element-shadow-active;
+                    }
 
-                            height: 24px;
-                            color: $text-secondary;
-                            font-size: 12px;
-                            line-height: 24px;
-                            background-color: $bcg-darker;
-
-                            &:hover,
-                            &.pcui-select-input-label-highlighted {
-                                color: $text-primary;
-                                background-color: $bcg-darkest;
-                            }
-                        }
+                    &.active::after {
+                        transform: rotate(180deg);
                     }
                 }
 

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -3559,18 +3559,23 @@ strong {
 // Individual Alert Popup
 .alert {
     position: absolute;
-    flex-direction: row;
-    align-self: center;
-    bottom: 0;
-    left: 12px;
-    width: calc(95% - 50px);
-    padding: 20px 25px;
     display: flex;
     align-items: center;
+    gap: 12px;
     justify-content: space-between;
-    background-color: $error-secondary;
-    font-size: 14px;
-    margin: 10px;
+    left: 20px;
+    right: 20px;
+    bottom: 12px;
+    width: auto;
+    min-height: 48px;
+    margin: 0;
+    padding: 10px 12px;
+    border: 1px solid rgb(168 61 61 / 65%);
+    border-radius: 6px;
+    color: #ff8a8a;
+    background-color: rgb(231 76 60 / 10%);
+    box-shadow: none;
+    font-size: 13px;
     z-index: 10000000;
 
     // Text and icon for the alert dialog
@@ -3578,64 +3583,82 @@ strong {
         @extend .font-regular;
 
         display: flex;
-        flex-direction: row;
         align-items: center;
+        flex: 1 1 auto;
+        gap: 10px;
+        min-width: 0;
 
         .alert--info {
             @extend .font-icon;
 
             &::before {
                 content: '\E218';
-                color: $text-primary;
-                font-size: medium;
-                margin-right: 20px;
+                color: currentcolor;
+                font-size: 16px;
+                line-height: 1;
             }
         }
 
         span {
-            font-size: 14px;
-            color: $text-primary;
-            text-transform: uppercase;
+            margin: 0;
+            color: currentcolor;
+            font-size: 13px;
+            line-height: 18px;
         }
     }
 
     // Upgrade Button
     .btn {
-        position: absolute;
-        right: 70px;
-        color: #e74c3c;
-        background-color: $text-primary !important;
-        border: none !important;
-        padding: 0 50px;
+        @extend .font-bold;
+
+        flex: 0 0 auto;
+        height: 30px;
+        margin: 0;
+        padding: 0 14px;
+        border: 1px solid $error-secondary !important;
+        border-radius: 5px;
+        color: $text-primary;
+        background-color: rgb(231 76 60 / 16%) !important;
+        font-size: 12px;
+        box-shadow: none;
 
         &:hover,
         &:focus {
-            background-color: $bcg-darkest !important;
-            border: none !important;
-            color: #e74c3c;
+            color: $text-primary;
+            background-color: rgb(231 76 60 / 26%) !important;
+            box-shadow: $element-shadow-hover;
         }
     }
 
     // Close Button for dialog
     &-close {
-        display: block;
-        position: relative;
-        font-size: large;
-        background: none !important;
-        border: none;
-        color: $text-primary;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 auto;
+        width: 28px;
+        height: 28px;
+        margin: 0;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        color: $text-dark;
+        background-color: transparent !important;
         box-shadow: none !important;
         cursor: pointer;
+        transition: color 100ms, background-color 100ms, border-color 100ms;
 
-        &:hover {
-            &::before {
-                color: $bcg-darkest;
-            }
+        &:hover,
+        &:focus {
+            color: $text-primary;
+            border-color: $bcg-darkest;
+            background-color: $bcg-darkest !important;
         }
 
         &::before {
             content: '\2715';
-            font-size: large;
+            font-size: 16px;
+            line-height: 1;
         }
     }
 }
@@ -3679,88 +3702,6 @@ strong {
         }
     }
 
-    // Individual Alert Popup
-    .alert {
-        position: absolute;
-        flex-direction: row;
-        align-self: center;
-        bottom: 0;
-        left: 12px;
-        width: calc(95% - 50px);
-        padding: 20px 25px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        background-color: #e74c3c;
-        font-size: 14px;
-        margin: 10px;
-
-        // Text and icon for the alert dialog
-        &-text {
-            @extend .font-regular;
-
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-
-            .alert--info {
-                @extend .font-icon;
-
-                &::before {
-                    content: '\E218';
-                    color: #fff;
-                    font-size: medium;
-                    margin-right: 20px;
-                }
-            }
-
-            span {
-                font-size: 14px;
-                color: #fff;
-                text-transform: uppercase;
-            }
-        }
-
-        // Upgrade Button
-        .btn {
-            position: absolute;
-            right: 70px;
-            color: #e74c3c;
-            background-color: #fff !important;
-            border: none !important;
-            padding: 0 50px;
-
-            &:hover,
-            &:focus {
-                background-color: $bcg-darkest !important;
-                border: none !important;
-                color: #e74c3c;
-            }
-        }
-
-        // Close Button for dialog
-        &-close {
-            display: block;
-            position: relative;
-            font-size: large;
-            background: none !important;
-            border: none;
-            color: #fff;
-            box-shadow: none;
-            cursor: pointer;
-
-            &:hover {
-                &::before {
-                    color: $bcg-darkest;
-                }
-            }
-
-            &::before {
-                content: '\2715';
-                font-size: large;
-            }
-        }
-    }
 }
 
 .pcui-container.picker-scene-panel {
@@ -6825,12 +6766,16 @@ strong {
 }
 
 .picker-team-management {
-    display: flex;
-    height: calc(100% - 30px);
-    flex-direction: column;
-    align-items: center;
-    gap: 50px;
-    padding: 15px 20px !important;
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 16px 20px 0 !important;
+    color: $text-primary;
+    font-size: 12px;
+
+    &:not(.pcui-hidden) {
+        display: flex;
+        flex-direction: column;
+    }
 
     .pcui-disabled {
         cursor: not-allowed !important;
@@ -6844,161 +6789,373 @@ strong {
         }
     }
 
-    .section-label {
-        @extend .font-regular;
-
-        color: $text-primary;
-        text-align: start;
-        white-space: pre-wrap;
-        width: 20%;
-    }
-
     > .invite-container {
-        display: flex;
-        justify-content: space-around;
-        width: 100%;
-        height: min-content;
+        flex-shrink: 0;
+        margin: 0 0 12px;
+        padding: 10px 12px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
 
-        & > .invite-input-container {
-            position: relative;
+        &:not(.pcui-hidden) {
             display: flex;
-            width: 80%;
-            height: max-content;
+            align-items: flex-start;
+            gap: 10px;
+        }
 
-            & > .invite-input-group {
-                display: flex;
-                height: 100%;
-                width: 100%;
+        > .invite-input-container {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
 
-                > .invite-input {
-                    width: 80%;
-                    height: 28px;
-                    margin-left: 0;
-                    margin-bottom: 0;
+        .invite-input-group {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            min-width: 0;
 
-                    &::after {
-                        left: 0;
-                        bottom: 0;
-                        right: auto;
-                        font-size: 0.8em;
-                        line-height: 2.5em;
-                    }
+            > .invite-input {
+                flex: 1 1 auto;
+                width: auto;
+                height: 34px;
+                margin: 0;
+                border: 1px solid $bcg-darkest;
+                border-radius: 6px;
+                background-color: $bcg-dark;
+                overflow: hidden;
+
+                > input {
+                    @extend .font-regular;
+
+                    height: 32px;
+                    color: $text-primary;
+                    font-size: 13px;
+                    line-height: 32px;
                 }
 
-                > .invite-submit {
-                    width: 30%;
-                    font-weight: 500;
+                &::after {
+                    line-height: 32px;
+                }
+
+                &:hover {
                     background-color: $bcg-darker;
-                    line-height: normal !important;
-                    border: none;
+                    box-shadow: $element-shadow-hover;
+                }
+
+                &:focus-within {
+                    background-color: $bcg-darkest;
+                    box-shadow: $element-shadow-active;
                 }
             }
 
-            & > .invite-warning {
-                display: block;
-                width: 100%;
-                margin: 5px 0 0;
-                white-space: pre-wrap;
+            > .invite-submit {
+                @extend .font-bold;
 
-                & > .warning-link--white {
-                    color: $text-primary;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                height: 34px;
+                margin: 0;
+                padding: 0 18px;
+                border: 1px solid transparent;
+                border-radius: 6px;
+                color: $text-primary;
+                background-color: $text-active;
+                font-size: 13px;
+                box-shadow: none;
+                transition: background-color 100ms, box-shadow 100ms, opacity 100ms;
+
+                > .pcui-label {
+                    margin: 0;
+                    color: inherit;
+                    font-size: inherit;
+                    line-height: 32px;
                 }
 
-                & > .warning-link::after {
-                    @extend .font-icon;
-
-                    content: '\E112';
-                    margin-left: 5px;
+                &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+                &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                    background-color: color.adjust($text-active, $lightness: -7%);
+                    box-shadow: $element-shadow-hover;
                 }
             }
         }
-    }
 
-    > .owner-container {
-        display: flex;
-        justify-content: space-around;
-        width: 100%;
-        height: min-content;
-
-        > .owner-widget-container {
+        .invite-warning {
             display: block;
-            height: min-content;
-            width: 80%;
+            width: 100%;
+            margin: 8px 0 0;
+            color: $text-dark;
+            font-size: 12px;
+            line-height: 17px;
+            white-space: pre-wrap;
+
+            > .warning-link--white {
+                color: $text-primary;
+            }
+
+            > .warning-link::after {
+                @extend .font-icon;
+
+                content: '\E112';
+                margin-left: 5px;
+            }
+        }
+
+        > .members-count {
+            @extend .font-bold;
+
+            flex: 0 0 auto;
+            margin: 7px 0 0;
+            color: $text-dark;
+            font-size: 11px;
+            line-height: 20px;
+            white-space: nowrap;
         }
     }
 
     > .members-container {
-        display: flex;
-        justify-content: space-around;
-        flex-direction: row;
-        width: 100%;
-        height: max-content;
-        max-height: 100%;
+        min-height: 0;
+        margin: 0 0 12px;
+        border: 1px solid $border-primary;
+        border-radius: 6px;
+        background-color: rgb(0 0 0 / 8%);
+        overflow: hidden;
+
+        &:not(.pcui-hidden) {
+            display: flex;
+            flex-direction: column;
+        }
+
+        > .members-header,
+        > .members-grid > .collaborator-container {
+            display: grid;
+            grid-template-columns: minmax(220px, 1fr) 130px 128px 72px;
+            gap: 12px;
+            align-items: center;
+            padding: 0 12px 0 14px;
+        }
+
+        > .members-header {
+            flex: 0 0 auto;
+            height: 34px;
+            border-bottom: 1px solid $border-primary;
+
+            > .pcui-label {
+                @extend .font-bold;
+
+                margin: 0;
+                color: $text-dark;
+                font-size: 10px;
+                line-height: 14px;
+                text-transform: uppercase;
+            }
+        }
 
         > .members-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            grid-auto-rows: min-content;
-            overflow-y: visible;
-            gap: 20px;
-            width: 80%;
+            min-height: 0;
+            overflow-y: auto;
 
-            > .user-collaborator {
-                border-bottom: 1px solid $text-active;
+            > .collaborator-container {
+                min-height: 58px;
+                border-bottom: 1px solid $border-primary;
+                transition: background-color 100ms ease;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+
+                &:hover {
+                    background-color: #354144;
+                }
+
+                &.owner-collaborator:hover {
+                    background-color: transparent;
+                }
+
+                > .member-cell {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                    min-width: 0;
+                }
+
+                .collaborator-image {
+                    flex: 0 0 auto;
+                    width: 34px;
+                    height: 34px;
+                    border: 1px solid $border-primary;
+                    border-radius: 4px;
+                    background-color: $bcg-darkest;
+                }
+
+                .collaborator-identity {
+                    min-width: 0;
+                }
+
+                .collaborator-name {
+                    @extend .font-bold;
+
+                    display: block;
+                    margin: 0;
+                    color: $text-primary;
+                    font-size: 14px;
+                    line-height: 18px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+
+                .collaborator-subtitle {
+                    display: block;
+                    margin: 0;
+                    color: $text-dark;
+                    font-size: 12px;
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+
+                > .access-cell {
+                    min-width: 0;
+                }
+
+                .role-select {
+                    width: auto;
+                    min-width: 112px;
+                    height: 22px;
+                    margin: 0;
+                    border: 1px solid $border-primary;
+                    border-radius: 4px;
+                    background-color: rgb(0 0 0 / 10%);
+
+                    .pcui-select-input-container-value {
+                        height: 22px;
+                        border-radius: 4px;
+                    }
+
+                    .pcui-select-input-value,
+                    .pcui-select-input-icon {
+                        height: 22px;
+                        line-height: 20px;
+                    }
+
+                    .pcui-select-input-value {
+                        @extend .font-bold;
+
+                        color: $text-dark;
+                        font-size: 10px;
+                        text-transform: uppercase;
+                    }
+                }
+
+                .team-pill {
+                    @extend .font-bold;
+
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: max-content;
+                    height: 20px;
+                    margin: 0;
+                    padding: 0 7px;
+                    border: 1px solid rgb(255 122 35 / 50%);
+                    border-radius: 4px;
+                    color: $text-active;
+                    background-color: rgb(255 122 35 / 16%);
+                    font-size: 10px;
+                    line-height: 18px;
+                    text-transform: uppercase;
+
+                    &.muted {
+                        border-color: $border-primary;
+                        color: $text-dark;
+                        background-color: rgb(0 0 0 / 10%);
+                    }
+
+                    &.green {
+                        border-color: rgb(111 208 136 / 42%);
+                        color: #6fd088;
+                        background-color: rgb(111 208 136 / 12%);
+                    }
+                }
+
+                > .actions-cell {
+                    display: flex;
+                    justify-content: flex-end;
+                    gap: 4px;
+                }
+
+                .team-action {
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 28px;
+                    height: 28px;
+                    min-width: 0;
+                    margin: 0;
+                    padding: 0;
+                    border: 1px solid transparent;
+                    border-radius: 4px;
+                    color: $text-dark;
+                    background-color: transparent;
+                    box-shadow: none;
+                    transition: color 100ms, background-color 100ms, border-color 100ms, box-shadow 100ms;
+
+                    &[data-icon]::before {
+                        margin: 0;
+                        font-size: 13px;
+                        line-height: 1;
+                    }
+
+                    &:not(.disabled, .pcui-disabled, .pcui-readonly):hover,
+                    &:not(.disabled, .pcui-disabled, .pcui-readonly):focus {
+                        color: $text-primary;
+                        border-color: $bcg-darkest;
+                        background-color: $bcg-dark;
+                        box-shadow: $element-shadow-hover;
+                    }
+                }
             }
         }
     }
 
-    .collaborator-container {
-        height: 62px;
-        margin: 0 10px 0 0;
-        display: grid;
-        grid-template-columns: 62px calc(100% - 62px);
+    > .add-me-as-admin {
+        @extend .font-bold;
 
-        > .collaborator-image {
-            display: inline-block;
-            background-color: white;
+        align-self: flex-start;
+        height: 34px;
+        margin: 0;
+        padding: 0 18px;
+        border: 1px solid transparent;
+        border-radius: 6px;
+        color: $text-primary;
+        background-color: $text-active;
+        font-size: 13px;
+        box-shadow: none;
+    }
+
+    @media (max-width: 760px) {
+        > .invite-container {
+            flex-wrap: wrap;
+
+            > .members-count {
+                margin-top: 0;
+            }
         }
 
-        > .collaborator-right-container {
-            width: calc(100% - 20px);
-            margin-right: 10px;
-            padding: 0 10px;
-            background-color: $bcg-darker;
-
-            > .collaborator-first-row {
-                display: flex;
-                width: 100%;
-                justify-content: space-between;
-
-                > span {
-                    width: calc(100% - 70px);
-                    margin-bottom: 0;
-                }
-
-                > .pcui-button {
-                    box-shadow: none;
-                    margin-top: 0;
-                    margin-right: 0;
-                    margin-bottom: 0;
-                    padding-right: 0;
-                    border: none;
-                    font-size: 1.1em;
-                    background-color: transparent;
-
-                    &:hover:not(.pcui-disabled) {
-                        color: $text-active;
-                    }
-                }
+        > .members-container {
+            > .members-header {
+                display: none;
             }
 
-            > .pcui-select-input {
-                width: 100%;
-                margin-left: 0;
-            }
+            > .members-grid > .collaborator-container {
+                grid-template-columns: minmax(0, 1fr) 64px;
 
-            > span {
-                color: rgba($text-primary, 0.3);
+                > .access-cell,
+                > .team-pill {
+                    display: none;
+                }
             }
         }
     }

--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -7038,11 +7038,6 @@ strong {
                         border-radius: 4px;
                     }
 
-                    .pcui-select-input-shadow {
-                        top: initial;
-                        bottom: 0;
-                    }
-
                     .pcui-select-input-value,
                     .pcui-select-input-icon {
                         height: 22px;
@@ -7058,8 +7053,6 @@ strong {
                     }
 
                     .pcui-select-input-list {
-                        top: initial;
-                        bottom: 100%;
                         border: 1px solid $border-primary;
                         border-radius: 4px;
                         background-color: $bcg-darker;

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -1,5 +1,11 @@
 import { Element, Label, Button, SelectInput, Container, TextInput } from '@playcanvas/pcui';
 
+const ACCESS_LEVEL_LABELS = new Map([
+    ['admin', 'Admin'],
+    ['read', 'Read Only'],
+    ['write', 'Read & Write']
+]);
+
 editor.once('load', () => {
     // GLOBAL VARIABLES
     const isAdmin = editor.call('permissions:admin');
@@ -10,6 +16,7 @@ editor.once('load', () => {
     let collaborators = [];
     let invitations = [];
     let uiRefresh = false;
+    let ownerRendered = false;
     const newCollaborator = {
         id: null,
         user: null,
@@ -26,8 +33,7 @@ editor.once('load', () => {
         inviteSubmit.hidden = false;
         inviteInput.hidden = false;
 
-        // Update number of members
-        membersLabel.text = currentProject.access_level !== 'none' ? `Project\nMembers\n\n${collaborators.length}/64` : '';
+        membersLabel.text = currentProject.access_level !== 'none' ? `${collaborators.length}/64 members` : '';
 
         addMeAsAdminButton.hidden = true;
         addMeAsAdminButton.enabled = false;
@@ -66,20 +72,37 @@ editor.once('load', () => {
             return;
         }  // don't display invitees to non-admin users
 
+        const isOwner = collaborator.username === owner.username;
+        if (isOwner) {
+            if (ownerRendered) {
+                return;
+            }
+            ownerRendered = true;
+        }
+        const isSelf = collaborator.id === config.self.id;
+        const accessLabel = ACCESS_LEVEL_LABELS.get(collaborator.access_level) || 'Read Only';
+
         const parentContainer = new Element({
             class: 'collaborator-container'
         });
-        if (collaborator.id === config.self.id) {
+        if (isSelf) {
             parentContainer.class.add('user-collaborator');
+        }
+        if (isOwner) {
+            parentContainer.class.add('owner-collaborator');
         }
         membersGrid.dom.appendChild(parentContainer.dom);
 
-        // image container (left)
+        const memberCell = new Element({
+            class: 'member-cell'
+        });
+        parentContainer.dom.appendChild(memberCell.dom);
+
         const image = new Element({
             dom: 'img',
             class: 'collaborator-image',
-            height: 62,
-            width: 62
+            height: 34,
+            width: 34
         });
         // if invitation, image url is different
         if (collaborator.inviter_id) {
@@ -87,84 +110,39 @@ editor.once('load', () => {
         } else {
             image.dom.src = `${config.url.api}/users/${collaborator.id}/thumbnail?size=80`;
         }
-        parentContainer.dom.appendChild(image.dom);
+        memberCell.dom.appendChild(image.dom);
 
-        // right container
-        const collaboratorRightContainer = new Element({
-            class: 'collaborator-right-container'
+        const identity = new Element({
+            class: 'collaborator-identity'
         });
-        parentContainer.dom.appendChild(collaboratorRightContainer.dom);
-
-        // first row
-        const firstRow = new Element({
-            class: 'collaborator-first-row'
-        });
-        collaboratorRightContainer.dom.appendChild(firstRow.dom);
+        memberCell.dom.appendChild(identity.dom);
 
         const collaboratorName = new Label({
+            class: 'collaborator-name',
             text: collaborator.inviter_id ? collaborator.email : collaborator.username
         });
-        firstRow.dom.appendChild(collaboratorName.dom);
+        identity.dom.appendChild(collaboratorName.dom);
 
-        const deleteCollaboratorBtn = new Button({ icon: 'E124' });
-
-        if (collaborator.username !== config.self.username) {
-            deleteCollaboratorBtn.enabled = currentProject.access_level === 'admin';  // only allow admins to remove collaborators
-        } else {
-            const configCollaboratorBtn = new Button({ icon: 'E134' });
-            firstRow.dom.appendChild(configCollaboratorBtn.dom);
-
-            deleteCollaboratorBtn.enabled = currentProject.owner !== config.self.username && currentProject.id !== config.project.id;
-
-            configCollaboratorBtn.on('click', () => {
-                window.open(`${config.url.home}/account`, '_blank');
-            });
-        }
-
-        deleteCollaboratorBtn.on('click', () => {
-            if (collaborator.username === config.self.username) {
-                editor.call('picker:project:deleteSelfConfirmation');
-            } else if (collaborator.inviter_id) {
-                // If invitation, remove invitation
-                removeInvitation(collaborator, parentContainer);
-            } else {
-                removeCollaborator(collaborator, parentContainer);
-            }
+        const collaboratorSubtitle = new Label({
+            class: 'collaborator-subtitle',
+            text: isOwner ? 'Project owner' : collaborator.inviter_id ? 'Invited user' : collaborator.full_name || collaborator.email || ''
         });
+        identity.dom.appendChild(collaboratorSubtitle.dom);
 
-        firstRow.dom.appendChild(deleteCollaboratorBtn.dom);
+        const accessCell = new Element({
+            class: 'access-cell'
+        });
+        parentContainer.dom.appendChild(accessCell.dom);
 
-        // second row (dropdown menu or label)
-        if (collaborator.inviter_id || currentUser && (currentUser.id === collaborator.id || currentProject.access_level !== 'admin')) {
-            let displayLabel;
-            switch (collaborator.access_level) {
-                case 'admin': {
-                    displayLabel = 'Admin';
-                    break;
-                }
-                case 'read': {
-                    displayLabel = 'Read Only';
-                    break;
-                }
-                case 'write': {
-                    displayLabel = 'Read & Write';
-                    break;
-                }
-            }
-
-            if (collaborator.inviter_id) {
-                displayLabel = 'Pending';
-            }
-            if (collaborator.organization) {
-                displayLabel = 'Organization';
-            }
-
+        if (isOwner || collaborator.inviter_id || currentUser && (currentUser.id === collaborator.id || currentProject.access_level !== 'admin')) {
             const accessLevelLabel = new Label({
-                text: displayLabel
+                class: isOwner ? ['team-pill', 'owner'] : ['team-pill', 'muted'],
+                text: isOwner ? 'Owner' : collaborator.organization ? 'Organization' : accessLabel
             });
-            collaboratorRightContainer.dom.appendChild(accessLevelLabel.dom);
+            accessCell.dom.appendChild(accessLevelLabel.dom);
         } else {
             const accessLevelDropdown = new SelectInput({
+                class: 'role-select',
                 options: [{
                     v: 'read',
                     t: 'Read Only'
@@ -182,8 +160,57 @@ editor.once('load', () => {
                 updateCollaborator(collaborator, accessLevelDropdown.value);
             });
 
-            collaboratorRightContainer.dom.appendChild(accessLevelDropdown.dom);
+            accessCell.dom.appendChild(accessLevelDropdown.dom);
         }
+
+        const statusLabel = new Label({
+            class: isSelf && !isOwner ? ['team-pill', 'green'] : ['team-pill', 'muted'],
+            text: isOwner ? 'Active' : collaborator.inviter_id ? 'Pending' : isSelf ? 'You' : 'Member'
+        });
+        parentContainer.dom.appendChild(statusLabel.dom);
+
+        const actionsCell = new Element({
+            class: 'actions-cell'
+        });
+        parentContainer.dom.appendChild(actionsCell.dom);
+
+        if (collaborator.username === config.self.username) {
+            const configCollaboratorBtn = new Button({
+                class: 'team-action',
+                icon: 'E134'
+            });
+            actionsCell.dom.appendChild(configCollaboratorBtn.dom);
+
+            configCollaboratorBtn.on('click', () => {
+                window.open(`${config.url.home}/account`, '_blank');
+            });
+        }
+
+        const deleteCollaboratorBtn = new Button({
+            class: 'team-action',
+            icon: 'E124'
+        });
+
+        if (isOwner) {
+            deleteCollaboratorBtn.enabled = false;
+        } else if (collaborator.username !== config.self.username) {
+            deleteCollaboratorBtn.enabled = currentProject.access_level === 'admin';  // only allow admins to remove collaborators
+        } else {
+            deleteCollaboratorBtn.enabled = currentProject.owner !== config.self.username && currentProject.id !== config.project.id;
+        }
+
+        deleteCollaboratorBtn.on('click', () => {
+            if (collaborator.username === config.self.username) {
+                editor.call('picker:project:deleteSelfConfirmation');
+            } else if (collaborator.inviter_id) {
+                // If invitation, remove invitation
+                removeInvitation(collaborator, parentContainer);
+            } else {
+                removeCollaborator(collaborator, parentContainer);
+            }
+        });
+
+        actionsCell.dom.appendChild(deleteCollaboratorBtn.dom);
     };
 
     // main panel
@@ -208,17 +235,10 @@ editor.once('load', () => {
     // holds events that need to be destroyed
     let events = [];
 
-    // Invite Container
     const inviteContainer = new Container({
         class: 'invite-container'
     });
     panel.append(inviteContainer);
-
-    const inviteLabel = new Label({
-        text: 'Invite',
-        class: 'section-label'
-    });
-    inviteContainer.append(inviteLabel);
 
     const inviteInputContainer = new Container({
         class: 'invite-input-container',
@@ -233,7 +253,7 @@ editor.once('load', () => {
 
     const inviteInput = new TextInput({
         enabled: isAdmin,
-        placeholder: 'Type Username or Email Address',
+        placeholder: 'Username or email address',
         class: 'invite-input',
         blurOnEnter: false
     });
@@ -253,16 +273,22 @@ editor.once('load', () => {
 
     inviteInput.on('blur', () => {
         if (inviteInput.value === '') {
-            inviteInput.placeholder = 'Type Username or Email Address';
+            inviteInput.placeholder = 'Username or email address';
         }
     });
 
     const inviteSubmit = new Button({
         enabled: isAdmin,
-        text: 'INVITE',
+        text: 'Invite',
         class: 'invite-submit'
     });
     inviteInputGroup.append(inviteSubmit);
+
+    const membersLabel = new Label({
+        text: '',
+        class: 'members-count'
+    });
+    inviteContainer.append(membersLabel);
 
     const inviteWarning = new Label({
         class: 'invite-warning',
@@ -276,60 +302,19 @@ editor.once('load', () => {
         inviteInput.value = '';
     });
 
-    // Owner
-    const ownerContainer = new Container({
-        class: 'owner-container'
-    });
-    panel.append(ownerContainer);
-
-    const ownerLabel = new Label({
-        text: 'Owner',
-        class: 'section-label'
-    });
-    ownerContainer.append(ownerLabel);
-
-    // Owner Widget
-    const ownerWidgetContainer = new Container({
-        class: 'owner-widget-container'
-    });
-    ownerContainer.append(ownerWidgetContainer);
-
-    const ownerWidget = new Container({ class: 'collaborator-container' });
-    ownerWidgetContainer.append(ownerWidget);
-    ownerWidget.style.width = '307.6px';
-
-    const ownerProfilePic = new Element({
-        dom: 'img',
-        class: 'collaborator-image'
-    });
-    ownerProfilePic.style.width = '62px';
-    ownerProfilePic.style.height = '62px';
-    ownerProfilePic.dom.loading = 'lazy';
-    ownerWidget.dom.appendChild(ownerProfilePic.dom);
-
-    const ownerWidgetRightContainer = new Container({ class: 'collaborator-right-container' });
-    ownerWidget.append(ownerWidgetRightContainer);
-
-    const ownerWidgetFirstRow = new Container({ class: 'collaborator-first-row' });
-    ownerWidgetRightContainer.append(ownerWidgetFirstRow);
-
-    const ownerWidgetName = new Label();
-    ownerWidgetFirstRow.append(ownerWidgetName);
-
-    const ownerWidgetLabel = new Label({ text: 'Owner' });
-    ownerWidgetRightContainer.append(ownerWidgetLabel);
-
-    // Members Container
     const membersContainer = new Container({
         class: 'members-container'
     });
     panel.append(membersContainer);
 
-    const membersLabel = new Label({
-        text: `Organization\nMembers\n\n${collaborators.length}/60`,
-        class: 'section-label'
+    const membersHeader = new Element({
+        class: 'members-header'
     });
-    membersContainer.append(membersLabel);
+    ['Member', 'Access', 'Status', ''].forEach((text) => {
+        const label = new Label({ text });
+        membersHeader.dom.appendChild(label.dom);
+    });
+    membersContainer.dom.appendChild(membersHeader.dom);
 
     const membersGrid = new Element({
         class: 'members-grid',
@@ -564,12 +549,8 @@ editor.once('load', () => {
     // on show
     panel.on('show', () => {
         currentProject = editor.call('picker:project:getCurrent');
-
-        // Load owner UI
-        ownerProfilePic.dom.src = `${config.url.api}/users/${currentProject.owner_id}/thumbnail?size=80`;
-        ownerWidgetName.text = currentProject.owner;
-
         currentProjectPrivate = editor.call('picker:project:getPrivateSetting');
+
         editor.call('users:loadOne', currentProject.owner_id, (res) => {
             owner = res;
 
@@ -577,8 +558,15 @@ editor.once('load', () => {
                 currentUser = owner;
             }
 
+            const refreshTeam = membersGrid.dom.childNodes.length === 0 || uiRefresh;
+            if (refreshTeam) {
+                membersGrid.dom.innerHTML = '';
+                ownerRendered = false;
+                createCollaboratorUI(owner);
+            }
+
             // Only populate first time around
-            if (currentProject.access_level !== 'none' && (membersGrid.dom.childNodes.length === 0 || uiRefresh)) {
+            if (currentProject.access_level !== 'none' && refreshTeam) {
 
                 let currentUserIsCollaborator = false;
                 editor.call('projects:getCollaborators', currentProject, (data) => {
@@ -670,6 +658,7 @@ editor.once('load', () => {
         currentProject = editor.call('picker:project:getCurrent');
         uiRefresh = true;
         membersGrid.dom.innerHTML = '';
+        ownerRendered = false;
         collaborators = [];
         inviteInput.enabled = currentProject.access_level === 'admin';
         inviteSubmit.enabled = currentProject.access_level === 'admin';

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -1,4 +1,4 @@
-import { Element, Label, Button, SelectInput, Container, TextInput } from '@playcanvas/pcui';
+import { Element, Label, Button, Menu, MenuItem, Container, TextInput } from '@playcanvas/pcui';
 
 const ACCESS_LEVEL_LABELS = new Map([
     ['admin', 'Admin'],
@@ -17,6 +17,7 @@ editor.once('load', () => {
     let invitations = [];
     let uiRefresh = false;
     let ownerRendered = false;
+    let activeRoleButton;
     const newCollaborator = {
         id: null,
         user: null,
@@ -141,9 +142,13 @@ editor.once('load', () => {
             });
             accessCell.dom.appendChild(accessLevelLabel.dom);
         } else {
-            const accessLevelDropdown = new SelectInput({
+            const accessLevelDropdown = new Button({
                 class: 'role-select',
-                options: [{
+                text: accessLabel
+            });
+            accessLevelDropdown.on('click', () => {
+                roleMenu.clear();
+                [{
                     v: 'read',
                     t: 'Read Only'
                 }, {
@@ -152,27 +157,26 @@ editor.once('load', () => {
                 }, {
                     v: 'admin',
                     t: 'Admin'
-                }],
-                value: collaborator.access_level
-            });
+                }].forEach((option) => {
+                    roleMenu.append(new MenuItem({
+                        text: option.t,
+                        class: option.v === collaborator.access_level ? 'selected' : '',
+                        onSelect: () => {
+                            accessLevelDropdown.text = option.t;
+                            updateCollaborator(collaborator, option.v);
+                        }
+                    }));
+                });
 
-            accessLevelDropdown.on('change', () => {
-                updateCollaborator(collaborator, accessLevelDropdown.value);
-            });
-            accessLevelDropdown.on('click', () => {
-                if (!accessLevelDropdown.dom.classList.contains('pcui-open')) {
-                    return;
+                if (activeRoleButton && activeRoleButton !== accessLevelDropdown) {
+                    activeRoleButton.class.remove('active');
                 }
+                activeRoleButton = accessLevelDropdown;
+                accessLevelDropdown.class.add('active');
+                roleMenu.hidden = false;
 
-                const list = accessLevelDropdown.dom.querySelector('.pcui-select-input-list');
-                if (!list) {
-                    return;
-                }
-
-                const overflow = list.getBoundingClientRect().bottom - membersGrid.dom.getBoundingClientRect().bottom;
-                if (overflow > 0) {
-                    membersGrid.dom.scrollTop += overflow + 4;
-                }
+                const rect = accessLevelDropdown.dom.getBoundingClientRect();
+                roleMenu.position(rect.left, rect.bottom);
             });
 
             accessCell.dom.appendChild(accessLevelDropdown.dom);
@@ -336,6 +340,15 @@ editor.once('load', () => {
         flex: true
     });
     membersContainer.append(membersGrid);
+
+    const roleMenu = new Menu({ class: ['picker-builds-filter-menu', 'team-role-menu'] });
+    editor.call('layout.root').append(roleMenu);
+    roleMenu.on('hide', () => {
+        if (activeRoleButton) {
+            activeRoleButton.class.remove('active');
+        }
+        activeRoleButton = null;
+    });
 
     const addMeAsAdminButton = new Button({
         class: 'add-me-as-admin',
@@ -637,6 +650,7 @@ editor.once('load', () => {
 
     // on hide
     panel.on('hide', () => {
+        roleMenu.hidden = true;
         destroyEvents();
         editor.call('picker:project:hideAlerts');
 
@@ -671,6 +685,7 @@ editor.once('load', () => {
     // hook to reload UI on project change
     editor.method('picker:team:management:refreshUI', () => {
         currentProject = editor.call('picker:project:getCurrent');
+        roleMenu.hidden = true;
         uiRefresh = true;
         membersGrid.dom.innerHTML = '';
         ownerRendered = false;

--- a/src/editor/pickers/picker-team-management.ts
+++ b/src/editor/pickers/picker-team-management.ts
@@ -159,6 +159,21 @@ editor.once('load', () => {
             accessLevelDropdown.on('change', () => {
                 updateCollaborator(collaborator, accessLevelDropdown.value);
             });
+            accessLevelDropdown.on('click', () => {
+                if (!accessLevelDropdown.dom.classList.contains('pcui-open')) {
+                    return;
+                }
+
+                const list = accessLevelDropdown.dom.querySelector('.pcui-select-input-list');
+                if (!list) {
+                    return;
+                }
+
+                const overflow = list.getBoundingClientRect().bottom - membersGrid.dom.getBoundingClientRect().bottom;
+                if (overflow > 0) {
+                    membersGrid.dom.scrollTop += overflow + 4;
+                }
+            });
 
             accessCell.dom.appendChild(accessLevelDropdown.dom);
         }


### PR DESCRIPTION
### What's Changed
- Modernizes the team member list into a compact table with member, access, status, and actions columns.
- Updates the team error banner and role control styling to match current picker patterns.
- Uses the builds picker menu pattern for role changes so the dropdown renders below the control without shifting the member list.

### Preview
<img width="2124" height="1204" alt="image" src="https://github.com/user-attachments/assets/722d7f1a-9a2a-4d0c-8606-fa542d33ecd6" />

### Manual smoke test
1. Open Project picker -> Team on a project with an owner, members, and pending invitations; expect rows to align under Member, Access, Status, and Actions.
2. As an admin, open a member access menu; expect the menu to appear below the access button with the builds picker dropdown styling.
3. Select a different member role; expect the role label to update and the member list to remain in place.
4. Trigger a user-not-found team error; expect the compact red team error banner to appear and dismiss cleanly.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)