### PR TITLE
feat(mcp): restore built-in MCP connection (#2149) + launch-page runtime peer

### DIFF
--- a/sass/editor.scss
+++ b/sass/editor.scss
@@ -10,6 +10,7 @@
 @import 'editor/editor-version-control-merge';
 @import 'editor/editor-layout';
 @import 'editor/editor-left-toolbar';
+@import 'editor/editor-mcp';
 @import 'editor/editor-console';
 @import 'editor/editor-hierarchy-panel';
 @import 'editor/editor-assets-panel';

--- a/sass/editor/_editor-mcp.scss
+++ b/sass/editor/_editor-mcp.scss
@@ -1,0 +1,81 @@
+#layout-toolbar > .pcui-button.mcp {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#layout-toolbar > .pcui-button.mcp .mcp-icon {
+    display: block;
+    width: 22px;
+    height: 22px;
+}
+
+.mcp-popover {
+    position: fixed; // centered on the toolbar button in toolbar.ts
+    width: 220px;
+    z-index: 402; // above #layout-toolbar (400) and PCUI Menu (401)
+    background-color: $bcg-primary;
+    border: 1px solid $border-primary;
+    border-radius: 2px;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+
+    .mcp-row {
+        display: flex;
+        align-items: center;
+        padding: 4px 10px;
+        margin: 0; // override pcui default element margin (6px)
+    }
+
+    .mcp-row > * {
+        margin: 0; // override pcui default element margin on labels/fields
+    }
+
+    .mcp-row:first-child {
+        padding-top: 9px; // a little breathing room below the header
+    }
+
+    .mcp-row-label {
+        width: 74px;
+        flex-shrink: 0;
+        color: $text-dark;
+        font-size: 12px;
+    }
+
+    .mcp-field {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .mcp-status-value {
+        position: relative;
+        padding-left: 16px;
+        color: $text-secondary;
+        font-size: 12px;
+
+        &::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background-color: $error;
+        }
+
+        &.mcp-connecting::before {
+            background-color: #f4a62a;
+        }
+
+        &.mcp-connected::before {
+            background-color: #4ea86a;
+        }
+    }
+
+    .mcp-toggle {
+        display: block;
+        width: calc(100% - 20px);
+        margin: 3px 10px 11px;
+    }
+}

--- a/sass/editor/_editor-mcp.scss
+++ b/sass/editor/_editor-mcp.scss
@@ -73,6 +73,15 @@
         }
     }
 
