### PR TITLE
fix(inspector): stop multiple tooltips stacking in shared tooltip

### DIFF
--- a/src/common/pcui/element/element-tooltip.ts
+++ b/src/common/pcui/element/element-tooltip.ts
@@ -20,6 +20,9 @@ class Tooltip extends Container {
         }
     >();
 
+    // the single container currently shown; the singleton shows one at a time (gh 2133)
+    private _shown: Container | null = null;
+
     /**
      * Creates new tooltip.
      *
@@ -153,7 +156,6 @@ class Tooltip extends Container {
 
         const events = [];
         let timeout = null;
-        let appended = false;
 
         const defer = () => {
             if (timeout) {
@@ -170,10 +172,16 @@ class Tooltip extends Container {
 
         const hover = () => {
             defer().then(() => {
+                // drop whatever was shown before. a field destroyed while its tooltip is
+                // up never fires hoverend, so its container would otherwise linger and
+                // stack with the next one shown (gh 2133)
+                if (this._shown && this._shown !== container) {
+                    this.remove(this._shown);
+                }
+                this._shown = container;
                 this.hidden = false;
-                if (!appended) {
+                if (container.parent !== this) {
                     this.append(container);
-                    appended = true;
                 }
                 this._realign(align, horz, vert);
             });
@@ -181,11 +189,13 @@ class Tooltip extends Container {
 
         const hoverend = () => {
             defer().then(() => {
-                this.hidden = true;
-                if (appended) {
-                    this.remove(container);
-                    appended = false;
+                // a later hover may have taken the singleton over; leave that one alone
+                if (this._shown !== container) {
+                    return;
                 }
+                this.hidden = true;
+                this.remove(container);
+                this._shown = null;
             });
         };
 
@@ -229,6 +239,9 @@ class Tooltip extends Container {
         events.forEach((evt: EventHandle) => evt.unbind());
         arrow.remove();
         this.remove(container);
+        if (this._shown === container) {
+            this._shown = null;
+        }
         this._targets.delete(target);
 
         return this;


### PR DESCRIPTION
Closes #2133

## Problem

After some time working in the editor, multiple reference tooltips start appearing stacked when hovering over inspector fields (see #2133).

The inspector's reference tooltips all share a single `Tooltip` singleton (`#layout-tooltip`). On hover, each field appends its own content container into the singleton and shows it. When you switch entities, the old field is torn down **without a mouseout**, so `hoverend` never fires and the field's container is never removed. Over a session these orphaned containers pile up inside the one singleton and render stacked.

Diagnostics confirmed both visible boxes were `.tooltip-reference` elements inside the same `#layout-tooltip`, with stale content (`clearColorBuffer` from a Camera, `type` from a Light) while the inspector showed an unrelated component.

## Fix

Enforce the missing invariant directly on the singleton — **it shows at most one content container at a time** — in `src/common/pcui/element/element-tooltip.ts`:

- `hover` removes whatever was shown before (`_shown`) prior to appending the new container, and checks `container.parent !== this` instead of a per-closure `appended` flag, so it is immune to stale flags.
- `hoverend` bails if a later hover has taken the singleton over (`_shown !== container`), which also fixes a pre-existing race where moving between fields could hide the wrong tooltip.
- `detach` clears `_shown` when it held the detached container.

This does not depend on fields emitting `destroy` on teardown (they don't, on entity switch), so any lingering container is cleared on the next hover and two can never coexist.

## Testing

- `npm run typecheck` clean.
- Manual: reproduced the stacked tooltips by flipping selection while hovering an inspector field; after the change only one tooltip is ever shown.