### PR TITLE
refactor: migrate project picker UI to PCUI

### DIFF
--- a/sass/editor/_editor-main.scss
+++ b/sass/editor/_editor-main.scss
@@ -20,6 +20,195 @@ strong {
     @extend .font-bold;
 }
 
+%modern-picker-card {
+    border: 1px solid $border-primary;
+    border-radius: 6px;
+    background-color: rgb(0 0 0 / 8%);
+}
+
+%modern-picker-checkbox {
+    flex: none;
+    appearance: none;
+    position: relative;
+    width: 16px;
+    height: 16px;
+    border: 1px solid $border-primary;
+    border-radius: 3px;
+    background-color: $bcg-darkest;
+    box-sizing: border-box;
+    cursor: pointer;
+    transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
+
+    &:hover {
+        border-color: rgb(255 102 0 / 55%);
+        background-color: rgb(255 102 0 / 8%);
+    }
+
+    &:focus {
+        outline: none;
+        box-shadow: $element-shadow-active;
+    }
+
+    &:checked,
+    &.pcui-boolean-input-ticked {
+        border-color: $text-active;
+        background: $text-active url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.2 6.5 11 12.5 4.5' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") center / 13px 13px no-repeat;
+
+        &::after {
+            display: none;
+        }
+    }
+}
+
+%modern-picker-select {
+    @extend .font-bold;
+
+    margin: 0;
+    border: 1px solid $bcg-darkest;
+    border-radius: 6px;
+    color: $text-secondary;
+    font-size: 12px;
+    box-shadow: none;
+    transition: color 100ms, box-shadow 100ms;
+
+    .pcui-select-input-container-value {
+        border-radius: 6px;
+        background-color: $bcg-dark;
+    }
+
+    .pcui-select-input-value {
+        color: $text-secondary;
+    }
+
+    &:not(.pcui-disabled):hover,
+    &:not(.pcui-disabled):focus {
+        color: $text-primary;
+        box-shadow: $element-shadow-hover;
+    }
+}
+
+%modern-picker-status {
+    flex: 0 0 24px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    border: 1px solid $border-primary;
+    color: $text-dark;
+    background-color: $bcg-darkest;
+    box-sizing: border-box;
+    position: relative;
+
+    &.complete {
+        color: #6fd088;
+        border-color: #3e8c54;
+        background-color: rgb(46 160 67 / 12%);
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 9px;
+            height: 5px;
+            border-bottom: 2px solid currentcolor;
+            border-left: 2px solid currentcolor;
+            box-sizing: border-box;
+            transform: translate(-50%, -60%) rotate(-45deg);
+        }
+    }
+
+    &.error {
+        color: #ff8a8a;
+        border-color: #a83d3d;
+        background-color: rgb(231 76 60 / 12%);
+
+        &::before,
+        &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 11px;
+            height: 2px;
+            background-color: currentcolor;
+        }
+
+        &::before { transform: translate(-50%, -50%) rotate(45deg); }
+        &::after { transform: translate(-50%, -50%) rotate(-45deg); }
+    }
+
+    &.running {
+        border-color: $text-dark;
+        background-color: transparent;
+
+        &::after {
+            content: '';
+            width: 12px;
+            height: 12px;
+            border: 2px solid $text-dark;
+            border-top-color: $text-active;
+            border-radius: 50%;
+            animation: build-status-spin 800ms linear infinite;
+        }
+    }
+}
+
+%modern-picker-badge {
+    @extend .font-regular;
+
+    flex: 0 0 auto;
+    height: 18px;
+    line-height: 18px;
+    padding: 0 6px;
+    border: 1px solid $border-primary;
+    border-radius: 4px;
+    color: $text-dark;
+    background-color: rgb(0 0 0 / 14%);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0;
+
+    &.publish {
+        color: #9dd4ff;
+        border-color: rgb(110 170 220 / 45%);
+    }
+
+    &.download {
+        color: #f3c16f;
+        border-color: rgb(225 166 62 / 45%);
+    }
+
+    &.primary-badge {
+        color: $text-active;
+        border-color: rgb(255 122 35 / 50%);
+    }
+}
+
+%modern-picker-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    line-height: 20px;
+
+    > .name {
+        @extend .font-bold;
+
+        min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 14px;
+        color: $text-primary;
+        margin: 0;
+    }
+}
+
 .noSelect {
     user-select: none;
 }