+    .mcp-hint {
+        padding: 2px 10px 0;
+        margin: 0;
+        color: $text-dark;
+        font-size: 11px;
+        line-height: 1.4;
+        white-space: normal;
+    }
+
     .mcp-toggle {
         display: block;
         width: calc(100% - 20px);

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -300,6 +300,11 @@ import './toolbar/toolbar-lightmapper';
 import './toolbar/toolbar-publish';
 import './toolbar/toolbar-code-editor';
 
+// mcp
+import './mcp/connection';
+import './mcp/methods';
+import './mcp/toolbar';
+
 // viewport controls
 import './viewport-controls/viewport-scene';
 import './viewport-controls/viewport-launch';

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -4,15 +4,19 @@ const DEFAULT_PORT = 52000;
 const RETRY_TIMEOUT = 1000;
 
 type Status = 'connecting' | 'connected' | 'disconnected';
-type Method = (...args: any[]) => { data?: any; error?: string } | Promise<{ data?: any; error?: string }>;
+type Role = 'editor' | 'runtime';
+type MethodResult = { data?: any; error?: string; meta?: Record<string, any> };
+type Method = (...args: any[]) => MethodResult | Promise<MethodResult>;
 
-const log = (msg: string) => console.log(`%c[MCP] ${msg}`, 'color:#f60');
-const error = (msg: unknown) => console.error(`%c[MCP] ${msg}`, 'color:#f60');
+const log = (msg: string) => console.log(`[MCP] ${msg}`);
+const error = (msg: unknown) => console.error(`[MCP] ${msg}`);
 
 /**
- * WebSocket client that connects the editor to the external MCP server and dispatches its
+ * WebSocket client that connects the page to the external MCP server and dispatches its
  * tool requests to registered handlers. Same wire protocol as the former Chrome extension:
- * `{ id, name, args }` in, `{ id, res }` out.
+ * `{ id, name, args }` in, `{ id, res }` out. On open it announces its role
+ * (`{ register: 'editor' | 'runtime' }`) so the server routes edit-time vs runtime
+ * methods to the correct peer.
  */
 class MCPConnection extends Events {
     private _ws: WebSocket | null = null;
@@ -23,8 +27,18 @@ class MCPConnection extends Events {
 
     private _status: Status = 'disconnected';
 
+    private _port: number = DEFAULT_PORT;
+
+    private _role: Role = 'editor';
+
+    private _forceClosed = false;
+
     get status() {
         return this._status;
+    }
+
+    get port() {
+        return this._port;
     }
 
     private _setStatus(status: Status) {
@@ -33,57 +47,77 @@ class MCPConnection extends Events {
     }
 
     /**
+     * Connect to the MCP server and keep the connection alive. If the socket drops
+     * unexpectedly (server restart, transient network, background-tab throttling) we retry
+     * automatically until it reconnects or disconnect() is called.
+     *
      * @param port - The MCP server port to connect to.
+     * @param role - The peer role announced to the server.
      */
-    connect(port: number = DEFAULT_PORT) {
-        const address = `ws://localhost:${port}`;
+    connect(port: number = DEFAULT_PORT, role: Role = 'editor') {
+        this._port = port;
+        this._role = role;
+        this._forceClosed = false;
+
         this._setStatus('connecting');
-        log(`Connecting to ${address}`);
+        log(`Connecting to ws://localhost:${port}`);
 
         if (this._connectTimeout) {
             clearTimeout(this._connectTimeout);
+            this._connectTimeout = null;
         }
 
-        this._connect(address, () => {
-            this._ws!.onclose = (evt) => {
-                if (evt.reason === 'FORCE') {
-                    return;
-                }
-                this._setStatus('disconnected');
-                log('Disconnected');
-            };
-            this._setStatus('connected');
-            log('Connected');
-        });
+        this._open();
     }
 
     /**
-     * @param address - The WebSocket address to connect to.
-     * @param resolve - Called once the connection is established.
+     * Open a single WebSocket and wire up auto-reconnect on unexpected close.
      */
-    private _connect(address: string, resolve: () => void) {
-        this._ws = new WebSocket(address);
-        this._ws.onopen = () => resolve();
-        this._ws.onmessage = async (event) => {
+    private _open() {
+        const ws = new WebSocket(`ws://localhost:${this._port}`);
+        this._ws = ws;
+
+        ws.onopen = () => {
+            // announce our role so the server can route edit-time vs runtime methods
+            ws.send(JSON.stringify({ register: this._role }));
+            this._setStatus('connected');
+            log('Connected');
+        };
+        ws.onmessage = async (event) => {
             try {
                 const { id, name, args } = JSON.parse(event.data);
                 const res = await this.call(name, ...args);
-                this._ws?.send(JSON.stringify({ id, res }));
+                ws.send(JSON.stringify({ id, res }));
             } catch (e) {
                 error(e);
             }
         };
-        this._ws.onclose = () => {
+        ws.onerror = () => {
+            // a socket error is always followed by a close event, which drives the
+            // reconnect below; swallow it here so it isn't surfaced as unhandled
+        };
+        ws.onclose = (evt) => {
+            // a deliberate disconnect() (FORCE) must never reconnect
+            if (this._forceClosed || evt?.reason === 'FORCE') {
+                return;
+            }
+            this._setStatus('connecting');
+            log('Disconnected; reconnecting');
+            if (this._connectTimeout) {
+                clearTimeout(this._connectTimeout);
+            }
             this._connectTimeout = setTimeout(() => {
                 this._connectTimeout = null;
-                this._connect(address, resolve);
+                this._open();
             }, RETRY_TIMEOUT);
         };
     }
 
     disconnect() {
+        this._forceClosed = true;
         if (this._connectTimeout) {
             clearTimeout(this._connectTimeout);
+            this._connectTimeout = null;
         }
         if (this._ws) {
             this._ws.close(1000, 'FORCE');
@@ -110,16 +144,21 @@ class MCPConnection extends Events {
      * @param args - The arguments to pass to the method.
      * @returns The handler result.
      */
-    call(name: string, ...args: any[]) {
-        return this._methods.get(name)?.(...args);
+    call(name: string, ...args: any[]): MethodResult | Promise<MethodResult> {
+        const fn = this._methods.get(name);
+        if (!fn) {
+            return { error: `Unknown method: ${name}. The editor may be outdated; reload the page and reconnect.` };
+        }
+        return fn(...args);
     }
 }
 
 const mcp = new MCPConnection();
 
-editor.method('mcp:connect', (port?: number) => mcp.connect(port));
+editor.method('mcp:connect', (port?: number, role?: Role) => mcp.connect(port, role));
 editor.method('mcp:disconnect', () => mcp.disconnect());
 editor.method('mcp:status', () => mcp.status);
+editor.method('mcp:port', () => mcp.port);
 mcp.on('status', (status: Status) => editor.emit('mcp:status', status));
 
 export { mcp, DEFAULT_PORT };

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -1,0 +1,125 @@
+import { Events } from '@playcanvas/observer';
+
+const DEFAULT_PORT = 52000;
+const RETRY_TIMEOUT = 1000;
+
+type Status = 'connecting' | 'connected' | 'disconnected';
+type Method = (...args: any[]) => { data?: any; error?: string } | Promise<{ data?: any; error?: string }>;
+
+const log = (msg: string) => console.log(`%c[MCP] ${msg}`, 'color:#f60');
+const error = (msg: unknown) => console.error(`%c[MCP] ${msg}`, 'color:#f60');
+
+/**
+ * WebSocket client that connects the editor to the external MCP server and dispatches its
+ * tool requests to registered handlers. Same wire protocol as the former Chrome extension:
+ * `{ id, name, args }` in, `{ id, res }` out.
+ */
+class MCPConnection extends Events {
+    private _ws: WebSocket | null = null;
+
+    private _methods = new Map<string, Method>();
+
+    private _connectTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    private _status: Status = 'disconnected';
+
+    get status() {
+        return this._status;
+    }
+
+    private _setStatus(status: Status) {
+        this._status = status;
+        this.emit('status', status);
+    }
+
+    /**
+     * @param port - The MCP server port to connect to.
+     */
+    connect(port: number = DEFAULT_PORT) {
+        const address = `ws://localhost:${port}`;
+        this._setStatus('connecting');
+        log(`Connecting to ${address}`);
+
+        if (this._connectTimeout) {
+            clearTimeout(this._connectTimeout);
+        }
+
+        this._connect(address, () => {
+            this._ws!.onclose = (evt) => {
+                if (evt.reason === 'FORCE') {
+                    return;
+                }
+                this._setStatus('disconnected');
+                log('Disconnected');
+            };
+            this._setStatus('connected');
+            log('Connected');
+        });
+    }
+
+    /**
+     * @param address - The WebSocket address to connect to.
+     * @param resolve - Called once the connection is established.
+     */
+    private _connect(address: string, resolve: () => void) {
+        this._ws = new WebSocket(address);
+        this._ws.onopen = () => resolve();
+        this._ws.onmessage = async (event) => {
+            try {
+                const { id, name, args } = JSON.parse(event.data);
+                const res = await this.call(name, ...args);
+                this._ws?.send(JSON.stringify({ id, res }));
+            } catch (e) {
+                error(e);
+            }
+        };
+        this._ws.onclose = () => {
+            this._connectTimeout = setTimeout(() => {
+                this._connectTimeout = null;
+                this._connect(address, resolve);
+            }, RETRY_TIMEOUT);
+        };
+    }
+
+    disconnect() {
+        if (this._connectTimeout) {
+            clearTimeout(this._connectTimeout);
+        }
+        if (this._ws) {
+            this._ws.close(1000, 'FORCE');
+            this._ws = null;
+        }
+        this._setStatus('disconnected');
+        log('Disconnected');
+    }
+
+    /**
+     * @param name - The name of the method to register.
+     * @param fn - The handler to call when the method is requested.
+     */
+    method(name: string, fn: Method) {
+        if (this._methods.get(name)) {
+            error(`Method already exists: ${name}`);
+            return;
+        }
+        this._methods.set(name, fn);
+    }
+
+    /**
+     * @param name - The name of the method to call.
+     * @param args - The arguments to pass to the method.
+     * @returns The handler result.
+     */
+    call(name: string, ...args: any[]) {
+        return this._methods.get(name)?.(...args);
+    }
+}
+
+const mcp = new MCPConnection();
+
+editor.method('mcp:connect', (port?: number) => mcp.connect(port));
+editor.method('mcp:disconnect', () => mcp.disconnect());
+editor.method('mcp:status', () => mcp.status);
+mcp.on('status', (status: Status) => editor.emit('mcp:status', status));
+
+export { mcp, DEFAULT_PORT };

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -1,8 +1,10 @@
+import { config } from '@/editor/config';
+
 import { mcp } from './connection';
 
 const api = editor.api.globals;
 
-const log = (msg: string) => console.log(`%c[MCP] ${msg}`, 'color:#f60');
+const log = (msg: string) => console.log(`[MCP] ${msg}`);
 
 /**
  * PlayCanvas REST API wrapper.
@@ -43,6 +45,130 @@ const iterateObject = (obj: Record<string, any>, callback: (path: string, value:
         }
     });
 };
+
+/**
+ * Build a human-readable hierarchy path for an entity (e.g. `Root/Player/Camera`).
+ * This resolves the otherwise opaque UUID chain into semantic context.
+ *
+ * @param entity - The entity API instance.
+ * @returns The slash-separated path from the root to the entity.
+ */
+const entityPath = (entity: any) => {
+    const names = [];
+    let current = entity;
+    const seen = new Set();
+    while (current && !seen.has(current.get('resource_id'))) {
+        seen.add(current.get('resource_id'));
+        names.unshift(current.get('name'));
+        const parentId = current.get('parent');
+        current = parentId ? api.entities.get(parentId) : null;
+    }
+    return names.join('/');
+};
+
+/**
+ * Produce the compact, semantic summary returned by list/create/modify tools.
+ * Returning this inline after mutations lets agents skip a follow-up
+ * `list_entities` round-trip.
+ *
+ * @param entity - The entity API instance.
+ * @returns The entity summary.
+ */
+const entitySummary = (entity: any) => {
+    const components = entity.get('components') || {};
+    return {
+        resource_id: entity.get('resource_id'),
+        name: entity.get('name'),
+        path: entityPath(entity),
+        parent: entity.get('parent'),
+        enabled: entity.get('enabled'),
+        tags: entity.get('tags') || [],
+        components: Object.keys(components)
+    };
+};
+
+// top-level entity properties that entities:modify may set directly. Anything
+// else must be addressed under `components.<type>.…` (or is not settable).
+const ENTITY_TOP_LEVEL_PATHS = ['name', 'enabled', 'position', 'rotation', 'scale', 'tags'];
+
+/**
+ * Validate an entities:modify path against an entity BEFORE writing, so an invalid path
+ * fails fast with an actionable message instead of silently "succeeding". Only rejects
+ * paths that are provably wrong (unknown top-level key, or a component path for a
+ * component the entity does not have) — valid edits are never blocked.
+ *
+ * @param entity - The entity API instance.
+ * @param path - The dot-notation path the caller wants to set.
+ * @returns An actionable error string if the path is invalid, otherwise null.
+ */
+const validateEntityPath = (entity: any, path: string) => {
+    const components = Object.keys(entity.get('components') || {});
+    const componentList = components.length ? components.join(', ') : 'none';
+    if (typeof path !== 'string' || !path.length) {
+        return `Missing path. Valid top-level paths: ${ENTITY_TOP_LEVEL_PATHS.join(', ')}; or component paths like components.<type>.<prop>. This entity has components: [${componentList}].`;
+    }
+    if (path.startsWith('components.')) {
+        const component = path.split('.')[1];
+        if (!component) {
+            return `Incomplete path '${path}'. Component paths look like components.<type>.<prop>, e.g. components.light.intensity. This entity has components: [${componentList}].`;
+        }
+        if (!entity.get(`components.${component}`)) {
+            return `Entity ${entity.get('resource_id')} (${entity.get('name')}) has no '${component}' component, so '${path}' cannot be set. This entity has components: [${componentList}]. Add it first with add_components, or target an existing component.`;
+        }
+        return null;
+    }
+    const top = path.split('.')[0];
+    if (!ENTITY_TOP_LEVEL_PATHS.includes(top)) {
+        return `Unknown path '${path}'. Valid top-level paths: ${ENTITY_TOP_LEVEL_PATHS.join(', ')} (vectors are arrays e.g. position [0,1,0], euler rotation in degrees). For component properties use components.<type>.<prop>; this entity has components: [${componentList}].`;
+    }
+    return null;
+};
+
+/**
+ * Compact summary for an asset.
+ *
+ * @param asset - The asset API instance.
+ * @returns The asset summary.
+ */
+const assetSummary = (asset: any) => {
+    const path = asset.get('path') || [];
+    return {
+        id: asset.get('id'),
+        name: asset.get('name'),
+        type: asset.get('type'),
+        folder: path.length > 0 ? path[path.length - 1] : null,
+        tags: asset.get('tags') || []
+    };
+};
+
+/**
+ * Apply limit/offset pagination to a list and return the page plus the pagination
+ * metadata that belongs in the response envelope.
+ *
+ * @param items - The full result set.
+ * @param options - Pagination options (`limit` default 50, `offset` default 0).
+ * @returns The page and pagination meta.
+ */
+const paginate = <T>(items: T[], options: { limit?: number; offset?: number } = {}) => {
+    const total = items.length;
+    const limit = Number.isFinite(options.limit) ? Math.max(0, options.limit!) : 50;
+    const offset = Number.isFinite(options.offset) ? Math.max(0, options.offset!) : 0;
+    const page = limit > 0 ? items.slice(offset, offset + limit) : items.slice(offset);
+    const end = offset + page.length;
+    const hasMore = end < total;
+    return {
+        page,
+        meta: {
+            total,
+            count: page.length,
+            hasMore,
+            nextCursor: hasMore ? String(end) : null
+        }
+    };
+};
+
+// remember a handle to the launched runtime window so we can stop it later
+let runtimeWindow: Window | null = null;
 
 // general
 mcp.method('ping', () => ({ data: 'pong' }));
@@ -109,26 +235,26 @@ mcp.method('viewport:capture', () => {
         const base64 = dataUrl.split(',')[1];
 
         log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
-        return { data: base64 };
+        return { data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } };
     } catch (e: any) {
-        return { error: `Failed to capture viewport: ${e.message}` };
+        return { error: `Failed to capture viewport: ${e.message}. Ensure a scene is loaded and the viewport is visible, then retry.` };
     }
 });
 mcp.method('viewport:focus', (ids, options: any = {}) => {
     const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
-        return { error: 'No valid entities found' };
+        return { error: 'No valid entities found. Call list_entities (or resolve_entities) to obtain valid resource_ids.' };
     }
     api.selection.set(entities, { history: true });
 
     // get camera and calculate target
     const camera = editor.call('camera:current');
     if (!camera) {
-        return { error: 'Could not retrieve current camera' };
+        return { error: 'Could not retrieve current camera. Ensure a scene is loaded in the editor and retry.' };
     }
     const aabb = editor.call('selection:aabb');
     if (!aabb) {
-        return { error: 'Could not calculate selection bounds' };
+        return { error: 'Could not calculate selection bounds. The selected entities may have no renderable bounds.' };
     }
 
     // calculate distance based on bounding box and FOV
@@ -160,7 +286,48 @@ mcp.method('viewport:focus', (ids, options: any = {}) => {
     // focus camera on target
     editor.call('camera:focus', aabb.center, distance);
     log(`Focused viewport on entities: ${ids.join(', ')}`);
-    return { data: true };
+    return { data: { focused: entities.length } };
+});
+
+// launch (runtime control)
+mcp.method('launch:start', (options: any = {}) => {
+    const sceneId = config.scene?.id;
+    const base = config.url?.launch;
+    if (!sceneId || !base) {
+        return { error: 'No scene loaded, or launch URL unavailable. Load a scene in the editor and retry.' };
+    }
+    const params = new URLSearchParams();
+
+    // debug=true makes the engine log warnings/errors to the console, which
+    // read_runtime_logs relies on
+    params.set('debug', 'true');
+    if (options.device) {
+        params.set('device', options.device);
+    }
+
+    // pass the MCP port so the launch page can connect back as the runtime peer
+    // without any popup UI
+    params.set('mcp_port', String(mcp.port));
+    const url = `${base}${sceneId}?${params.toString()}`;
+
+    if (runtimeWindow && !runtimeWindow.closed) {
+        runtimeWindow.close();
+    }
+    runtimeWindow = window.open(url, '_blank');
+    if (!runtimeWindow) {
+        return { error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.' };
+    }
+    log(`Launched runtime for scene(${sceneId})`);
+    return { data: { url, sceneId } };
+});
+mcp.method('launch:stop', () => {
+    const wasOpen = !!(runtimeWindow && !runtimeWindow.closed);
+    if (runtimeWindow && !runtimeWindow.closed) {
+        runtimeWindow.close();
+    }
+    runtimeWindow = null;
+    log('Stopped runtime');
+    return { data: { stopped: wasOpen } };
 });
 
 // entities
@@ -170,66 +337,94 @@ mcp.method('entities:create', (entityDataArray) => {
         if (Object.hasOwn(entityData, 'parent')) {
             const parent = api.entities.get(entityData.parent);
             if (!parent) {
-                return { error: `Parent entity not found: ${entityData.parent}` };
+                return { error: `Parent entity not found: ${entityData.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id, or omit 'parent' to create under the root.` };
             }
             entityData.entity.parent = parent;
         }
 
         const entity = api.entities.create(entityData.entity);
         if (!entity) {
-            return { error: 'Failed to create entity' };
+            return { error: 'Failed to create entity. Verify the entity definition is valid (e.g. component data types) and retry.' };
         }
         entities.push(entity);
 
         log(`Created entity(${entity.get('resource_id')})`);
     }
-    return { data: entities.map((entity) => entity.get('resource_id')) };
+
+    // return the resulting entity summaries inline so the agent gets the new
+    // ids + hierarchy paths without a follow-up list_entities call
+    return { data: entities.map(entitySummary) };
 });
 mcp.method('entities:modify', (edits) => {
+    const modified = new Map();
     for (const { id, path, value } of edits) {
         const entity = api.entities.get(id);
         if (!entity) {
-            return { error: `Entity not found: ${id}` };
+            return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        }
+
+        // validate-on-write: reject a provably-invalid path up front so the agent gets
+        // an actionable message and never mistakes a no-op for a successful edit
+        const pathError = validateEntityPath(entity, path);
+        if (pathError) {
+            return { error: pathError };
         }
         entity.set(path, value);
+        modified.set(id, entity);
         log(`Set property(${path}) of entity(${id}) to: ${JSON.stringify(value)}`);
     }
-    return { data: true };
+
+    // return the post-edit summaries of every touched entity
+    return { data: Array.from(modified.values()).map(entitySummary) };
 });
 mcp.method('entities:duplicate', async (ids, options: any = {}) => {
-    const entities = ids.map((id: string) => api.entities.get(id));
+    const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
-        return { error: 'Entities not found' };
+        return { error: 'No valid entities to duplicate. Call list_entities (or resolve_entities) to obtain valid resource_ids.' };
     }
     const res = await api.entities.duplicate(entities, options);
     log(`Duplicated entities: ${res.map((entity: any) => entity.get('resource_id')).join(', ')}`);
-    return { data: res.map((entity: any) => entity.get('resource_id')) };
+    return { data: res.map(entitySummary) };
 });
 mcp.method('entities:reparent', (options) => {
     const entity = api.entities.get(options.id);
     if (!entity) {
-        return { error: 'Entity not found' };
+        return { error: `Entity not found: ${options.id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
     }
     const parent = api.entities.get(options.parent);
     if (!parent) {
-        return { error: 'Parent entity not found' };
+        return { error: `Parent entity not found: ${options.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id.` };
     }
     entity.reparent(parent, options.index, {
         preserveTransform: options.preserveTransform
     });
     log(`Reparented entity(${options.id}) to entity(${options.parent})`);
-    return { data: true };
+    return { data: entitySummary(entity) };
 });
 mcp.method('entities:delete', async (ids) => {
     const entities = ids
         .map((id: string) => api.entities.get(id))
-        .filter((entity: any) => entity !== api.entities.root);
+        .filter((entity: any) => entity && entity !== api.entities.root);
     if (!entities.length) {
-        return { error: 'No entities to delete' };
+        return { error: 'No deletable entities found (the root entity cannot be deleted). Call list_entities to obtain valid, non-root resource_ids.' };
     }
     await api.entities.delete(entities);
     log(`Deleted entities: ${ids.join(', ')}`);
-    return { data: true };
+    return { data: { deleted: entities.length } };
+});
+mcp.method('entities:resolve', (options: any = {}) => {
+    const name = (options.name || '').toLowerCase();
+    if (!name) {
+        return { error: 'Provide a non-empty "name" to resolve.' };
+    }
+    const matches = api.entities.list().filter((entity) => {
+        const entityName = (entity.get('name') || '').toLowerCase();
+        return options.exact ? entityName === name : entityName.includes(name);
+    });
+    log(`Resolved entities by name(${options.name}): ${matches.length} match(es)`);
+
+    // empty match is a valid result, not an error
+    return { data: matches.map(entitySummary), meta: { total: matches.length, count: matches.length } };
 });
 mcp.method('entities:list', (options: any = {}) => {
     let entities = api.entities.list();
@@ -246,65 +441,66 @@ mcp.method('entities:list', (options: any = {}) => {
         entities = entities.filter((entity) => entity.get('tags').includes(options.tag));
     }
 
-    if (!entities.length) {
-        return { error: 'No entities found' };
-    }
+    // an empty result is a valid success, not an error
+    const { page, meta } = paginate(entities, options);
 
-    log('Listed entities');
+    log(`Listed entities (${meta.count}/${meta.total})`);
 
     // return full JSON or summary
     if (options.full) {
-        return { data: entities.map((entity) => entity.json()) };
+        return { data: page.map((entity) => entity.json()), meta };
     }
 
-    // summary mode: return minimal data with component names
-    return {
-        data: entities.map((entity) => {
-            const components = entity.get('components') || {};
-            return {
-                resource_id: entity.get('resource_id'),
-                name: entity.get('name'),
-                parent: entity.get('parent'),
-                enabled: entity.get('enabled'),
-                tags: entity.get('tags') || [],
-                components: Object.keys(components)
-            };
-        })
-    };
+    // summary mode: compact, semantic data
+    return { data: page.map(entitySummary), meta };
 });
 mcp.method('entities:components:add', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: 'Entity not found' };
+        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
     }
     Object.entries(components).forEach(([name, data]) => {
         entity.addComponent(name, data);
     });
     log(`Added components(${Object.keys(components).join(', ')}) to entity(${id})`);
-    return { data: true };
+    return { data: entitySummary(entity) };
 });
 mcp.method('entities:components:remove', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: 'Entity not found' };
+        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
     }
     components.forEach((component: string) => {
         entity.removeComponent(component);
     });
     log(`Removed components(${components.join(', ')}) from entity(${id})`);
-    return { data: true };
+    return { data: entitySummary(entity) };
 });
 mcp.method('entities:components:script:add', (id, scriptName) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: 'Entity not found' };
+        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
     }
     if (!entity.get('components.script')) {
-        return { error: 'Script component not found' };
+        return { error: `Entity ${id} has no script component. Add one first via add_components { script: {} } or use attach_script which creates it automatically.` };
     }
     entity.addScript(scriptName);
     log(`Added script(${scriptName}) to component(script) of entity(${id})`);
-    return { data: entity.get('components.script') };
+    return { data: entitySummary(entity) };
+});
+mcp.method('entities:script:attach', (id, scriptName) => {
+    const entity = api.entities.get(id);
+    if (!entity) {
+        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+    }
+
+    // consolidated flow: ensure the script component exists, then attach
+    if (!entity.get('components.script')) {
+        entity.addComponent('script', {});
+    }
+    entity.addScript(scriptName);
+    log(`Attached script(${scriptName}) to entity(${id})`);
+    return { data: entitySummary(entity) };
 });
 
 // assets
@@ -357,8 +553,9 @@ mcp.method('assets:create', async (assets) => {
                 throw new Error(`Failed to create asset of type ${type}`);
             }
 
+            // return the asset summary inline
             log(`Created asset(${asset.get('id')}) - Type: ${type}`);
-            return asset.get('id');
+            return assetSummary(asset);
         });
 
         const createdAssetsData = await Promise.all(assetCreationPromises);
@@ -370,13 +567,13 @@ mcp.method('assets:create', async (assets) => {
     }
 });
 mcp.method('assets:delete', (ids) => {
-    const assets = ids.map((id: number) => api.assets.get(id));
+    const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
     if (!assets.length) {
-        return { error: 'Assets not found' };
+        return { error: 'No valid assets to delete. Call list_assets to obtain valid asset ids.' };
     }
     api.assets.delete(assets);
     log(`Deleted assets: ${ids.join(', ')}`);
-    return { data: true };
+    return { data: { deleted: assets.length } };
 });
 mcp.method('assets:list', (options: any = {}) => {
     let assets = api.assets.list();
@@ -393,56 +590,59 @@ mcp.method('assets:list', (options: any = {}) => {
         assets = assets.filter((asset) => (asset.get('tags') || []).includes(options.tag));
     }
 
-    if (!assets.length) {
-        return { error: 'No assets found' };
-    }
+    // an empty result is a valid success, not an error
+    const { page, meta } = paginate(assets, options);
 
-    log('Listed assets');
+    log(`Listed assets (${meta.count}/${meta.total})`);
 
     // return full JSON or summary
     if (options.full) {
-        return { data: assets.map((asset) => asset.json()) };
+        return { data: page.map((asset) => asset.json()), meta };
     }
 
     // summary mode: return minimal data
-    return {
-        data: assets.map((asset) => {
-            const path = asset.get('path') || [];
-            return {
-                id: asset.get('id'),
-                name: asset.get('name'),
-                type: asset.get('type'),
-                folder: path.length > 0 ? path[path.length - 1] : null,
-                tags: asset.get('tags') || []
-            };
-        })
-    };
+    return { data: page.map(assetSummary), meta };
 });
 mcp.method('assets:instantiate', async (ids) => {
-    const assets = ids.map((id: number) => api.assets.get(id));
+    const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
     if (!assets.length) {
-        return { error: 'Assets not found' };
+        return { error: 'No valid assets found. Call list_assets with type="template" to obtain valid template asset ids.' };
     }
     if (assets.some((asset: any) => asset.get('type') !== 'template')) {
-        return { error: 'Invalid template asset' };
+        return { error: 'One or more ids are not template assets. Only template assets can be instantiated; call list_assets with type="template".' };
     }
     const entities = await api.assets.instantiateTemplates(assets, api.entities.root);
     log(`Instantiated assets: ${ids.join(', ')}`);
-    return { data: entities.map((entity: any) => entity.get('resource_id')) };
+    return { data: entities.map(entitySummary) };
 });
 mcp.method('assets:property:set', (id, prop, value) => {
     const asset = api.assets.get(id);
     if (!asset) {
-        return { error: 'Asset not found' };
+        return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
     }
     asset.set(`data.${prop}`, value);
     log(`Set asset(${id}) property(${prop}) to: ${JSON.stringify(value)}`);
-    return { data: true };
+    return { data: { id, [prop]: value } };
+});
+mcp.method('assets:data:set', (id, props) => {
+    const asset = api.assets.get(id);
+    if (!asset) {
+        return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
+    }
+    const keys = Object.keys(props || {});
+    if (!keys.length) {
+        return { error: 'No properties provided to set.' };
+    }
+    keys.forEach((key) => {
+        asset.set(`data.${key}`, props[key]);
+    });
+    log(`Set asset(${id}) properties(${keys.join(', ')})`);
+    return { data: assetSummary(asset) };
 });
 mcp.method('assets:script:text:set', async (id, text) => {
     const asset = api.assets.get(id);
     if (!asset) {
-        return { error: 'Asset not found' };
+        return { error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.` };
     }
 
     const form = new FormData();
@@ -464,8 +664,9 @@ mcp.method('assets:script:text:set', async (id, text) => {
 mcp.method('assets:script:parse', async (id) => {
     const asset = api.assets.get(id);
     if (!asset) {
-        return { error: 'Asset not found' };
+        return { error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.` };
     }
+
     // FIXME: hacky way to get the parsed script data. Expose a proper API for this.
     const [err, data] = await new Promise<any[]>((resolve) => {
         editor.call('scripts:parse', (asset as any).observer, (...d: any[]) => resolve(d));
@@ -487,7 +688,9 @@ mcp.method('scene:settings:modify', (settings) => {
         scene.set(path, value);
     });
     log('Modified scene settings');
-    return { data: true };
+
+    // return the resulting settings snapshot inline
+    return { data: scene.json() };
 });
 mcp.method('scene:settings:query', () => {
     const scene = api.settings.scene;

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -237,13 +237,17 @@ mcp.method('viewport:capture', () => {
         log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
         return { data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } };
     } catch (e: any) {
-        return { error: `Failed to capture viewport: ${e.message}. Ensure a scene is loaded and the viewport is visible, then retry.` };
+        return {
+            error: `Failed to capture viewport: ${e.message}. Ensure a scene is loaded and the viewport is visible, then retry.`
+        };
     }
 });
 mcp.method('viewport:focus', (ids, options: any = {}) => {
     const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
-        return { error: 'No valid entities found. Call list_entities (or resolve_entities) to obtain valid resource_ids.' };
+        return {
+            error: 'No valid entities found. Call list_entities (or resolve_entities) to obtain valid resource_ids.'
+        };
     }
     api.selection.set(entities, { history: true });
 
@@ -315,7 +319,9 @@ mcp.method('launch:start', (options: any = {}) => {
     }
     runtimeWindow = window.open(url, '_blank');
     if (!runtimeWindow) {
-        return { error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.' };
+        return {
+            error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.'
+        };
     }
     log(`Launched runtime for scene(${sceneId})`);
     return { data: { url, sceneId } };
@@ -337,14 +343,18 @@ mcp.method('entities:create', (entityDataArray) => {
         if (Object.hasOwn(entityData, 'parent')) {
             const parent = api.entities.get(entityData.parent);
             if (!parent) {
-                return { error: `Parent entity not found: ${entityData.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id, or omit 'parent' to create under the root.` };
+                return {
+                    error: `Parent entity not found: ${entityData.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id, or omit 'parent' to create under the root.`
+                };
             }
             entityData.entity.parent = parent;
         }
 
         const entity = api.entities.create(entityData.entity);
         if (!entity) {
-            return { error: 'Failed to create entity. Verify the entity definition is valid (e.g. component data types) and retry.' };
+            return {
+                error: 'Failed to create entity. Verify the entity definition is valid (e.g. component data types) and retry.'
+            };
         }
         entities.push(entity);
 
@@ -360,7 +370,9 @@ mcp.method('entities:modify', (edits) => {
     for (const { id, path, value } of edits) {
         const entity = api.entities.get(id);
         if (!entity) {
-            return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+            return {
+                error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+            };
         }
 
         // validate-on-write: reject a provably-invalid path up front so the agent gets
@@ -380,7 +392,9 @@ mcp.method('entities:modify', (edits) => {
 mcp.method('entities:duplicate', async (ids, options: any = {}) => {
     const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
-        return { error: 'No valid entities to duplicate. Call list_entities (or resolve_entities) to obtain valid resource_ids.' };
+        return {
+            error: 'No valid entities to duplicate. Call list_entities (or resolve_entities) to obtain valid resource_ids.'
+        };
     }
     const res = await api.entities.duplicate(entities, options);
     log(`Duplicated entities: ${res.map((entity: any) => entity.get('resource_id')).join(', ')}`);
@@ -389,11 +403,15 @@ mcp.method('entities:duplicate', async (ids, options: any = {}) => {
 mcp.method('entities:reparent', (options) => {
     const entity = api.entities.get(options.id);
     if (!entity) {
-        return { error: `Entity not found: ${options.id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        return {
+            error: `Entity not found: ${options.id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+        };
     }
     const parent = api.entities.get(options.parent);
     if (!parent) {
-        return { error: `Parent entity not found: ${options.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id.` };
+        return {
+            error: `Parent entity not found: ${options.parent}. Call list_entities (or resolve_entities) to obtain a valid parent resource_id.`
+        };
     }
     entity.reparent(parent, options.index, {
         preserveTransform: options.preserveTransform
@@ -406,7 +424,9 @@ mcp.method('entities:delete', async (ids) => {
         .map((id: string) => api.entities.get(id))
         .filter((entity: any) => entity && entity !== api.entities.root);
     if (!entities.length) {
-        return { error: 'No deletable entities found (the root entity cannot be deleted). Call list_entities to obtain valid, non-root resource_ids.' };
+        return {
+            error: 'No deletable entities found (the root entity cannot be deleted). Call list_entities to obtain valid, non-root resource_ids.'
+        };
     }
     await api.entities.delete(entities);
     log(`Deleted entities: ${ids.join(', ')}`);
@@ -457,7 +477,9 @@ mcp.method('entities:list', (options: any = {}) => {
 mcp.method('entities:components:add', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        return {
+            error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+        };
     }
     Object.entries(components).forEach(([name, data]) => {
         entity.addComponent(name, data);
@@ -468,7 +490,9 @@ mcp.method('entities:components:add', (id, components) => {
 mcp.method('entities:components:remove', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        return {
+            error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+        };
     }
     components.forEach((component: string) => {
         entity.removeComponent(component);
@@ -479,10 +503,14 @@ mcp.method('entities:components:remove', (id, components) => {
 mcp.method('entities:components:script:add', (id, scriptName) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        return {
+            error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+        };
     }
     if (!entity.get('components.script')) {
-        return { error: `Entity ${id} has no script component. Add one first via add_components { script: {} } or use attach_script which creates it automatically.` };
+        return {
+            error: `Entity ${id} has no script component. Add one first via add_components { script: {} } or use attach_script which creates it automatically.`
+        };
     }
     entity.addScript(scriptName);
     log(`Added script(${scriptName}) to component(script) of entity(${id})`);
@@ -491,7 +519,9 @@ mcp.method('entities:components:script:add', (id, scriptName) => {
 mcp.method('entities:script:attach', (id, scriptName) => {
     const entity = api.entities.get(id);
     if (!entity) {
-        return { error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.` };
+        return {
+            error: `Entity not found: ${id}. Call list_entities (or resolve_entities) to obtain a valid resource_id.`
+        };
     }
 
     // consolidated flow: ensure the script component exists, then attach
@@ -606,10 +636,14 @@ mcp.method('assets:list', (options: any = {}) => {
 mcp.method('assets:instantiate', async (ids) => {
     const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
     if (!assets.length) {
-        return { error: 'No valid assets found. Call list_assets with type="template" to obtain valid template asset ids.' };
+        return {
+            error: 'No valid assets found. Call list_assets with type="template" to obtain valid template asset ids.'
+        };
     }
     if (assets.some((asset: any) => asset.get('type') !== 'template')) {
-        return { error: 'One or more ids are not template assets. Only template assets can be instantiated; call list_assets with type="template".' };
+        return {
+            error: 'One or more ids are not template assets. Only template assets can be instantiated; call list_assets with type="template".'
+        };
     }
     const entities = await api.assets.instantiateTemplates(assets, api.entities.root);
     log(`Instantiated assets: ${ids.join(', ')}`);
@@ -642,7 +676,9 @@ mcp.method('assets:data:set', (id, props) => {
 mcp.method('assets:script:text:set', async (id, text) => {
     const asset = api.assets.get(id);
     if (!asset) {
-        return { error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.` };
+        return {
+            error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.`
+        };
     }
 
     const form = new FormData();
@@ -664,7 +700,9 @@ mcp.method('assets:script:text:set', async (id, text) => {
 mcp.method('assets:script:parse', async (id) => {
     const asset = api.assets.get(id);
     if (!asset) {
-        return { error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.` };
+        return {
+            error: `Asset not found: ${id}. Call list_assets with type="script" to obtain a valid script asset id.`
+        };
     }
 
     // FIXME: hacky way to get the parsed script data. Expose a proper API for this.

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -1,0 +1,621 @@
+import { mcp } from './connection';
+
+const api = editor.api.globals;
+
+const log = (msg: string) => console.log(`%c[MCP] ${msg}`, 'color:#f60');
+
+/**
+ * PlayCanvas REST API wrapper.
+ *
+ * @param method - The HTTP method to use.
+ * @param path - The path to the API endpoint.
+ * @param data - The data to send.
+ * @param auth - Whether to send the access token.
+ * @returns The parsed JSON response.
+ */
+const rest = (method: string, path: string, data?: FormData | object, auth = false) => {
+    const headers: Record<string, string> = {};
+    if (auth) {
+        headers.Authorization = `Bearer ${api.accessToken}`;
+    }
+    const init: RequestInit = { method, headers };
+    if (data instanceof FormData) {
+        init.body = data;
+    } else if (data) {
+        headers['Content-Type'] = 'application/json';
+        init.body = JSON.stringify(data);
+    }
+    return fetch(`/api/${path}`, init).then((res) => res.json());
+};
+
+/**
+ * @param obj - The object to iterate.
+ * @param callback - Called with the dot path and value of each leaf.
+ * @param currentPath - The current path prefix.
+ */
+const iterateObject = (obj: Record<string, any>, callback: (path: string, value: any) => void, currentPath = '') => {
+    Object.entries(obj).forEach(([key, value]) => {
+        const path = currentPath ? `${currentPath}.${key}` : key;
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            iterateObject(value, callback, path);
+        } else {
+            callback(path, value);
+        }
+    });
+};
+
+// general
+mcp.method('ping', () => ({ data: 'pong' }));
+
+// viewport
+mcp.method('viewport:capture', () => {
+    const app = editor.call('viewport:app');
+    if (!app) {
+        return { error: 'Viewport app not found' };
+    }
+
+    const device = app.graphicsDevice;
+    const gl = device.gl;
+    if (!gl) {
+        return { error: 'WebGL context not found' };
+    }
+
+    try {
+        // force a render to ensure we have the latest frame
+        editor.call('viewport:render');
+        app.tick();
+
+        const width = device.width;
+        const height = device.height;
+
+        // read pixels from the backbuffer
+        const pixels = new Uint8Array(width * height * 4);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        // flip the image vertically (WebGL reads bottom-to-top)
+        const flipped = new Uint8Array(width * height * 4);
+        const rowSize = width * 4;
+        for (let y = 0; y < height; y++) {
+            flipped.set(pixels.subarray((height - 1 - y) * rowSize, (height - y) * rowSize), y * rowSize);
+        }
+
+        // create source canvas with full resolution
+        const srcCanvas = document.createElement('canvas');
+        srcCanvas.width = width;
+        srcCanvas.height = height;
+        const srcCtx = srcCanvas.getContext('2d')!;
+        const imageData = new ImageData(new Uint8ClampedArray(flipped.buffer), width, height);
+        srcCtx.putImageData(imageData, 0, 0);
+
+        // scale down to max 800px width while maintaining aspect ratio
+        const maxWidth = 800;
+        let dstWidth = width;
+        let dstHeight = height;
+        if (width > maxWidth) {
+            dstWidth = maxWidth;
+            dstHeight = Math.round(height * (maxWidth / width));
+        }
+
+        // create destination canvas and draw scaled image
+        const dstCanvas = document.createElement('canvas');
+        dstCanvas.width = dstWidth;
+        dstCanvas.height = dstHeight;
+        const dstCtx = dstCanvas.getContext('2d')!;
+        dstCtx.drawImage(srcCanvas, 0, 0, dstWidth, dstHeight);
+
+        // convert to base64 WebP for smaller file size (falls back to PNG if unsupported)
+        const dataUrl = dstCanvas.toDataURL('image/webp', 0.8);
+        const base64 = dataUrl.split(',')[1];
+
+        log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
+        return { data: base64 };
+    } catch (e: any) {
+        return { error: `Failed to capture viewport: ${e.message}` };
+    }
+});
+mcp.method('viewport:focus', (ids, options: any = {}) => {
+    const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
+    if (!entities.length) {
+        return { error: 'No valid entities found' };
+    }
+    api.selection.set(entities, { history: true });
+
+    // get camera and calculate target
+    const camera = editor.call('camera:current');
+    if (!camera) {
+        return { error: 'Could not retrieve current camera' };
+    }
+    const aabb = editor.call('selection:aabb');
+    if (!aabb) {
+        return { error: 'Could not calculate selection bounds' };
+    }
+
+    // calculate distance based on bounding box and FOV
+    let distance = Math.max(aabb.halfExtents.x, aabb.halfExtents.y, aabb.halfExtents.z);
+    distance /= Math.tan((0.5 * camera.camera.fov * Math.PI) / 180.0);
+    distance = distance * 1.1 + 1;
+
+    // apply orientation if specified
+    if (options.view) {
+        const views: Record<string, [number, number]> = {
+            top: [-90, 0],
+            bottom: [90, 0],
+            front: [0, 0],
+            back: [0, 180],
+            left: [0, -90],
+            right: [0, 90],
+            perspective: [-25, 45]
+        };
+        const angles = views[options.view];
+        if (angles) {
+            camera.setEulerAngles(angles[0], angles[1], 0);
+        }
+    } else if (options.yaw !== undefined || options.pitch !== undefined) {
+        const yaw = options.yaw ?? 45;
+        const pitch = options.pitch ?? -25;
+        camera.setEulerAngles(pitch, yaw, 0);
+    }
+
+    // focus camera on target
+    editor.call('camera:focus', aabb.center, distance);
+    log(`Focused viewport on entities: ${ids.join(', ')}`);
+    return { data: true };
+});
+
+// entities
+mcp.method('entities:create', (entityDataArray) => {
+    const entities = [];
+    for (const entityData of entityDataArray) {
+        if (Object.hasOwn(entityData, 'parent')) {
+            const parent = api.entities.get(entityData.parent);
+            if (!parent) {
+                return { error: `Parent entity not found: ${entityData.parent}` };
+            }
+            entityData.entity.parent = parent;
+        }
+
+        const entity = api.entities.create(entityData.entity);
+        if (!entity) {
+            return { error: 'Failed to create entity' };
+        }
+        entities.push(entity);
+
+        log(`Created entity(${entity.get('resource_id')})`);
+    }
+    return { data: entities.map((entity) => entity.get('resource_id')) };
+});
+mcp.method('entities:modify', (edits) => {
+    for (const { id, path, value } of edits) {
+        const entity = api.entities.get(id);
+        if (!entity) {
+            return { error: `Entity not found: ${id}` };
+        }
+        entity.set(path, value);
+        log(`Set property(${path}) of entity(${id}) to: ${JSON.stringify(value)}`);
+    }
+    return { data: true };
+});
+mcp.method('entities:duplicate', async (ids, options: any = {}) => {
+    const entities = ids.map((id: string) => api.entities.get(id));
+    if (!entities.length) {
+        return { error: 'Entities not found' };
+    }
+    const res = await api.entities.duplicate(entities, options);
+    log(`Duplicated entities: ${res.map((entity: any) => entity.get('resource_id')).join(', ')}`);
+    return { data: res.map((entity: any) => entity.get('resource_id')) };
+});
+mcp.method('entities:reparent', (options) => {
+    const entity = api.entities.get(options.id);
+    if (!entity) {
+        return { error: 'Entity not found' };
+    }
+    const parent = api.entities.get(options.parent);
+    if (!parent) {
+        return { error: 'Parent entity not found' };
+    }
+    entity.reparent(parent, options.index, {
+        preserveTransform: options.preserveTransform
+    });
+    log(`Reparented entity(${options.id}) to entity(${options.parent})`);
+    return { data: true };
+});
+mcp.method('entities:delete', async (ids) => {
+    const entities = ids
+        .map((id: string) => api.entities.get(id))
+        .filter((entity: any) => entity !== api.entities.root);
+    if (!entities.length) {
+        return { error: 'No entities to delete' };
+    }
+    await api.entities.delete(entities);
+    log(`Deleted entities: ${ids.join(', ')}`);
+    return { data: true };
+});
+mcp.method('entities:list', (options: any = {}) => {
+    let entities = api.entities.list();
+
+    // apply filters
+    if (options.name) {
+        const searchName = options.name.toLowerCase();
+        entities = entities.filter((entity) => entity.get('name').toLowerCase().includes(searchName));
+    }
+    if (options.component) {
+        entities = entities.filter((entity) => entity.get(`components.${options.component}`));
+    }
+    if (options.tag) {
+        entities = entities.filter((entity) => entity.get('tags').includes(options.tag));
+    }
+
+    if (!entities.length) {
+        return { error: 'No entities found' };
+    }
+
+    log('Listed entities');
+
+    // return full JSON or summary
+    if (options.full) {
+        return { data: entities.map((entity) => entity.json()) };
+    }
+
+    // summary mode: return minimal data with component names
+    return {
+        data: entities.map((entity) => {
+            const components = entity.get('components') || {};
+            return {
+                resource_id: entity.get('resource_id'),
+                name: entity.get('name'),
+                parent: entity.get('parent'),
+                enabled: entity.get('enabled'),
+                tags: entity.get('tags') || [],
+                components: Object.keys(components)
+            };
+        })
+    };
+});
+mcp.method('entities:components:add', (id, components) => {
+    const entity = api.entities.get(id);
+    if (!entity) {
+        return { error: 'Entity not found' };
+    }
+    Object.entries(components).forEach(([name, data]) => {
+        entity.addComponent(name, data);
+    });
+    log(`Added components(${Object.keys(components).join(', ')}) to entity(${id})`);
+    return { data: true };
+});
+mcp.method('entities:components:remove', (id, components) => {
+    const entity = api.entities.get(id);
+    if (!entity) {
+        return { error: 'Entity not found' };
+    }
+    components.forEach((component: string) => {
+        entity.removeComponent(component);
+    });
+    log(`Removed components(${components.join(', ')}) from entity(${id})`);
+    return { data: true };
+});
+mcp.method('entities:components:script:add', (id, scriptName) => {
+    const entity = api.entities.get(id);
+    if (!entity) {
+        return { error: 'Entity not found' };
+    }
+    if (!entity.get('components.script')) {
+        return { error: 'Script component not found' };
+    }
+    entity.addScript(scriptName);
+    log(`Added script(${scriptName}) to component(script) of entity(${id})`);
+    return { data: entity.get('components.script') };
+});
+
+// assets
+mcp.method('assets:create', async (assets) => {
+    try {
+        const assetCreationPromises = assets.map(async ({ type, options }: any) => {
+            if (options?.folder) {
+                options.folder = api.assets.get(options.folder);
+            }
+
+            let createPromise;
+
+            switch (type) {
+                case 'css':
+                    createPromise = api.assets.createCss(options);
+                    break;
+                case 'folder':
+                    createPromise = api.assets.createFolder(options);
+                    break;
+                case 'html':
+                    createPromise = api.assets.createHtml(options);
+                    break;
+                case 'material':
+                    if (options?.data?.name) {
+                        options.name = options.data.name;
+                    }
+                    createPromise = api.assets.createMaterial(options);
+                    break;
+                case 'script':
+                    createPromise = api.assets.createScript(options);
+                    break;
+                case 'shader':
+                    createPromise = api.assets.createShader(options);
+                    break;
+                case 'template':
+                    if (options?.entity) {
+                        options.entity = api.entities.get(options.entity);
+                    }
+                    createPromise = api.assets.createTemplate(options);
+                    break;
+                case 'text':
+                    createPromise = api.assets.createText(options);
+                    break;
+                default:
+                    throw new Error(`Invalid asset type: ${type}`);
+            }
+
+            const asset = await createPromise;
+            if (!asset) {
+                throw new Error(`Failed to create asset of type ${type}`);
+            }
+
+            log(`Created asset(${asset.get('id')}) - Type: ${type}`);
+            return asset.get('id');
+        });
+
+        const createdAssetsData = await Promise.all(assetCreationPromises);
+        return { data: createdAssetsData };
+    } catch (e: any) {
+        const errorMessage = e instanceof Error ? e.message : 'An unknown error occurred during asset creation.';
+        log(`Error creating assets: ${errorMessage}`);
+        return { error: errorMessage };
+    }
+});
+mcp.method('assets:delete', (ids) => {
+    const assets = ids.map((id: number) => api.assets.get(id));
+    if (!assets.length) {
+        return { error: 'Assets not found' };
+    }
+    api.assets.delete(assets);
+    log(`Deleted assets: ${ids.join(', ')}`);
+    return { data: true };
+});
+mcp.method('assets:list', (options: any = {}) => {
+    let assets = api.assets.list();
+
+    // apply filters
+    if (options.type) {
+        assets = assets.filter((asset) => asset.get('type') === options.type);
+    }
+    if (options.name) {
+        const searchName = options.name.toLowerCase();
+        assets = assets.filter((asset) => asset.get('name').toLowerCase().includes(searchName));
+    }
+    if (options.tag) {
+        assets = assets.filter((asset) => (asset.get('tags') || []).includes(options.tag));
+    }
+
+    if (!assets.length) {
+        return { error: 'No assets found' };
+    }
+
+    log('Listed assets');
+
+    // return full JSON or summary
+    if (options.full) {
+        return { data: assets.map((asset) => asset.json()) };
+    }
+
+    // summary mode: return minimal data
+    return {
+        data: assets.map((asset) => {
+            const path = asset.get('path') || [];
+            return {
+                id: asset.get('id'),
+                name: asset.get('name'),
+                type: asset.get('type'),
+                folder: path.length > 0 ? path[path.length - 1] : null,
+                tags: asset.get('tags') || []
+            };
+        })
+    };
+});
+mcp.method('assets:instantiate', async (ids) => {
+    const assets = ids.map((id: number) => api.assets.get(id));
+    if (!assets.length) {
+        return { error: 'Assets not found' };
+    }
+    if (assets.some((asset: any) => asset.get('type') !== 'template')) {
+        return { error: 'Invalid template asset' };
+    }
+    const entities = await api.assets.instantiateTemplates(assets, api.entities.root);
+    log(`Instantiated assets: ${ids.join(', ')}`);
+    return { data: entities.map((entity: any) => entity.get('resource_id')) };
+});
+mcp.method('assets:property:set', (id, prop, value) => {
+    const asset = api.assets.get(id);
+    if (!asset) {
+        return { error: 'Asset not found' };
+    }
+    asset.set(`data.${prop}`, value);
+    log(`Set asset(${id}) property(${prop}) to: ${JSON.stringify(value)}`);
+    return { data: true };
+});
+mcp.method('assets:script:text:set', async (id, text) => {
+    const asset = api.assets.get(id);
+    if (!asset) {
+        return { error: 'Asset not found' };
+    }
+
+    const form = new FormData();
+    form.append('filename', asset.get('file.filename'));
+    form.append('file', new Blob([text], { type: 'text/plain' }), asset.get('file.filename'));
+    form.append('branchId', config.self.branch.id);
+
+    try {
+        const data = await rest('PUT', `assets/${id}`, form, true);
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Set asset(${id}) script text`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+mcp.method('assets:script:parse', async (id) => {
+    const asset = api.assets.get(id);
+    if (!asset) {
+        return { error: 'Asset not found' };
+    }
+    // FIXME: hacky way to get the parsed script data. Expose a proper API for this.
+    const [err, data] = await new Promise<any[]>((resolve) => {
+        editor.call('scripts:parse', (asset as any).observer, (...d: any[]) => resolve(d));
+    });
+    if (err) {
+        return { error: err };
+    }
+    if (Object.keys(data.scripts).length === 0) {
+        return { error: 'Failed to parse script' };
+    }
+    log(`Parsed asset(${id}) script`);
+    return { data };
+});
+
+// scenes
+mcp.method('scene:settings:modify', (settings) => {
+    const scene = api.settings.scene;
+    iterateObject(settings, (path, value) => {
+        scene.set(path, value);
+    });
+    log('Modified scene settings');
+    return { data: true };
+});
+mcp.method('scene:settings:query', () => {
+    const scene = api.settings.scene;
+    log('Queried scene settings');
+    return { data: scene.json() };
+});
+
+// store - playcanvas
+mcp.method('store:playcanvas:list', async (options: any = {}) => {
+    const params = [];
+    if (options.search) {
+        params.push(`search=${options.search}`);
+    }
+    params.push('regexp=true');
+    if (options.order) {
+        params.push(`order=${options.order}`);
+    }
+    if (options.skip) {
+        params.push(`skip=${options.skip}`);
+    }
+    if (options.limit) {
+        params.push(`limit=${options.limit}`);
+    }
+
+    try {
+        const data = await rest('GET', `store?${params.join('&')}`);
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Searched store: ${JSON.stringify(options)}`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+mcp.method('store:playcanvas:get', async (id) => {
+    try {
+        const data = await rest('GET', `store/${id}`);
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Got store item(${id})`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+mcp.method('store:playcanvas:clone', async (id, name, license) => {
+    try {
+        const data = await rest('POST', `store/${id}/clone`, {
+            scope: {
+                type: 'project',
+                id: config.project.id
+            },
+            name,
+            store: 'playcanvas',
+            targetFolderId: null,
+            license
+        });
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Cloned store item(${id})`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+// store - sketchfab
+mcp.method('store:sketchfab:list', async (options: any = {}) => {
+    const params = ['restricted=0', 'type=models', 'downloadable=true'];
+    if (options.search) {
+        params.push(`q=${options.search}`);
+    }
+    if (options.order) {
+        params.push(`sort_by=${options.order}`);
+    }
+    if (options.skip) {
+        params.push(`cursor=${options.skip}`);
+    }
+    if (options.limit) {
+        params.push(`count=${Math.min(options.limit ?? 0, 24)}`);
+    }
+
+    try {
+        const res = await fetch(`https://api.sketchfab.com/v3/search?${params.join('&')}`);
+        const data = await res.json();
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Searched Sketchfab: ${JSON.stringify(options)}`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+mcp.method('store:sketchfab:get', async (uid) => {
+    try {
+        const res = await fetch(`https://api.sketchfab.com/v3/models/${uid}`);
+        const data = await res.json();
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Got Sketchfab model(${uid})`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+mcp.method('store:sketchfab:clone', async (uid, name, license) => {
+    try {
+        const data = await rest('POST', `store/${uid}/clone`, {
+            scope: {
+                type: 'project',
+                id: config.project.id
+            },
+            name,
+            store: 'sketchfab',
+            targetFolderId: null,
+            license
+        });
+        if (data.error) {
+            return { error: data.error };
+        }
+        log(`Cloned sketchfab item(${uid})`);
+        return { data };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -39,10 +39,22 @@ editor.once('load', () => {
 
     const toggle = new Button({ class: 'mcp-toggle', text: 'CONNECT' });
 
+    // shown when an app was launched before connecting, so its URL has no mcp_port
+    const hint = new Label({ class: 'mcp-hint', text: 'Relaunch the open app to connect it', hidden: true });
+
     popover.append(statusRow);
     popover.append(portRow);
+    popover.append(hint);
     popover.append(toggle);
     root.append(popover);
+
+    const updateHint = () => {
+        const last = editor.call('launch:window');
+        hint.hidden = !(
+            editor.call('mcp:status') === 'connected' &&
+            last && !last.window.closed && !last.mcp
+        );
+    };
 
     const render = (state: string) => {
         statusValue.text = state.charAt(0).toUpperCase() + state.slice(1);
@@ -53,6 +65,7 @@ editor.once('load', () => {
         button.class[state === 'connected' ? 'add' : 'remove']('active');
         portField.enabled = state === 'disconnected';
         toggle.text = state === 'connecting' ? 'CANCEL' : state === 'connected' ? 'DISCONNECT' : 'CONNECT';
+        updateHint();
     };
     render(editor.call('mcp:status') || 'disconnected');
     editor.on('mcp:status', render);
@@ -88,6 +101,7 @@ editor.once('load', () => {
         // suppress the hover tooltip while open so its arrow doesn't poke out from under the popover
         tooltip.detach();
         tooltip.hidden = true;
+        updateHint();
         window.addEventListener('mousedown', onOutside);
     });
     popover.on('hide', () => {

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -1,0 +1,97 @@
+import { Button, Container, Label, Panel, TextInput } from '@playcanvas/pcui';
+
+import { TooltipHandle } from '@/common/tooltips';
+
+import { DEFAULT_PORT } from './connection';
+
+// MCP mark from Hugeicons (mcp-server-solid-sharp), fills set to currentColor.
+const MCP_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" class="mcp-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M11.3574 2.48548C12.8602 1.12772 15.1806 1.17296 16.6289 2.62122C17.4208 3.41316 17.7931 4.46597 17.7461 5.50306C18.7835 5.45572 19.8367 5.82907 20.6289 6.62122L20.7646 6.76478C22.0784 8.21914 22.0785 10.4384 20.7646 11.8927L20.6289 12.0353L13.6641 19.0001L15.7499 21.0859L14.3358 22.5L12.25 20.4142C11.4692 19.6332 11.4692 18.3671 12.25 17.5861L19.2148 10.6212L19.3398 10.4826C19.8866 9.8123 19.8864 8.84526 19.3398 8.17494L19.2148 8.03529C18.5454 7.36591 17.4857 7.32444 16.7676 7.91029L16.6289 8.03529L9.75 14.9142L8.33594 13.5001L15.2148 6.62122L15.3398 6.48255C15.9256 5.76438 15.8843 4.70474 15.2148 4.03529C14.5454 3.36591 13.4857 3.32444 12.7676 3.91029L12.6289 4.03529L3.66406 13.0001L2.25 11.5861L11.2148 2.62122L11.3574 2.48548Z" fill="currentColor"/><path d="M12.1426 16.5145C10.6398 17.8723 8.31936 17.8271 6.87109 16.3788C5.42285 14.9304 5.37768 12.6101 6.73535 11.1073L6.87109 10.9647L13.75 4.08581L15.1641 5.49987L8.28516 12.3788L8.16016 12.5174C7.57439 13.2356 7.61576 14.2953 8.28516 14.9647C8.95454 15.6341 10.0143 15.6755 10.7324 15.0897L10.8711 14.9647L17.75 8.08581L19.1641 9.49987L12.2852 16.3788L12.1426 16.5145Z" fill="currentColor"/></svg>';
+
+editor.once('load', () => {
+    const root = editor.call('layout.root');
+    const toolbar = editor.call('layout.toolbar');
+
+    // toolbar button, placed below the publish button (last item in the top group)
+    const button = new Button({ class: ['pc-icon', 'mcp'] });
+    button.dom.appendChild(new DOMParser().parseFromString(MCP_ICON, 'image/svg+xml').documentElement);
+    toolbar.append(button);
+
+    const tooltip = TooltipHandle.attach({
+        target: button.dom,
+        text: 'MCP Server',
+        align: 'left',
+        root
+    });
+
+    // connect popover
+    const popover = new Panel({ class: 'mcp-popover', headerText: 'MCP SERVER', collapsible: true, hidden: true });
+
+    const statusValue = new Label({ class: 'mcp-status-value', text: 'Disconnected' });
+    const statusRow = new Container({ class: 'mcp-row' });
+    statusRow.append(new Label({ class: 'mcp-row-label', text: 'Status' }));
+    statusRow.append(statusValue);
+
+    const portField = new TextInput({ class: 'mcp-field', value: String(DEFAULT_PORT) });
+    const portRow = new Container({ class: 'mcp-row' });
+    portRow.append(new Label({ class: 'mcp-row-label', text: 'Port' }));
+    portRow.append(portField);
+
+    const toggle = new Button({ class: 'mcp-toggle', text: 'CONNECT' });
+
+    popover.append(statusRow);
+    popover.append(portRow);
+    popover.append(toggle);
+    root.append(popover);
+
+    const render = (state: string) => {
+        statusValue.text = state.charAt(0).toUpperCase() + state.slice(1);
+        statusValue.class.remove('mcp-connecting', 'mcp-connected');
+        if (state === 'connecting' || state === 'connected') {
+            statusValue.class.add(`mcp-${state}`);
+        }
+        button.class[state === 'connected' ? 'add' : 'remove']('active');
+        portField.enabled = state === 'disconnected';
+        toggle.text = state === 'connecting' ? 'CANCEL' : state === 'connected' ? 'DISCONNECT' : 'CONNECT';
+    };
+    render(editor.call('mcp:status') || 'disconnected');
+    editor.on('mcp:status', render);
+
+    toggle.on('click', () => {
+        if (editor.call('mcp:status') === 'disconnected') {
+            editor.call('mcp:connect', parseInt(portField.value, 10) || DEFAULT_PORT);
+        } else {
+            editor.call('mcp:disconnect');
+        }
+    });
+
+    // toggle popover, centered vertically on the button, close on outside click
+    const onOutside = (evt: MouseEvent) => {
+        const target = evt.target as Node;
+        if (popover.dom.contains(target) || button.dom.contains(target)) {
+            return;
+        }
+        popover.hidden = true;
+    };
+    button.on('click', () => {
+        if (!popover.hidden) {
+            popover.hidden = true;
+            return;
+        }
+        popover.hidden = false;
+        const rect = button.dom.getBoundingClientRect();
+        const top = rect.top + rect.height / 2 - popover.dom.offsetHeight / 2;
+        popover.dom.style.left = `${rect.right + 4}px`;
+        popover.dom.style.top = `${Math.max(4, top)}px`;
+    });
+    popover.on('show', () => {
+        // suppress the hover tooltip while open so its arrow doesn't poke out from under the popover
+        tooltip.detach();
+        tooltip.hidden = true;
+        window.addEventListener('mousedown', onOutside);
+    });
+    popover.on('hide', () => {
+        tooltip.attach(button.dom);
+        window.removeEventListener('mousedown', onOutside);
+    });
+});

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -50,10 +50,7 @@ editor.once('load', () => {
 
     const updateHint = () => {
         const last = editor.call('launch:window');
-        hint.hidden = !(
-            editor.call('mcp:status') === 'connected' &&
-            last && !last.window.closed && !last.mcp
-        );
+        hint.hidden = !(editor.call('mcp:status') === 'connected' && last && !last.window.closed && !last.mcp);
     };
 
     const render = (state: string) => {

--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -52,6 +52,10 @@ editor.once('load', () => {
 
     const launchOptions = {};
 
+    // last manually launched window and whether its URL carried mcp_port, so the
+    // MCP popover can hint that an already-open app needs a relaunch to connect
+    let lastLaunch: { window: Window; mcp: boolean } | null = null;
+
     const launchApp = (
         deviceOptions: {
             webgpu?: boolean;
@@ -93,6 +97,13 @@ editor.once('load', () => {
             query.push('ministats=true');
         }
 
+        // if the editor is connected to an MCP server, hand the port to the launch
+        // page so it connects back as the runtime peer
+        const withMcp = editor.call('mcp:status') === 'connected';
+        if (withMcp) {
+            query.push(`mcp_port=${editor.call('mcp:port')}`);
+        }
+
         const params = new URLSearchParams(location.search);
         if (params.has('use_local_engine')) {
             query.push(`use_local_engine=${params.get('use_local_engine')}`);
@@ -120,8 +131,11 @@ editor.once('load', () => {
         if (launcher) {
             launcher.opener = null;
             launcher.location = url;
+            lastLaunch = { window: launcher, mcp: withMcp };
         }
     };
+
+    editor.method('launch:window', () => lastLaunch);
 
     buttonLaunch.on('click', (e: MouseEvent) => launchApp({}, e.shiftKey));
 

--- a/src/launch/index.ts
+++ b/src/launch/index.ts
@@ -6,6 +6,9 @@ import '@/common/extensions';
 
 // general
 import './editor';
+
+// mcp runtime peer (imported early so console capture covers scene/script logs)
+import './mcp/runtime';
 import './messenger/messenger';
 import './wasm/wasm';
 

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -1,0 +1,395 @@
+import { mcp } from '@/editor/mcp/connection';
+
+/**
+ * MCP "runtime" peer for the launch page (ported from the former Chrome extension's
+ * launch content script). Captures console output early, screenshots the *running* app,
+ * and answers `runtime:*` calls from the MCP server. Connects automatically when the
+ * page is opened with `?mcp_port=<port>` (appended by the editor's `launch:start`
+ * MCP method), registering as the 'runtime' peer; otherwise stays idle.
+ */
+
+const LOG_CAP = 1000;
+
+type LogEntry = { time: number; level: string; text: string };
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const logs: LogEntry[] = [];
+const original = {
+    log: console.log.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    debug: console.debug.bind(console)
+};
+
+// use the original console to avoid buffering our own output into runtime:logs
+const log = (msg: string) => original.log(`[MCP] ${msg}`);
+
+const push = (level: string, args: any[], stack?: string) => {
+    const text = args
+        .map((a) => {
+            if (typeof a === 'string') {
+                return a;
+            }
+            try {
+                return JSON.stringify(a);
+            } catch {
+                return String(a);
+            }
+        })
+        .join(' ');
+    logs.push({ time: Date.now(), level, text: stack ? `${text}\n${stack}` : text });
+    if (logs.length > LOG_CAP) {
+        logs.shift();
+    }
+};
+
+(['log', 'info', 'warn', 'error', 'debug'] as const).forEach((level) => {
+    console[level] = (...args: any[]) => {
+        push(level, args);
+        original[level](...args);
+    };
+});
+window.addEventListener('error', (e) => {
+    push('error', [e.message], e.error?.stack || `${e.filename}:${e.lineno}:${e.colno}`);
+});
+window.addEventListener('unhandledrejection', (e) => {
+    push('error', [`Unhandled promise rejection: ${e.reason?.message ?? e.reason}`], e.reason?.stack);
+});
+
+mcp.method('runtime:ping', () => ({ data: 'pong' }));
+
+mcp.method('runtime:capture', () => new Promise<{ data?: any; error?: string; meta?: Record<string, any> }>((resolve) => {
+    const app = editor.call('viewport:app');
+    if (!app || !app.graphicsDevice) {
+        resolve({ error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.' });
+        return;
+    }
+    const device = app.graphicsDevice;
+    const gl = device.gl;
+    if (!gl) {
+        resolve({ error: 'WebGL context not found on the runtime app.' });
+        return;
+    }
+
+    // read the backbuffer at the end of a frame, while it is still valid
+    const onEnd = () => {
+        app.off('frameend', onEnd);
+        try {
+            const width = device.width;
+            const height = device.height;
+
+            const pixels = new Uint8Array(width * height * 4);
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+            // flip vertically (WebGL reads bottom-to-top)
+            const flipped = new Uint8Array(width * height * 4);
+            const rowSize = width * 4;
+            for (let y = 0; y < height; y++) {
+                flipped.set(pixels.subarray((height - 1 - y) * rowSize, (height - y) * rowSize), y * rowSize);
+            }
+
+            const srcCanvas = document.createElement('canvas');
+            srcCanvas.width = width;
+            srcCanvas.height = height;
+            const srcCtx = srcCanvas.getContext('2d')!;
+            srcCtx.putImageData(new ImageData(new Uint8ClampedArray(flipped.buffer), width, height), 0, 0);
+
+            const maxWidth = 800;
+            let dstWidth = width;
+            let dstHeight = height;
+            if (width > maxWidth) {
+                dstWidth = maxWidth;
+                dstHeight = Math.round(height * (maxWidth / width));
+            }
+
+            const dstCanvas = document.createElement('canvas');
+            dstCanvas.width = dstWidth;
+            dstCanvas.height = dstHeight;
+            dstCanvas.getContext('2d')!.drawImage(srcCanvas, 0, 0, dstWidth, dstHeight);
+
+            const base64 = dstCanvas.toDataURL('image/webp', 0.8).split(',')[1];
+            log(`Captured runtime screenshot (${dstWidth}x${dstHeight})`);
+            resolve({ data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } });
+        } catch (e: any) {
+            resolve({ error: `Failed to capture runtime: ${e.message}` });
+        }
+    };
+    app.on('frameend', onEnd);
+}));
+
+mcp.method('runtime:logs', (options: any = {}) => {
+    const order: Record<string, number> = { debug: 0, log: 1, info: 1, warn: 2, error: 3 };
+    const minLevel = options.level && options.level !== 'all' ? (order[options.level] ?? 0) : 0;
+    const keyword = options.keyword ? String(options.keyword).toLowerCase() : null;
+
+    let filtered = logs.filter((entry) => (order[entry.level] ?? 1) >= minLevel);
+    if (keyword) {
+        filtered = filtered.filter((entry) => entry.text.toLowerCase().includes(keyword));
+    }
+
+    // newest first so the most recent entries are returned by default
+    filtered = filtered.slice().reverse();
+
+    const total = filtered.length;
+    const limit = Number.isFinite(options.limit) ? Math.max(0, options.limit) : 100;
+    const offset = Number.isFinite(options.offset) ? Math.max(0, options.offset) : 0;
+    const page = limit > 0 ? filtered.slice(offset, offset + limit) : filtered.slice(offset);
+    const end = offset + page.length;
+    const hasMore = end < total;
+
+    return {
+        data: page,
+        meta: {
+            total,
+            count: page.length,
+            hasMore,
+            nextCursor: hasMore ? String(end) : null
+        }
+    };
+});
+
+/**
+ * Round a number to 4 decimals to keep runtime-state payloads compact and free of
+ * float noise (e.g. 1.0000000002 -> 1).
+ *
+ * @param n - The number to round.
+ * @returns The rounded number.
+ */
+const round = (n: number) => (typeof n === 'number' && Number.isFinite(n) ? Math.round(n * 1e4) / 1e4 : n);
+
+/**
+ * Build a compact, non-visual snapshot of a live runtime entity — the ground-truth
+ * read-back that lets the agent confirm behaviour (did the ball move? did the score
+ * update?) without guessing screenshot timing.
+ *
+ * @param e - The pc.Entity instance.
+ * @returns The runtime state summary.
+ */
+const entityRuntimeState = (e: any) => {
+    const p = e.getPosition();
+    const lp = e.getLocalPosition();
+    const r = e.getEulerAngles();
+    const s = e.getLocalScale();
+    const state: Record<string, any> = {
+        name: e.name,
+        guid: e.getGuid(),
+        enabled: e.enabled,
+        position: [round(p.x), round(p.y), round(p.z)],
+        localPosition: [round(lp.x), round(lp.y), round(lp.z)],
+        rotation: [round(r.x), round(r.y), round(r.z)],
+        scale: [round(s.x), round(s.y), round(s.z)],
+        components: Object.keys(e.c || {})
+    };
+    if (e.rigidbody) {
+        const lv = e.rigidbody.linearVelocity;
+        const av = e.rigidbody.angularVelocity;
+        state.rigidbody = {
+            type: e.rigidbody.type,
+            mass: e.rigidbody.mass,
+            enabled: e.rigidbody.enabled,
+            linearVelocity: lv ? [round(lv.x), round(lv.y), round(lv.z)] : null,
+            angularVelocity: av ? [round(av.x), round(av.y), round(av.z)] : null
+        };
+    }
+    if (e.collision) {
+        state.collision = { type: e.collision.type, enabled: e.collision.enabled };
+    }
+    if (e.element) {
+        state.element = { type: e.element.type, text: e.element.text };
+    }
+    return state;
+};
+
+mcp.method('runtime:state', (options: any = {}) => {
+    const app = editor.call('viewport:app');
+    if (!app || !app.root) {
+        return { error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.' };
+    }
+
+    let entities;
+    if (Array.isArray(options.ids) && options.ids.length) {
+        entities = options.ids.map((id: string) => app.root.findByGuid(id)).filter(Boolean);
+    } else if (options.name) {
+        const q = String(options.name).toLowerCase();
+        entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n.name && n.name.toLowerCase().includes(q));
+    } else {
+        // no filter: return every entity (paginated). Excludes the root.
+        entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n !== app.root);
+    }
+
+    const total = entities.length;
+    const limit = Number.isFinite(options.limit) ? Math.max(0, options.limit) : 50;
+    const offset = Number.isFinite(options.offset) ? Math.max(0, options.offset) : 0;
+    const page = limit > 0 ? entities.slice(offset, offset + limit) : entities.slice(offset);
+    const end = offset + page.length;
+    const hasMore = end < total;
+
+    log(`Queried runtime state (${page.length}/${total})`);
+    return {
+        data: page.map(entityRuntimeState),
+        meta: {
+            total,
+            count: page.length,
+            hasMore,
+            nextCursor: hasMore ? String(end) : null
+        }
+    };
+});
+
+const SPECIAL_KEYS: Record<string, { key: string; code: string; keyCode: number }> = {
+    ' ': { key: ' ', code: 'Space', keyCode: 32 },
+    space: { key: ' ', code: 'Space', keyCode: 32 },
+    enter: { key: 'Enter', code: 'Enter', keyCode: 13 },
+    return: { key: 'Enter', code: 'Enter', keyCode: 13 },
+    escape: { key: 'Escape', code: 'Escape', keyCode: 27 },
+    esc: { key: 'Escape', code: 'Escape', keyCode: 27 },
+    tab: { key: 'Tab', code: 'Tab', keyCode: 9 },
+    backspace: { key: 'Backspace', code: 'Backspace', keyCode: 8 },
+    delete: { key: 'Delete', code: 'Delete', keyCode: 46 },
+    shift: { key: 'Shift', code: 'ShiftLeft', keyCode: 16 },
+    control: { key: 'Control', code: 'ControlLeft', keyCode: 17 },
+    ctrl: { key: 'Control', code: 'ControlLeft', keyCode: 17 },
+    alt: { key: 'Alt', code: 'AltLeft', keyCode: 18 },
+    arrowleft: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+    left: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+    arrowup: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+    up: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+    arrowright: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+    right: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+    arrowdown: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+    down: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 }
+};
+
+/**
+ * Resolve a friendly key name into the fields PlayCanvas / the DOM expect.
+ *
+ * @param raw - The key name (e.g. 'w', 'Space', 'ArrowUp').
+ * @returns Key descriptor.
+ */
+const keyInfo = (raw: string) => {
+    const k = String(raw);
+    const special = SPECIAL_KEYS[k.toLowerCase()];
+    if (special) {
+        return special;
+    }
+    if (k.length === 1) {
+        const code = k.toUpperCase().charCodeAt(0);
+        if (/[a-z]/i.test(k)) {
+            return { key: k, code: `Key${k.toUpperCase()}`, keyCode: code };
+        }
+        if (/[0-9]/.test(k)) {
+            return { key: k, code: `Digit${k}`, keyCode: code };
+        }
+        return { key: k, code: k, keyCode: code };
+    }
+    return { key: k, code: k, keyCode: 0 };
+};
+
+const getCanvas = (): HTMLCanvasElement | null => {
+    const app = editor.call('viewport:app');
+    return (app && app.graphicsDevice && app.graphicsDevice.canvas) || document.querySelector('canvas') || null;
+};
+
+const dispatchKey = (kind: string, info: { key: string; code: string; keyCode: number }) => {
+    const e = new KeyboardEvent(kind, { key: info.key, code: info.code, bubbles: true, cancelable: true, view: window });
+
+    // keyCode/which are read-only and not settable via the constructor, but
+    // PlayCanvas' keyboard handler reads them — so back them with getters
+    Object.defineProperty(e, 'keyCode', { get: () => info.keyCode });
+    Object.defineProperty(e, 'which', { get: () => info.keyCode });
+    window.dispatchEvent(e);
+    document.dispatchEvent(e);
+};
+
+const dispatchMouse = (kind: string, canvas: HTMLCanvasElement, x?: number, y?: number, button?: number) => {
+    const rect = canvas.getBoundingClientRect();
+    const clientX = rect.left + (x || 0);
+    const clientY = rect.top + (y || 0);
+    const buttons = kind === 'mousedown' ? (button === 2 ? 2 : button === 1 ? 4 : 1) : 0;
+    canvas.dispatchEvent(new MouseEvent(kind, {
+        clientX, clientY, button: button || 0, buttons, bubbles: true, cancelable: true, view: window
+    }));
+};
+
+const dispatchTouch = (kind: string, canvas: HTMLCanvasElement, x?: number, y?: number, id?: number) => {
+    const rect = canvas.getBoundingClientRect();
+    const clientX = rect.left + (x || 0);
+    const clientY = rect.top + (y || 0);
+    const touch = new Touch({ identifier: id || 0, target: canvas, clientX, clientY, pageX: clientX, pageY: clientY, radiusX: 1, radiusY: 1, force: 1 });
+    const active = kind === 'touchend' ? [] : [touch];
+    canvas.dispatchEvent(new TouchEvent(kind, {
+        touches: active, targetTouches: active, changedTouches: [touch], bubbles: true, cancelable: true, view: window
+    }));
+};
+
+mcp.method('runtime:input', async (payload: any = {}) => {
+    const events = Array.isArray(payload.events) ? payload.events : [];
+    if (!events.length) {
+        return { error: 'No input events provided.' };
+    }
+    const canvas = getCanvas();
+    if (!canvas) {
+        return { error: 'Runtime canvas not found. Ensure launch_start succeeded and the scene has loaded, then retry.' };
+    }
+    const betweenMs = Number.isFinite(payload.betweenMs) ? payload.betweenMs : 0;
+
+    let dispatched = 0;
+    for (const ev of events) {
+        if (ev.type === 'key') {
+            const info = keyInfo(ev.key);
+            const action = ev.action || 'press';
+            const repeat = Math.max(1, ev.repeat || 1);
+            for (let i = 0; i < repeat; i++) {
+                if (action === 'down') {
+                    dispatchKey('keydown', info);
+                } else if (action === 'up') {
+                    dispatchKey('keyup', info);
+                } else {
+                    dispatchKey('keydown', info);
+                    if (ev.holdMs) {
+                        await wait(ev.holdMs);
+                    }
+                    dispatchKey('keyup', info);
+                }
+                dispatched++;
+            }
+        } else if (ev.type === 'mouse') {
+            if (ev.action === 'click') {
+                dispatchMouse('mousedown', canvas, ev.x, ev.y, ev.button);
+                dispatchMouse('mouseup', canvas, ev.x, ev.y, ev.button);
+            } else {
+                dispatchMouse(`mouse${ev.action}`, canvas, ev.x, ev.y, ev.button);
+            }
+            dispatched++;
+        } else if (ev.type === 'touch') {
+            if (ev.action === 'tap') {
+                dispatchTouch('touchstart', canvas, ev.x, ev.y, ev.id);
+                dispatchTouch('touchend', canvas, ev.x, ev.y, ev.id);
+            } else {
+                dispatchTouch(`touch${ev.action}`, canvas, ev.x, ev.y, ev.id);
+            }
+            dispatched++;
+        }
+        if (betweenMs) {
+            await wait(betweenMs);
+        }
+    }
+    log(`Injected ${dispatched} input event(s)`);
+    return { data: { dispatched } };
+});
+
+// connect automatically when opened via the editor's launch:start (which appends
+// mcp_port); otherwise stay idle
+const port = new URLSearchParams(location.search).get('mcp_port');
+if (port) {
+    mcp.connect(parseInt(port, 10), 'runtime');
+}
+
+window.addEventListener('beforeunload', () => {
+    if (mcp.status !== 'disconnected') {
+        mcp.disconnect();
+    }
+});

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -60,65 +60,71 @@ window.addEventListener('unhandledrejection', (e) => {
 
 mcp.method('runtime:ping', () => ({ data: 'pong' }));
 
-mcp.method('runtime:capture', () => new Promise<{ data?: any; error?: string; meta?: Record<string, any> }>((resolve) => {
-    const app = editor.call('viewport:app');
-    if (!app || !app.graphicsDevice) {
-        resolve({ error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.' });
-        return;
-    }
-    const device = app.graphicsDevice;
-    const gl = device.gl;
-    if (!gl) {
-        resolve({ error: 'WebGL context not found on the runtime app.' });
-        return;
-    }
-
-    // read the backbuffer at the end of a frame, while it is still valid
-    const onEnd = () => {
-        app.off('frameend', onEnd);
-        try {
-            const width = device.width;
-            const height = device.height;
-
-            const pixels = new Uint8Array(width * height * 4);
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-            gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-            // flip vertically (WebGL reads bottom-to-top)
-            const flipped = new Uint8Array(width * height * 4);
-            const rowSize = width * 4;
-            for (let y = 0; y < height; y++) {
-                flipped.set(pixels.subarray((height - 1 - y) * rowSize, (height - y) * rowSize), y * rowSize);
+mcp.method(
+    'runtime:capture',
+    () =>
+        new Promise<{ data?: any; error?: string; meta?: Record<string, any> }>((resolve) => {
+            const app = editor.call('viewport:app');
+            if (!app || !app.graphicsDevice) {
+                resolve({
+                    error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.'
+                });
+                return;
+            }
+            const device = app.graphicsDevice;
+            const gl = device.gl;
+            if (!gl) {
+                resolve({ error: 'WebGL context not found on the runtime app.' });
+                return;
             }
 
-            const srcCanvas = document.createElement('canvas');
-            srcCanvas.width = width;
-            srcCanvas.height = height;
-            const srcCtx = srcCanvas.getContext('2d')!;
-            srcCtx.putImageData(new ImageData(new Uint8ClampedArray(flipped.buffer), width, height), 0, 0);
+            // read the backbuffer at the end of a frame, while it is still valid
+            const onEnd = () => {
+                app.off('frameend', onEnd);
+                try {
+                    const width = device.width;
+                    const height = device.height;
 
-            const maxWidth = 800;
-            let dstWidth = width;
-            let dstHeight = height;
-            if (width > maxWidth) {
-                dstWidth = maxWidth;
-                dstHeight = Math.round(height * (maxWidth / width));
-            }
+                    const pixels = new Uint8Array(width * height * 4);
+                    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 
-            const dstCanvas = document.createElement('canvas');
-            dstCanvas.width = dstWidth;
-            dstCanvas.height = dstHeight;
-            dstCanvas.getContext('2d')!.drawImage(srcCanvas, 0, 0, dstWidth, dstHeight);
+                    // flip vertically (WebGL reads bottom-to-top)
+                    const flipped = new Uint8Array(width * height * 4);
+                    const rowSize = width * 4;
+                    for (let y = 0; y < height; y++) {
+                        flipped.set(pixels.subarray((height - 1 - y) * rowSize, (height - y) * rowSize), y * rowSize);
+                    }
 
-            const base64 = dstCanvas.toDataURL('image/webp', 0.8).split(',')[1];
-            log(`Captured runtime screenshot (${dstWidth}x${dstHeight})`);
-            resolve({ data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } });
-        } catch (e: any) {
-            resolve({ error: `Failed to capture runtime: ${e.message}` });
-        }
-    };
-    app.on('frameend', onEnd);
-}));
+                    const srcCanvas = document.createElement('canvas');
+                    srcCanvas.width = width;
+                    srcCanvas.height = height;
+                    const srcCtx = srcCanvas.getContext('2d')!;
+                    srcCtx.putImageData(new ImageData(new Uint8ClampedArray(flipped.buffer), width, height), 0, 0);
+
+                    const maxWidth = 800;
+                    let dstWidth = width;
+                    let dstHeight = height;
+                    if (width > maxWidth) {
+                        dstWidth = maxWidth;
+                        dstHeight = Math.round(height * (maxWidth / width));
+                    }
+
+                    const dstCanvas = document.createElement('canvas');
+                    dstCanvas.width = dstWidth;
+                    dstCanvas.height = dstHeight;
+                    dstCanvas.getContext('2d')!.drawImage(srcCanvas, 0, 0, dstWidth, dstHeight);
+
+                    const base64 = dstCanvas.toDataURL('image/webp', 0.8).split(',')[1];
+                    log(`Captured runtime screenshot (${dstWidth}x${dstHeight})`);
+                    resolve({ data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } });
+                } catch (e: any) {
+                    resolve({ error: `Failed to capture runtime: ${e.message}` });
+                }
+            };
+            app.on('frameend', onEnd);
+        })
+);
 
 mcp.method('runtime:logs', (options: any = {}) => {
     const order: Record<string, number> = { debug: 0, log: 1, info: 1, warn: 2, error: 3 };
@@ -206,7 +212,9 @@ const entityRuntimeState = (e: any) => {
 mcp.method('runtime:state', (options: any = {}) => {
     const app = editor.call('viewport:app');
     if (!app || !app.root) {
-        return { error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.' };
+        return {
+            error: 'Runtime app not ready yet. Wait for the scene to finish loading (poll read_runtime_logs) and retry.'
+        };
     }
 
     let entities;
@@ -214,7 +222,9 @@ mcp.method('runtime:state', (options: any = {}) => {
         entities = options.ids.map((id: string) => app.root.findByGuid(id)).filter(Boolean);
     } else if (options.name) {
         const q = String(options.name).toLowerCase();
-        entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n.name && n.name.toLowerCase().includes(q));
+        entities = app.root.find(
+            (n: any) => typeof n.getGuid === 'function' && n.name && n.name.toLowerCase().includes(q)
+        );
     } else {
         // no filter: return every entity (paginated). Excludes the root.
         entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n !== app.root);
@@ -294,7 +304,13 @@ const getCanvas = (): HTMLCanvasElement | null => {
 };
 
 const dispatchKey = (kind: string, info: { key: string; code: string; keyCode: number }) => {
-    const e = new KeyboardEvent(kind, { key: info.key, code: info.code, bubbles: true, cancelable: true, view: window });
+    const e = new KeyboardEvent(kind, {
+        key: info.key,
+        code: info.code,
+        bubbles: true,
+        cancelable: true,
+        view: window
+    });
 
     // keyCode/which are read-only and not settable via the constructor, but
     // PlayCanvas' keyboard handler reads them — so back them with getters
@@ -309,20 +325,45 @@ const dispatchMouse = (kind: string, canvas: HTMLCanvasElement, x?: number, y?: 
     const clientX = rect.left + (x || 0);
     const clientY = rect.top + (y || 0);
     const buttons = kind === 'mousedown' ? (button === 2 ? 2 : button === 1 ? 4 : 1) : 0;
-    canvas.dispatchEvent(new MouseEvent(kind, {
-        clientX, clientY, button: button || 0, buttons, bubbles: true, cancelable: true, view: window
-    }));
+    canvas.dispatchEvent(
+        new MouseEvent(kind, {
+            clientX,
+            clientY,
+            button: button || 0,
+            buttons,
+            bubbles: true,
+            cancelable: true,
+            view: window
+        })
+    );
 };
 
 const dispatchTouch = (kind: string, canvas: HTMLCanvasElement, x?: number, y?: number, id?: number) => {
     const rect = canvas.getBoundingClientRect();
     const clientX = rect.left + (x || 0);
     const clientY = rect.top + (y || 0);
-    const touch = new Touch({ identifier: id || 0, target: canvas, clientX, clientY, pageX: clientX, pageY: clientY, radiusX: 1, radiusY: 1, force: 1 });
+    const touch = new Touch({
+        identifier: id || 0,
+        target: canvas,
+        clientX,
+        clientY,
+        pageX: clientX,
+        pageY: clientY,
+        radiusX: 1,
+        radiusY: 1,
+        force: 1
+    });
     const active = kind === 'touchend' ? [] : [touch];
-    canvas.dispatchEvent(new TouchEvent(kind, {
-        touches: active, targetTouches: active, changedTouches: [touch], bubbles: true, cancelable: true, view: window
-    }));
+    canvas.dispatchEvent(
+        new TouchEvent(kind, {
+            touches: active,
+            targetTouches: active,
+            changedTouches: [touch],
+            bubbles: true,
+            cancelable: true,
+            view: window
+        })
+    );
 };
 
 mcp.method('runtime:input', async (payload: any = {}) => {
@@ -332,7 +373,9 @@ mcp.method('runtime:input', async (payload: any = {}) => {
     }
     const canvas = getCanvas();
     if (!canvas) {
-        return { error: 'Runtime canvas not found. Ensure launch_start succeeded and the scene has loaded, then retry.' };
+        return {
+            error: 'Runtime canvas not found. Ensure launch_start succeeded and the scene has loaded, then retry.'
+        };
     }
     const betweenMs = Number.isFinite(payload.betweenMs) ? payload.betweenMs : 0;
 


### PR DESCRIPTION
### Overview

**Restores #2149 (built-in MCP server connection) and builds on it.** #2149 was merged but later rolled back off `main`, so `main` currently has no `src/editor/mcp/` module. This PR brings it back **and** adds new features on top:

- **Commit 1** — the original #2149 squash, restoring the editor-as-MCP-peer module (`connection.ts` / `methods.ts` / `toolbar.ts`).
- **Commit 2** — the new work below: a **runtime peer for the launch page** plus editor-side launch control, so an MCP client (Claude Desktop / Cursor) can not only edit the scene but also **drive and inspect the running app** — same external MCP server, same wire protocol, with a new `{ register: 'editor' | 'runtime' }` handshake so the server routes edit-time vs runtime calls to the right peer.

### What's new

**Runtime peer — `src/launch/mcp/runtime.ts`** (ported from the former Chrome extension's launch content script):
- Early console + `error`/`unhandledrejection` capture into a ring buffer (`runtime:logs`, level/keyword filter + pagination).
- `runtime:capture` — screenshots the *running* app by reading the live WebGL backbuffer at `frameend` (webp).
- `runtime:state` — compact, non-visual snapshot of live entities (position/rotation/scale, rigidbody/collision/element) so the agent can confirm behaviour without guessing screenshot timing.
- `runtime:input` — injects key/mouse/touch events into the running canvas.
- Auto-connects as the `runtime` peer when the launch URL carries `?mcp_port=<port>`; otherwise idle.

**Connection — `src/editor/mcp/connection.ts`:**
- Announces its role (`editor`/`runtime`) on open.
- Robust auto-reconnect on unexpected close (server restart, transient network, tab throttling), with a `FORCE`/`_forceClosed` guard so a deliberate disconnect never reconnects.
- Adds `mcp:port`; unknown-method calls now return an actionable error instead of `undefined`.

**Editor tools — `src/editor/mcp/methods.ts`:**
- `launch:start` / `launch:stop` — open/close the preview window with `mcp_port` + `debug=true` appended (no popup UI), so the agent can launch the runtime peer directly.
- `entities:resolve` (find by name), `entities:script:attach` (ensure script component + attach in one call).
- Validate-on-write entity paths — a provably-invalid path fails fast with an actionable message instead of silently no-op'ing.
- Mutations return inline entity/asset summaries (with hierarchy `path`), saving a follow-up `list_entities` round-trip.
- Pagination + response `meta` across list tools; empty results are a valid success, not an error; richer, actionable error messages throughout.

**Editor → launch handoff — `viewport-launch.ts` / `toolbar.ts`:**
- When the editor is MCP-connected, the manual **Launch** button appends `mcp_port` so the launched app connects back as the runtime peer.
- Popover hint ("Relaunch the open app to connect it") when an app was launched *before* connecting.

### Verification

- `eslint` / `stylelint` clean on the touched files (`no-explicit-any` warnings only, matching the existing MCP module).
- No new `tsc` errors in the touched files (pre-existing errors in `src/workers/*` and `viewport-launch.ts`'s `launchOptions` are unrelated and present on `main`).
- Full end-to-end against a live MCP server driving a launched app is the remaining manual check.
