### PR TITLE
feat(mcp): expand editor MCP methods (asset read, scene/project mgmt, selection, history, gizmo, camera, search)

### DIFF
--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -726,8 +726,8 @@ mcp.method('assets:file:text:get', async (id) => {
         const text = await res.text();
         log(`Got asset(${id}) text`);
         return { data: { id, type, filename: asset.get('file.filename'), text } };
-    } catch (e: any) {
-        return { error: e.message };
+    } catch (e) {
+        return { error: e instanceof Error ? e.message : String(e) };
     }
 });
 mcp.method('assets:script:parse', async (id) => {
@@ -795,7 +795,7 @@ mcp.method('scenes:list', async () => {
     return { data };
 });
 mcp.method('scenes:get', async (id) => {
-    const [err, data] = await new Promise<any[]>((resolve) => {
+    const [err, data] = await new Promise<unknown[]>((resolve) => {
         editor.call('scenes:get', String(id), (e: unknown, d: unknown) => resolve([e, d]));
     });
     if (err) {
@@ -837,17 +837,17 @@ mcp.method('scene:load', (uniqueId) => {
 mcp.method('selection:get', () => {
     const items = api.selection.items || [];
     const type = editor.call('selector:type');
-    const ids = items.map((it: any) => (type === 'asset' ? it.get('id') : it.get('resource_id')));
+    const ids = items.map((it) => (type === 'asset' ? it.get('id') : it.get('resource_id')));
     log('Queried selection');
     return { data: { type, ids } };
 });
 mcp.method('selection:set', (type, ids) => {
     const items = (ids || [])
-        .map((id: any) => (type === 'asset' ? api.assets.get(id) : api.entities.get(id)))
+        .map((id) => (type === 'asset' ? api.assets.get(id) : api.entities.get(id)))
         .filter(Boolean);
     api.selection.set(items);
     log(`Set ${type} selection (${items.length})`);
-    return { data: { type, ids: items.map((it: any) => (type === 'asset' ? it.get('id') : it.get('resource_id'))) } };
+    return { data: { type, ids: items.map((it) => (type === 'asset' ? it.get('id') : it.get('resource_id'))) } };
 });
 mcp.method('selection:clear', () => {
     api.selection.clear();

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -6,6 +6,9 @@ import { mcp } from './connection';
 
 const api = editor.api.globals;
 
+// reused scratch vector — camera:focus copies it synchronously, no listener retains it
+const tmpVec3 = new Vec3();
+
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
 
 /**
@@ -891,7 +894,7 @@ mcp.method('camera:focus:point', (point, distance) => {
     if (!Array.isArray(point) || point.length !== 3) {
         return { error: 'point must be an array [x, y, z].' };
     }
-    editor.call('camera:focus', new Vec3(point[0], point[1], point[2]), distance);
+    editor.call('camera:focus', tmpVec3.set(point[0], point[1], point[2]), distance);
     log(`Focused camera on [${point.join(', ')}] at distance ${distance}`);
     return { data: { point, distance } };
 });

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -1,3 +1,5 @@
+import { Vec3 } from 'playcanvas';
+
 import { config } from '@/editor/config';
 
 import { mcp } from './connection';
@@ -697,6 +699,34 @@ mcp.method('assets:script:text:set', async (id, text) => {
         return { error: e.message };
     }
 });
+mcp.method('assets:file:text:get', async (id) => {
+    const asset = api.assets.get(id);
+    if (!asset) {
+        return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
+    }
+
+    const type = asset.get('type');
+    if (!['css', 'html', 'json', 'script', 'shader', 'text'].includes(type)) {
+        return { error: `Asset ${id} is type "${type}"; only text-based assets (css, html, json, script, shader, text) can be read as text.` };
+    }
+
+    const url = asset.get('file.url');
+    if (!url) {
+        return { error: `Asset ${id} has no source file.` };
+    }
+
+    try {
+        const res = await fetch(url);
+        if (!res.ok) {
+            return { error: `Failed to fetch asset text: ${res.status} ${res.statusText}` };
+        }
+        const text = await res.text();
+        log(`Got asset(${id}) text`);
+        return { data: { id, type, filename: asset.get('file.filename'), text } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
 mcp.method('assets:script:parse', async (id) => {
     const asset = api.assets.get(id);
     if (!asset) {
@@ -734,6 +764,151 @@ mcp.method('scene:settings:query', () => {
     const scene = api.settings.scene;
     log('Queried scene settings');
     return { data: scene.json() };
+});
+
+// project settings
+mcp.method('project:settings:modify', (settings) => {
+    const project = editor.call('settings:project');
+    iterateObject(settings, (path, value) => {
+        project.set(path, value);
+    });
+    log('Modified project settings');
+
+    // return the resulting settings snapshot inline
+    return { data: project.json() };
+});
+mcp.method('project:settings:query', () => {
+    const project = editor.call('settings:project');
+    log('Queried project settings');
+    return { data: project.json() };
+});
+
+// scene management
+mcp.method('scenes:list', async () => {
+    const data = await new Promise((resolve) => {
+        editor.call('scenes:list', (result: unknown) => resolve(result));
+    });
+    log('Listed scenes');
+    return { data };
+});
+mcp.method('scenes:get', async (id) => {
+    const [err, data] = await new Promise<any[]>((resolve) => {
+        editor.call('scenes:get', String(id), (e: unknown, d: unknown) => resolve([e, d]));
+    });
+    if (err) {
+        return { error: `Scene not found: ${id}. Call list_scenes to obtain a valid scene id.` };
+    }
+    log(`Got scene(${id})`);
+    return { data };
+});
+mcp.method('scenes:new', async (name) => {
+    const data = await new Promise((resolve) => {
+        editor.call('scenes:new', name, (d: unknown) => resolve(d));
+    });
+    log(`Created scene: ${name ?? '(unnamed)'}`);
+    return { data };
+});
+mcp.method('scenes:duplicate', async (id, name) => {
+    const data = await new Promise((resolve) => {
+        editor.call('scenes:duplicate', String(id), name, (d: unknown) => resolve(d));
+    });
+    log(`Duplicated scene(${id})`);
+    return { data };
+});
+mcp.method('scenes:delete', async (id) => {
+    await new Promise<void>((resolve) => {
+        editor.call('scenes:delete', String(id), () => resolve());
+    });
+    log(`Deleted scene(${id})`);
+    return { data: { deleted: id } };
+});
+mcp.method('scene:load', (uniqueId) => {
+    // scene:load defers until realtime is authenticated, so this returns before
+    // the switch completes; the editor loads the scene asynchronously.
+    editor.call('scene:load', uniqueId);
+    log(`Loading scene(${uniqueId})`);
+    return { data: { loading: uniqueId } };
+});
+
+// selection
+mcp.method('selection:get', () => {
+    const items = api.selection.items || [];
+    const type = editor.call('selector:type');
+    const ids = items.map((it: any) => (type === 'asset' ? it.get('id') : it.get('resource_id')));
+    log('Queried selection');
+    return { data: { type, ids } };
+});
+mcp.method('selection:set', (type, ids) => {
+    const items = (ids || [])
+        .map((id: any) => (type === 'asset' ? api.assets.get(id) : api.entities.get(id)))
+        .filter(Boolean);
+    api.selection.set(items);
+    log(`Set ${type} selection (${items.length})`);
+    return { data: { type, ids: items.map((it: any) => (type === 'asset' ? it.get('id') : it.get('resource_id'))) } };
+});
+mcp.method('selection:clear', () => {
+    api.selection.clear();
+    log('Cleared selection');
+    return { data: { type: null, ids: [] } };
+});
+
+// history (undo/redo)
+mcp.method('history:undo', () => {
+    const undone = api.history.canUndo;
+    if (undone) {
+        api.history.undo();
+    }
+    log(undone ? 'Undo' : 'Undo (nothing to undo)');
+    return { data: { undone, canUndo: api.history.canUndo, canRedo: api.history.canRedo } };
+});
+mcp.method('history:redo', () => {
+    const redone = api.history.canRedo;
+    if (redone) {
+        api.history.redo();
+    }
+    log(redone ? 'Redo' : 'Redo (nothing to redo)');
+    return { data: { redone, canUndo: api.history.canUndo, canRedo: api.history.canRedo } };
+});
+
+// transform gizmo
+mcp.method('gizmo:state:set', (state) => {
+    const s = state || {};
+    if (s.mode !== undefined) {
+        editor.call('gizmo:type', s.mode);
+    }
+    if (s.space !== undefined) {
+        editor.call('gizmo:coordSystem', s.space);
+    }
+    if (s.snap !== undefined) {
+        editor.call('gizmo:snap', s.snap);
+    }
+    log('Set gizmo state');
+    return { data: { mode: editor.call('gizmo:type'), space: editor.call('gizmo:coordSystem') } };
+});
+
+// camera framing
+mcp.method('camera:focus:point', (point, distance) => {
+    if (!Array.isArray(point) || point.length !== 3) {
+        return { error: 'point must be an array [x, y, z].' };
+    }
+    editor.call('camera:focus', new Vec3(point[0], point[1], point[2]), distance);
+    log(`Focused camera on [${point.join(', ')}] at distance ${distance}`);
+    return { data: { point, distance } };
+});
+
+// entity search
+mcp.method('entities:search', (query, limit) => {
+    let results = editor.call('entities:fuzzy-search', query) || [];
+    if (typeof limit === 'number') {
+        results = results.slice(0, limit);
+    }
+    log(`Searched entities for "${query}" (${results.length})`);
+    return { data: results.map(entitySummary) };
+});
+mcp.method('entities:byScript', (script) => {
+    const results = editor.call('entities:list:byScript', script) || [];
+    log(`Listed entities by script "${script}" (${results.length})`);
+    return { data: results.map(entitySummary) };
 });
 
 // store - playcanvas

--- a/src/editor/mcp/methods.ts
+++ b/src/editor/mcp/methods.ts
@@ -710,7 +710,9 @@ mcp.method('assets:file:text:get', async (id) => {
 
     const type = asset.get('type');
     if (!['css', 'html', 'json', 'script', 'shader', 'text'].includes(type)) {
-        return { error: `Asset ${id} is type "${type}"; only text-based assets (css, html, json, script, shader, text) can be read as text.` };
+        return {
+            error: `Asset ${id} is type "${type}"; only text-based assets (css, html, json, script, shader, text) can be read as text.`
+        };
     }
 
     const url = asset.get('file.url');


### PR DESCRIPTION
Adds MCP bridge handlers in `src/editor/mcp/methods.ts` that pair with new tools in the editor-mcp-server package. This expands what an MCP client can drive in the editor beyond content authoring.

## New methods

**Reading**
- `assets:file:text:get` — read any text-based asset's source (script/text/json/css/html/shader), with a type guard so binary assets are rejected

**Project & scene management**
- `project:settings:query` / `project:settings:modify` — read/patch project-wide settings
- `scenes:list` / `scenes:get` / `scenes:new` / `scenes:duplicate` / `scenes:delete` and `scene:load` — scene management (previously only scene *settings* were exposed)

**Editing session / viewport control**
- `selection:get` / `selection:set` / `selection:clear` — drive the editor selection
- `history:undo` / `history:redo` — roll back / re-apply edits
- `gizmo:state:set` — set transform gizmo mode/space/snap
- `camera:focus:point` — aim the current camera at a world-space point

**Search**
- `entities:search` — fuzzy-search entities by name
- `entities:byScript` — list entities whose script component uses a given script

## Notes
- Handlers reuse existing editor capabilities (`editor.call('gizmo:*' | 'camera:focus' | 'entities:fuzzy-search' | 'entities:list:byScript')`, `api.selection`, `api.history`) — no new core logic.
- `eslint` passes with 0 errors (new `no-explicit-any` warnings match the existing style in this file).
- Not yet exercised against a live editor; `tsc` typecheck + a manual smoke test recommended before merge.
