### PR TITLE
chore: update playcanvas engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.20.2",
+        "playcanvas": "2.20.6",
         "postcss": "8.5.12",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",
@@ -10137,9 +10137,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.2.tgz",
-      "integrity": "sha512-v17Q6rmMIK/Xc9w8ywKXtPE0qL34LxDvVLDV0ZjHNjkPapN0LKODx+z7jkJuyHzcPn5fFDsp5gCBsZgQDp7CPA==",
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.20.6.tgz",
+      "integrity": "sha512-Dc0jlnjL782G9DhU+dT6UyxcnKA305xSCwZYTXpn2Ohx+6GXisCknYvog50b2FgMb+OPSY7SqBWMVrSsgvUtKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "0.47.0",
     "monaco-themes": "0.4.8",
     "ot-text": "github:playcanvas/ot-text",
-    "playcanvas": "2.20.2",
+    "playcanvas": "2.20.6",
     "postcss": "8.5.12",
     "rollup": "4.59.0",
     "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
Bumps the `playcanvas` engine from `2.20.2` to `2.20.6`.

Release notes: https://github.com/playcanvas/engine/releases