@@ -4242,11 +4431,10 @@ strong {
 
     // card sections matching the build detail page
     > .form-section {
+        @extend %modern-picker-card;
+
         margin: 0 0 12px;
         padding: 14px 16px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
-        background-color: rgb(0 0 0 / 8%);
 
         &:not(.pcui-hidden) {
             display: flex;
@@ -4406,9 +4594,10 @@ strong {
 
     .pcui-select-input.engine-version-dropdown,
     .pcui-select-input.download-format-dropdown {
+        @extend %modern-picker-select;
+
         width: 100%;
         max-width: 340px;
-        margin: 0;
     }
 
     .pcui-container.options > .pcui-container.field {
@@ -4427,7 +4616,8 @@ strong {
         }
 
         > .pcui-boolean-input {
-            flex: 0 0 auto;
+            @extend %modern-picker-checkbox;
+
             margin: 0;
         }
 
@@ -4693,12 +4883,11 @@ strong {
     }
 
     > .scenes-empty {
+        @extend %modern-picker-card;
+
         margin: 0 0 12px;
         padding: 14px 16px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
         color: $text-dark;
-        background-color: rgb(0 0 0 / 8%);
         box-sizing: border-box;
 
         > .pcui-label {
@@ -4946,127 +5135,17 @@ strong {
 
     // shared build-status indicator (list rows + detail header)
     .status {
-        flex: 0 0 24px;
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 14px;
-        border: 1px solid $border-primary;
-        color: $text-dark;
-        background-color: $bcg-darkest;
-        box-sizing: border-box;
-        position: relative;
-
-        &.complete {
-            color: #6fd088;
-            border-color: #3e8c54;
-            background-color: rgb(46 160 67 / 12%);
-
-            &::before {
-                content: '';
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                width: 9px;
-                height: 5px;
-                border-bottom: 2px solid currentcolor;
-                border-left: 2px solid currentcolor;
-                box-sizing: border-box;
-                transform: translate(-50%, -60%) rotate(-45deg);
-            }
-        }
-
-        &.error {
-            color: #ff8a8a;
-            border-color: #a83d3d;
-            background-color: rgb(231 76 60 / 12%);
-
-            &::before,
-            &::after {
-                content: '';
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                width: 11px;
-                height: 2px;
-                background-color: currentcolor;
-            }
-
-            &::before { transform: translate(-50%, -50%) rotate(45deg); }
-            &::after { transform: translate(-50%, -50%) rotate(-45deg); }
-        }
-
-        &.running {
-            border-color: $text-dark;
-            background-color: transparent;
-
-            &::after {
-                content: '';
-                width: 12px;
-                height: 12px;
-                border: 2px solid $text-dark;
-                border-top-color: $text-active;
-                border-radius: 50%;
-                animation: build-status-spin 800ms linear infinite;
-            }
-        }
+        @extend %modern-picker-status;
     }
 
     // shared badge pills (list rows + detail header)
     .badge {
-        @extend .font-regular;
-
-        flex: 0 0 auto;
-        height: 18px;
-        line-height: 18px;
-        padding: 0 6px;
-        border: 1px solid $border-primary;
-        border-radius: 4px;
-        color: $text-dark;
-        background-color: rgb(0 0 0 / 14%);
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0;
-
-        &.publish {
-            color: #9dd4ff;
-            border-color: rgb(110 170 220 / 45%);
-        }
-
-        &.download {
-            color: #f3c16f;
-            border-color: rgb(225 166 62 / 45%);
-        }
-
-        &.primary-badge {
-            color: $text-active;
-            border-color: rgb(255 122 35 / 50%);
-        }
+        @extend %modern-picker-badge;
     }
 
     // shared name + badges row (list rows + detail header)
     .name-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        min-width: 0;
-        line-height: 20px;
-
-        > .name {
-            @extend .font-bold;
-
-            min-width: 0;
-            max-width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            font-size: 14px;
-            color: $text-primary;
-            margin: 0;
-        }
+        @extend %modern-picker-name-row;
     }
 
     > .primary-build-summary {
@@ -5631,104 +5710,11 @@ strong {
     }
 
     .status {
-        flex: 0 0 24px;
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 14px;
-        border: 1px solid $border-primary;
-        color: $text-dark;
-        background-color: $bcg-darkest;
-        box-sizing: border-box;
-        position: relative;
-
-        &.complete {
-            color: #6fd088;
-            border-color: #3e8c54;
-            background-color: rgb(46 160 67 / 12%);
-
-            &::before {
-                content: '';
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                width: 9px;
-                height: 5px;
-                border-bottom: 2px solid currentcolor;
-                border-left: 2px solid currentcolor;
-                box-sizing: border-box;
-                transform: translate(-50%, -60%) rotate(-45deg);
-            }
-        }
-
-        &.error {
-            color: #ff8a8a;
-            border-color: #a83d3d;
-            background-color: rgb(231 76 60 / 12%);
-
-            &::before,
-            &::after {
-                content: '';
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                width: 11px;
-                height: 2px;
-                background-color: currentcolor;
-            }
-
-            &::before { transform: translate(-50%, -50%) rotate(45deg); }
-            &::after { transform: translate(-50%, -50%) rotate(-45deg); }
-        }
-
-        &.running {
-            border-color: $text-dark;
-            background-color: transparent;
-
-            &::after {
-                content: '';
-                width: 12px;
-                height: 12px;
-                border: 2px solid $text-dark;
-                border-top-color: $text-active;
-                border-radius: 50%;
-                animation: build-status-spin 800ms linear infinite;
-            }
-        }
+        @extend %modern-picker-status;
     }
 
     .badge {
-        @extend .font-regular;
-
-        flex: 0 0 auto;
-        height: 18px;
-        line-height: 18px;
-        padding: 0 6px;
-        border: 1px solid $border-primary;
-        border-radius: 4px;
-        color: $text-dark;
-        background-color: rgb(0 0 0 / 14%);
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0;
-
-        &.publish {
-            color: #9dd4ff;
-            border-color: rgb(110 170 220 / 45%);
-        }
-
-        &.download {
-            color: #f3c16f;
-            border-color: rgb(225 166 62 / 45%);
-        }
-
-        &.primary-badge {
-            color: $text-active;
-            border-color: rgb(255 122 35 / 50%);
-        }
+        @extend %modern-picker-badge;
     }
 
     .name-row {
@@ -6396,11 +6382,10 @@ strong {
     }
 
     & > .project-settings {
+        @extend %modern-picker-card;
+
         margin: 0 0 12px;
         padding: 14px 16px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
-        background-color: rgb(0 0 0 / 8%);
 
         &:not(.pcui-hidden) {
             display: flex;
@@ -6570,11 +6555,10 @@ strong {
     }
 
     & > .locked-container {
+        @extend %modern-picker-card;
+
         margin: 0 0 12px;
         padding: 14px 16px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
-        background-color: rgb(0 0 0 / 8%);
 
         &:not(.pcui-hidden) {
             display: flex;
@@ -6790,12 +6774,11 @@ strong {
     }
 
     > .invite-container {
+        @extend %modern-picker-card;
+
         flex-shrink: 0;
         margin: 0 0 12px;
         padding: 10px 12px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
-        background-color: rgb(0 0 0 / 8%);
 
         &:not(.pcui-hidden) {
             display: flex;
@@ -6914,11 +6897,10 @@ strong {
     }
 
     > .members-container {
+        @extend %modern-picker-card;
+
         min-height: 0;
         margin: 0 0 12px;
-        border: 1px solid $border-primary;
-        border-radius: 6px;
-        background-color: rgb(0 0 0 / 8%);
         overflow: hidden;
 
         &:not(.pcui-hidden) {

--- a/sass/editor/_editor-version-control-diff.scss
+++ b/sass/editor/_editor-version-control-diff.scss
@@ -232,33 +232,10 @@ $vc-add-edge: #3fb950;
         // .pcui-button): rounded $bcg-dark chip with a $bcg-darkest outline that lifts
         // to primary text + shadow on hover
         > .pcui-select-input {
-            @extend .font-bold;
+            @extend %modern-picker-select;
 
             flex: none;
             width: 110px;
-            margin: 0;
-            border: 1px solid $bcg-darkest;
-            border-radius: 6px;
-            color: $text-secondary;
-            font-size: 12px;
-            box-shadow: none;
-            transition: color 100ms, box-shadow 100ms;
-
-            // pcui paints the fill (and clips corners) on the inner value box
-            .pcui-select-input-container-value {
-                border-radius: 6px;
-                background-color: $bcg-dark;
-            }
-
-            .pcui-select-input-value {
-                color: $text-secondary;
-            }
-
-            &:not(.pcui-disabled):hover,
-            &:not(.pcui-disabled):focus {
-                color: $text-primary;
-                box-shadow: $element-shadow-hover;
-            }
         }
     }
 

--- a/sass/editor/_editor-version-control-picker.scss
+++ b/sass/editor/_editor-version-control-picker.scss
@@ -34,32 +34,7 @@
 
 // rounded checkbox shared by the history compare list and the vc dialogs
 %vc-checkbox {
-    flex: none;
-    appearance: none;
-    position: relative;
-    width: 16px;
-    height: 16px;
-    border: 1px solid $border-primary;
-    border-radius: 3px;
-    background-color: $bcg-darkest;
-    box-sizing: border-box;
-    cursor: pointer;
-    transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
-
-    &:hover {
-        border-color: rgb(255 102 0 / 55%);
-        background-color: rgb(255 102 0 / 8%);
-    }
-
-    &:focus {
-        outline: none;
-        box-shadow: $element-shadow-active;
-    }
-
-    &:checked {
-        border-color: $text-active;
-        background: $text-active url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.2 6.5 11 12.5 4.5' fill='none' stroke='%23fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") center / 13px 13px no-repeat;
-    }
+    @extend %modern-picker-checkbox;
 }
 
 .pcui-container.picker-vc {

--- a/src/editor/pickers/picker-project.ts
+++ b/src/editor/pickers/picker-project.ts
@@ -1,7 +1,5 @@
 import { Button, Container, Element, Label, Overlay, Panel } from '@playcanvas/pcui';
 
-import { LegacyList } from '@/common/ui/list';
-import { LegacyListItem } from '@/common/ui/list-item';
 import { bytesToHuman } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -440,8 +438,11 @@ editor.once('load', () => {
     });
 
     // menu
-    const list = new LegacyList();
-    leftPanel.dom.appendChild(list.element);
+    const list = new Container({
+        dom: 'ul',
+        class: ['ui-list', 'selectable']
+    });
+    leftPanel.dom.appendChild(list.dom);
 
     // project CMS button
     const projectCMSButton = new Button({
@@ -654,7 +655,21 @@ editor.once('load', () => {
 
     // register new panel / menu option
     editor.method('picker:project:registerMenu', (name, title, panel, displayName = '') => {
-        const menuItem = new LegacyListItem({ text: MENU_LABELS.get(name) || displayName || name });
+        const menuItem = new Container({
+            dom: 'li',
+            class: 'ui-list-item'
+        }) as Container & { text: string };
+        const menuItemText = document.createElement('span');
+        Object.defineProperty(menuItem, 'text', {
+            get() {
+                return menuItemText.textContent;
+            },
+            set(value: string) {
+                menuItemText.textContent = value;
+            }
+        });
+        menuItem.text = MENU_LABELS.get(name) || displayName || name;
+        menuItem.dom.appendChild(menuItemText);
 
         if (title === 'PROJECT SETTINGS') {
             projectSettingsListMenu = menuItem;

--- a/src/editor/pickers/picker-publish-new.ts
+++ b/src/editor/pickers/picker-publish-new.ts
@@ -2,8 +2,6 @@ import type { EventHandle } from '@playcanvas/observer';
 import { BooleanInput, Button, Container, Element, Label, Progress, SelectInput, TextAreaInput, TextInput } from '@playcanvas/pcui';
 
 import { tooltip, tooltipSimpleItem } from '@/common/tooltips';
-import { LegacyList } from '@/common/ui/list';
-import { LegacyListItem } from '@/common/ui/list-item';
 import { convertDatetime } from '@/common/utils';
 import { config } from '@/editor/config';
 
@@ -490,8 +488,10 @@ editor.once('load', () => {
     selectAllGroup.append(selectAll);
 
     // scenes container
-    const sceneList = new LegacyList();
-    sceneList.class.add('scene-list');
+    const sceneList = new Container({
+        dom: 'ul',
+        class: ['ui-list', 'scene-list']
+    });
     containerScenes.append(sceneList);
 
     const containerNoScenes = new Container({
@@ -714,8 +714,13 @@ editor.once('load', () => {
     };
 
     const createSceneItem = function (scene: any) {
-        const row: any = new LegacyListItem();
-        row.element.id = `picker-scene-${scene.id}`;
+        const row: any = new Container({
+            dom: 'li',
+            id: `picker-scene-${scene.id}`,
+            class: 'ui-list-item'
+        });
+        const rowText = document.createElement('span');
+        row.dom.appendChild(rowText);
         row.sceneId = scene.id;
 
         sceneList.append(row);
@@ -736,7 +741,7 @@ editor.once('load', () => {
             class: 'primary-tooltip-anchor'
         });
         primary.dom.appendChild(tooltipAnchor.dom);
-        row.element.appendChild(primary.dom);
+        row.append(primary);
 
         primary.on('click', () => {
             if (!editor.call('permissions:write')) {
@@ -771,18 +776,18 @@ editor.once('load', () => {
             text: scene.name,
             class: 'name'
         });
-        row.element.appendChild(name.dom);
+        row.append(name);
 
         // scene date
         const date = new Label({
             text: convertDatetime(scene.modified),
             class: 'date'
         });
-        row.element.appendChild(date.dom);
+        row.append(date);
 
         // selection
         const select = new BooleanInput();
-        row.element.appendChild(select.dom);
+        row.append(select);
 
         // if selectAll changes then change this too
         events.push(selectAll.on('change', (value) => {
@@ -849,7 +854,7 @@ editor.once('load', () => {
 
         destroyTooltips();
         destroyEvents();
-        sceneList.element.innerHTML = '';
+        sceneList.clear();
         sortScenes(scenes);
         containerScenes.hidden = !scenes.length;
         containerNoScenes.hidden = !containerScenes.hidden;
@@ -879,7 +884,7 @@ editor.once('load', () => {
         labelNoScenes.hidden = true;
         loadingScenes.hidden = false;
         progressBar.hidden = false;
-        sceneList.element.innerHTML = '';
+        sceneList.clear();
         inputName.value = config.project.name;
         inputDescription.value = config.project.description;
         inputVersion.value = '';

--- a/test-suite/test/ui/basic.test.ts
+++ b/test-suite/test/ui/basic.test.ts
@@ -55,9 +55,9 @@ test.describe('create/delete', () => {
         expect(await capture('delete-project', page, async () => {
             await page.goto(editorBlankUrl(), { waitUntil: 'networkidle' });
             await page.getByText(projectName).first().click();
-            await page.getByRole('button', { name: 'DELETE PROJECT' }).click();
-            await page.getByRole('textbox').nth(4).fill(projectName);
-            await page.getByRole('button', { name: 'DELETE', exact: true }).click();
+            await page.locator('#delete-project-button').click();
+            await page.locator('.picker-delete-project .form-group--input input').fill(projectName);
+            await page.locator('.picker-delete-project .delete-project-button').click();
         })).toStrictEqual([]);
     });
 });
@@ -99,7 +99,7 @@ test.describe('export/import', () => {
             // save export project
             const downloadPagePromise = page.waitForEvent('popup');
             const downloadPromise = page.waitForEvent('download');
-            await page.getByRole('button', { name: 'EXPORT PROJECT' }).click();
+            await page.getByRole('button', { name: /Export Project/ }).click();
             await downloadPagePromise;
             const download = await downloadPromise;
             await download.saveAs(exportPath);
@@ -130,9 +130,9 @@ test.describe('export/import', () => {
         expect(await capture('delete-imported-project', page, async () => {
             await page.goto(editorBlankUrl(), { waitUntil: 'networkidle' });
             await page.getByText(projectName).first().click();
-            await page.getByRole('button', { name: 'DELETE PROJECT' }).click();
-            await page.getByRole('textbox').nth(4).fill(projectName);
-            await page.getByRole('button', { name: 'DELETE', exact: true }).click();
+            await page.locator('#delete-project-button').click();
+            await page.locator('.picker-delete-project .form-group--input input').fill(projectName);
+            await page.locator('.picker-delete-project .delete-project-button').click();
         })).toStrictEqual([]);
     });
 });


### PR DESCRIPTION
### What changed
- Replace the remaining project picker list rows with PCUI-backed structure.
- Consolidate shared modern picker styles for card shells, badges, status icons, checkboxes, and selects.
- Reuse the shared checkbox and dropdown styling in build settings and version control controls.

### Manual smoke test
1. Open the project picker and switch through Project settings, Scenes, Builds & Publish, Team, and Version control; expect each panel to keep the same layout and styling.
2. Open Builds & Publish, then open Publish or Download; expect Build settings checkboxes and dropdowns to match the modern picker controls.
3. Open Version Control compare and diff views; expect compare checkboxes and diff dropdowns to keep the same shared styling.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)