### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.20.1",
+        "playcanvas": "2.20.2",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -8751,9 +8751,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.1.tgz",
-      "integrity": "sha512-xWa7fwX54J0abFbTfmIhycSJEVPHarrGDWa3mgEh7ef8w+MPWOdB/vL0hNXXp/SqA1bU9TEmI6tx+V4OLDv/6Q==",
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.2.tgz",
+      "integrity": "sha512-v17Q6rmMIK/Xc9w8ywKXtPE0qL34LxDvVLDV0ZjHNjkPapN0LKODx+z7jkJuyHzcPn5fFDsp5gCBsZgQDp7CPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.20.1",
+    "playcanvas": "2.20.2",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
### What's Changed
- Update PlayCanvas engine from 2.20.1 to 2.20.2.
- Refresh package lock metadata for the new tarball.

### Manual smoke test
1. Open the editor and load a project scene; expect the viewport to render.
2. Launch the project; expect the launch page to start without runtime errors.

### Checks
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)