### PR TITLE
fix(launch): skip script concatenation for projects with esm scripts

### DIFF
--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -81,7 +81,10 @@ editor.once('load', () => {
             query.push('debug=true');
         }
 
-        if (launchOptions.concatenate) {
+        // concatenation is a classic-scripts-only backend feature; the concatenated-scripts
+        // endpoint times out (504) for projects containing esm (.mjs) scripts, which hangs the
+        // launcher, so skip it when any esm script is present
+        if (launchOptions.concatenate && !editor.call('assets:list').some(a => editor.call('assets:isModule', a))) {
             query.push('concatenateScripts=true');
         }
 


### PR DESCRIPTION
## Problem

Launching with **Concatenate Scripts (Classic)** enabled (`concatenateScripts=true`) hangs the launcher — it never finishes loading — for any project that contains ESM (`.mjs`) scripts.

Script concatenation is a classic-scripts-only backend feature. When the project also has ESM scripts, the `/api/projects/:id/concatenated-scripts/scripts.js` endpoint times out:

```
Failed to load resource: the server responded with a status of 504 ()
Script: .../concatenated-scripts/scripts.js?branchId=... failed to load
```

Every preloaded classic script points at that URL, so the engine's preload blocks on the failing request and the loading screen stalls until the gateway times out.

## Fix

Guard `concatenateScripts=true` at its single source (`launchApp` in `viewport-launch.ts`): don't request concatenation when the project contains any ESM script. Evaluated fresh on each launch, so it tracks scripts added/removed mid-session, and the `&&` short-circuits so the asset scan only runs when the option is checked.

## Notes / trade-offs

- Mixed classic+ESM projects lose classic-script concatenation entirely — forced by the backend, which 504s on the whole bundle when any ESM script is present.
- A hand-typed `?concatenateScripts=true` URL still bypasses this; the launcher can't reliably detect ESM before it routes assets. The real cure there is the backend not 504-ing.

## Testing

- `eslint` clean on the changed file; `typecheck` introduces no new errors (pre-existing baseline unchanged).
- Not exercised end-to-end (requires a project with ESM scripts against the live launch backend).