### PR TITLE
feat: VCS mcp methods (branches, checkpoints, merge lifecycle)

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -303,6 +303,7 @@ import './toolbar/toolbar-code-editor';
 // mcp
 import './mcp/connection';
 import './mcp/methods';
+import './mcp/methods-vcs';
 import './mcp/toolbar';
 
 // viewport controls

--- a/src/editor/mcp/methods-vcs.ts
+++ b/src/editor/mcp/methods-vcs.ts
@@ -1,0 +1,117 @@
+import { config } from '@/editor/config';
+import { checkpointCreate } from '@/editor/messenger/jobs';
+
+import { mcp } from './connection';
+
+const api = editor.api.globals;
+
+// current branch id, used as the default target for branch-scoped ops
+const currentBranchId = () => config.self.branch.id;
+
+// cursor pagination: the backend `skip` param is the last item's id, not an offset
+const listMeta = (result: { id: string }[], pagination?: { hasMore?: boolean }) => ({
+    hasMore: pagination?.hasMore ?? false,
+    nextCursor: result.length ? result[result.length - 1].id : null
+});
+
+mcp.method('vcs:status', () => {
+    const b = config.self.branch;
+    return {
+        data: {
+            projectId: config.project.id,
+            branch: { id: b.id, name: b.name, latestCheckpointId: b.latestCheckpointId },
+            mergeInProgress: !!b.merge
+        }
+    };
+});
+
+mcp.method('vcs:branch:list', async (opts: any = {}) => {
+    try {
+        const res: any = await api.rest.projects.projectBranches({
+            limit: opts.limit,
+            skip: opts.cursor,
+            closed: opts.closed,
+            favorite: opts.favorite
+        }).promisify();
+        return { data: res.result, meta: listMeta(res.result, res.pagination) };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:branch:create', async (opts: any = {}) => {
+    try {
+        const branch = await api.rest.branches.branchCreate({
+            name: opts.name,
+            projectId: config.project.id,
+            sourceBranchId: opts.sourceBranchId ?? currentBranchId(),
+            sourceCheckpointId: opts.sourceCheckpointId
+        }).promisify();
+        // the version-control messenger adopts the new branch and reloads the page
+        return { data: { status: 'creating', branch } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:branch:checkout', async (branchId: string) => {
+    try {
+        await api.rest.branches.branchCheckout({ branchId }).promisify();
+        // the version-control messenger switches branch and reloads the page
+        return { data: { status: 'switching', branchId } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:checkpoint:list', async (opts: any = {}) => {
+    try {
+        const res: any = await api.rest.branches.branchCheckpoints({
+            branchId: opts.branchId ?? currentBranchId(),
+            limit: opts.limit,
+            skip: opts.cursor
+        }).promisify();
+        return { data: res.result, meta: listMeta(res.result, res.pagination) };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:checkpoint:create', async (opts: any = {}) => {
+    try {
+        const checkpoint = await checkpointCreate({
+            projectId: config.project.id,
+            branchId: opts.branchId ?? currentBranchId(),
+            description: opts.description
+        });
+        return { data: checkpoint };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:checkpoint:restore', async (opts: any = {}) => {
+    try {
+        await api.rest.checkpoints.checkpointRestore({
+            checkpointId: opts.checkpointId,
+            branchId: opts.branchId ?? currentBranchId()
+        }).promisify();
+        // restore overwrites working state; the messenger reloads the page
+        return { data: { status: 'restoring', checkpointId: opts.checkpointId } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
+    try {
+        await api.rest.checkpoints.checkpointHardReset({
+            checkpointId: opts.checkpointId,
+            branchId: opts.branchId ?? currentBranchId()
+        }).promisify();
+        // hard reset erases later checkpoints and reloads the page
+        return { data: { status: 'resetting', checkpointId: opts.checkpointId } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});

--- a/src/editor/mcp/methods-vcs.ts
+++ b/src/editor/mcp/methods-vcs.ts
@@ -1,12 +1,43 @@
+import { MERGE_STATUS_AUTO_ENDED, MERGE_STATUS_READY_FOR_REVIEW } from '@/core/constants';
 import { config } from '@/editor/config';
-import { checkpointCreate } from '@/editor/messenger/jobs';
+import { checkpointCreate, diffCreate } from '@/editor/messenger/jobs';
 
 import { mcp } from './connection';
 
 const api = editor.api.globals;
 
+// how long to wait for an async merge step to progress before giving up
+const MERGE_WAIT_MS = 60_000;
+
 // current branch id, used as the default target for branch-scoped ops
 const currentBranchId = () => config.self.branch.id;
+
+// merge is async: mergeCreate/mergeApply return before the worker finishes, and progress
+// arrives as messenger:merge.setProgress events for the current (destination) branch.
+// resolve once one of `statuses` is reached; reject on task failure or timeout.
+const waitForMergeStatus = (statuses: string[]) => new Promise<string>((resolve, reject) => {
+    const branchId = currentBranchId();
+    const evt: any = editor.on('messenger:merge.setProgress', (data: any) => {
+        if (data.dst_branch_id !== branchId) {
+            return;
+        }
+        if (data.task_failed) {
+            clearTimeout(timer);
+            evt.unbind();
+            reject(new Error('Merge failed'));
+            return;
+        }
+        if (statuses.includes(data.status)) {
+            clearTimeout(timer);
+            evt.unbind();
+            resolve(data.status);
+        }
+    });
+    const timer = setTimeout(() => {
+        evt.unbind();
+        reject(new Error('Timed out waiting for the merge to progress'));
+    }, MERGE_WAIT_MS);
+});
 
 // cursor pagination: the backend `skip` param is the last item's id, not an offset
 const listMeta = (result: { id: string }[], pagination?: { hasMore?: boolean }) => ({
@@ -111,6 +142,143 @@ mcp.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
         }).promisify();
         // hard reset erases later checkpoints and reloads the page
         return { data: { status: 'resetting', checkpointId: opts.checkpointId } };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:checkpoint:get', async (opts: any = {}) => {
+    try {
+        const checkpoint = await api.rest.checkpoints.checkpointGet({ checkpointId: opts.checkpointId }).promisify();
+        return { data: checkpoint };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:branch:close', async (opts: any = {}) => {
+    try {
+        const branch = await api.rest.branches.branchClose({ branchId: opts.branchId }).promisify();
+        return { data: branch };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:branch:open', async (opts: any = {}) => {
+    try {
+        const branch = await api.rest.branches.branchOpen({ branchId: opts.branchId }).promisify();
+        return { data: branch };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:branch:delete', async (opts: any = {}) => {
+    try {
+        const branch = await api.rest.branches.branchDelete({ branchId: opts.branchId }).promisify();
+        return { data: branch };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:merge:create', async (opts: any = {}) => {
+    try {
+        // subscribe before firing so we can't miss the auto-merge-done event
+        const settled = waitForMergeStatus([MERGE_STATUS_AUTO_ENDED, MERGE_STATUS_READY_FOR_REVIEW]);
+        const created: any = await api.rest.merge.mergeCreate({
+            srcBranchId: opts.sourceBranchId,
+            dstBranchId: currentBranchId(),
+            srcBranchClose: !!opts.closeSource
+        }).promisify();
+        await settled;
+        // re-fetch so conflicts are populated (mergeCreate returns before the worker finishes)
+        const merge = await api.rest.merge.mergeGet({ mergeId: created.id }).promisify();
+        return { data: merge };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:merge:get', async (opts: any = {}) => {
+    try {
+        const merge = await api.rest.merge.mergeGet({ mergeId: opts.mergeId }).promisify();
+        return { data: merge };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:merge:apply', async (opts: any = {}) => {
+    try {
+        if (opts.finalize) {
+            // finalize commits the merge checkpoint onto the current branch; the messenger
+            // reloads the page on merge_apply_ended, so return now and let the server wait
+            await api.rest.merge.mergeApply({ mergeId: opts.mergeId, finalize: true }).promisify();
+            return { data: { status: 'applying', mergeId: opts.mergeId } };
+        }
+        // review pass: prepare the merge, wait until it is ready for review (no reload)
+        const settled = waitForMergeStatus([MERGE_STATUS_READY_FOR_REVIEW]);
+        await api.rest.merge.mergeApply({ mergeId: opts.mergeId, finalize: false }).promisify();
+        await settled;
+        const merge = await api.rest.merge.mergeGet({ mergeId: opts.mergeId }).promisify();
+        return { data: merge };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:merge:delete', async (opts: any = {}) => {
+    try {
+        const merge = await api.rest.merge.mergeDelete({ mergeId: opts.mergeId }).promisify();
+        return { data: merge };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:conflict:resolve', async (opts: any = {}) => {
+    try {
+        const flags =
+            opts.resolution === 'source' ? { useSrc: true } :
+                opts.resolution === 'dest' ? { useDst: true } :
+                    { revert: true };
+        const res: any = await api.rest.conflicts.conflictsResolve({
+            mergeId: opts.mergeId,
+            conflictIds: opts.conflictIds,
+            ...flags
+        }).promisify();
+        return { data: res.result };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:conflict:getfile', async (opts: any = {}) => {
+    try {
+        const content = await api.rest.merge.mergeConflicts({
+            mergeId: opts.mergeId,
+            conflictId: opts.conflictId,
+            fileName: opts.fileName,
+            resolved: !!opts.resolved
+        }).promisify();
+        return { data: content };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+});
+
+mcp.method('vcs:diff', async (opts: any = {}) => {
+    try {
+        // diffCreate posts /diff then awaits the job-done event and fetches the result
+        const diff = await diffCreate({
+            srcBranchId: opts.srcBranchId ?? currentBranchId(),
+            dstBranchId: opts.dstBranchId ?? currentBranchId(),
+            srcCheckpointId: opts.srcCheckpointId,
+            dstCheckpointId: opts.dstCheckpointId
+        });
+        return { data: diff };
     } catch (e: any) {
         return { error: e.message };
     }

--- a/src/editor/mcp/methods-vcs.ts
+++ b/src/editor/mcp/methods-vcs.ts
@@ -15,29 +15,30 @@ const currentBranchId = () => config.self.branch.id;
 // merge is async: mergeCreate/mergeApply return before the worker finishes, and progress
 // arrives as messenger:merge.setProgress events for the current (destination) branch.
 // resolve once one of `statuses` is reached; reject on task failure or timeout.
-const waitForMergeStatus = (statuses: string[]) => new Promise<string>((resolve, reject) => {
-    const branchId = currentBranchId();
-    const evt: any = editor.on('messenger:merge.setProgress', (data: any) => {
-        if (data.dst_branch_id !== branchId) {
-            return;
-        }
-        if (data.task_failed) {
-            clearTimeout(timer);
+const waitForMergeStatus = (statuses: string[]) =>
+    new Promise<string>((resolve, reject) => {
+        const branchId = currentBranchId();
+        const evt: any = editor.on('messenger:merge.setProgress', (data: any) => {
+            if (data.dst_branch_id !== branchId) {
+                return;
+            }
+            if (data.task_failed) {
+                clearTimeout(timer);
+                evt.unbind();
+                reject(new Error('Merge failed'));
+                return;
+            }
+            if (statuses.includes(data.status)) {
+                clearTimeout(timer);
+                evt.unbind();
+                resolve(data.status);
+            }
+        });
+        const timer = setTimeout(() => {
             evt.unbind();
-            reject(new Error('Merge failed'));
-            return;
-        }
-        if (statuses.includes(data.status)) {
-            clearTimeout(timer);
-            evt.unbind();
-            resolve(data.status);
-        }
+            reject(new Error('Timed out waiting for the merge to progress'));
+        }, MERGE_WAIT_MS);
     });
-    const timer = setTimeout(() => {
-        evt.unbind();
-        reject(new Error('Timed out waiting for the merge to progress'));
-    }, MERGE_WAIT_MS);
-});
 
 // cursor pagination: the backend `skip` param is the last item's id, not an offset
 const listMeta = (result: { id: string }[], pagination?: { hasMore?: boolean }) => ({
@@ -58,12 +59,14 @@ mcp.method('vcs:status', () => {
 
 mcp.method('vcs:branch:list', async (opts: any = {}) => {
     try {
-        const res: any = await api.rest.projects.projectBranches({
-            limit: opts.limit,
-            skip: opts.cursor,
-            closed: opts.closed,
-            favorite: opts.favorite
-        }).promisify();
+        const res: any = await api.rest.projects
+            .projectBranches({
+                limit: opts.limit,
+                skip: opts.cursor,
+                closed: opts.closed,
+                favorite: opts.favorite
+            })
+            .promisify();
         return { data: res.result, meta: listMeta(res.result, res.pagination) };
     } catch (e: any) {
         return { error: e.message };
@@ -72,12 +75,14 @@ mcp.method('vcs:branch:list', async (opts: any = {}) => {
 
 mcp.method('vcs:branch:create', async (opts: any = {}) => {
     try {
-        const branch = await api.rest.branches.branchCreate({
-            name: opts.name,
-            projectId: config.project.id,
-            sourceBranchId: opts.sourceBranchId ?? currentBranchId(),
-            sourceCheckpointId: opts.sourceCheckpointId
-        }).promisify();
+        const branch = await api.rest.branches
+            .branchCreate({
+                name: opts.name,
+                projectId: config.project.id,
+                sourceBranchId: opts.sourceBranchId ?? currentBranchId(),
+                sourceCheckpointId: opts.sourceCheckpointId
+            })
+            .promisify();
         // the version-control messenger adopts the new branch and reloads the page
         return { data: { status: 'creating', branch } };
     } catch (e: any) {
@@ -97,11 +102,13 @@ mcp.method('vcs:branch:checkout', async (branchId: string) => {
 
 mcp.method('vcs:checkpoint:list', async (opts: any = {}) => {
     try {
-        const res: any = await api.rest.branches.branchCheckpoints({
-            branchId: opts.branchId ?? currentBranchId(),
-            limit: opts.limit,
-            skip: opts.cursor
-        }).promisify();
+        const res: any = await api.rest.branches
+            .branchCheckpoints({
+                branchId: opts.branchId ?? currentBranchId(),
+                limit: opts.limit,
+                skip: opts.cursor
+            })
+            .promisify();
         return { data: res.result, meta: listMeta(res.result, res.pagination) };
     } catch (e: any) {
         return { error: e.message };
@@ -123,10 +130,12 @@ mcp.method('vcs:checkpoint:create', async (opts: any = {}) => {
 
 mcp.method('vcs:checkpoint:restore', async (opts: any = {}) => {
     try {
-        await api.rest.checkpoints.checkpointRestore({
-            checkpointId: opts.checkpointId,
-            branchId: opts.branchId ?? currentBranchId()
-        }).promisify();
+        await api.rest.checkpoints
+            .checkpointRestore({
+                checkpointId: opts.checkpointId,
+                branchId: opts.branchId ?? currentBranchId()
+            })
+            .promisify();
         // restore overwrites working state; the messenger reloads the page
         return { data: { status: 'restoring', checkpointId: opts.checkpointId } };
     } catch (e: any) {
@@ -136,10 +145,12 @@ mcp.method('vcs:checkpoint:restore', async (opts: any = {}) => {
 
 mcp.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
     try {
-        await api.rest.checkpoints.checkpointHardReset({
-            checkpointId: opts.checkpointId,
-            branchId: opts.branchId ?? currentBranchId()
-        }).promisify();
+        await api.rest.checkpoints
+            .checkpointHardReset({
+                checkpointId: opts.checkpointId,
+                branchId: opts.branchId ?? currentBranchId()
+            })
+            .promisify();
         // hard reset erases later checkpoints and reloads the page
         return { data: { status: 'resetting', checkpointId: opts.checkpointId } };
     } catch (e: any) {
@@ -187,11 +198,13 @@ mcp.method('vcs:merge:create', async (opts: any = {}) => {
     try {
         // subscribe before firing so we can't miss the auto-merge-done event
         const settled = waitForMergeStatus([MERGE_STATUS_AUTO_ENDED, MERGE_STATUS_READY_FOR_REVIEW]);
-        const created: any = await api.rest.merge.mergeCreate({
-            srcBranchId: opts.sourceBranchId,
-            dstBranchId: currentBranchId(),
-            srcBranchClose: !!opts.closeSource
-        }).promisify();
+        const created: any = await api.rest.merge
+            .mergeCreate({
+                srcBranchId: opts.sourceBranchId,
+                dstBranchId: currentBranchId(),
+                srcBranchClose: !!opts.closeSource
+            })
+            .promisify();
         await settled;
         // re-fetch so conflicts are populated (mergeCreate returns before the worker finishes)
         const merge = await api.rest.merge.mergeGet({ mergeId: created.id }).promisify();
@@ -241,14 +254,18 @@ mcp.method('vcs:merge:delete', async (opts: any = {}) => {
 mcp.method('vcs:conflict:resolve', async (opts: any = {}) => {
     try {
         const flags =
-            opts.resolution === 'source' ? { useSrc: true } :
-                opts.resolution === 'dest' ? { useDst: true } :
-                    { revert: true };
-        const res: any = await api.rest.conflicts.conflictsResolve({
-            mergeId: opts.mergeId,
-            conflictIds: opts.conflictIds,
-            ...flags
-        }).promisify();
+            opts.resolution === 'source'
+                ? { useSrc: true }
+                : opts.resolution === 'dest'
+                  ? { useDst: true }
+                  : { revert: true };
+        const res: any = await api.rest.conflicts
+            .conflictsResolve({
+                mergeId: opts.mergeId,
+                conflictIds: opts.conflictIds,
+                ...flags
+            })
+            .promisify();
         return { data: res.result };
     } catch (e: any) {
         return { error: e.message };
@@ -257,12 +274,14 @@ mcp.method('vcs:conflict:resolve', async (opts: any = {}) => {
 
 mcp.method('vcs:conflict:getfile', async (opts: any = {}) => {
     try {
-        const content = await api.rest.merge.mergeConflicts({
-            mergeId: opts.mergeId,
-            conflictId: opts.conflictId,
-            fileName: opts.fileName,
-            resolved: !!opts.resolved
-        }).promisify();
+        const content = await api.rest.merge
+            .mergeConflicts({
+                mergeId: opts.mergeId,
+                conflictId: opts.conflictId,
+                fileName: opts.fileName,
+                resolved: !!opts.resolved
+            })
+            .promisify();
         return { data: content };
     } catch (e: any) {
         return { error: e.message };

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -69,8 +69,12 @@ editor.once('load', () => {
 
     toggle.on('click', () => {
         if (editor.call('mcp:status') === 'disconnected') {
-            editor.call('mcp:connect', parseInt(portField.value, 10) || DEFAULT_PORT);
+            const port = parseInt(portField.value, 10) || DEFAULT_PORT;
+            editor.call('localStorage:set', 'editor:mcp:connected', true);
+            editor.call('localStorage:set', 'editor:mcp:port', port);
+            editor.call('mcp:connect', port);
         } else {
+            editor.call('localStorage:set', 'editor:mcp:connected', false);
             editor.call('mcp:disconnect');
         }
     });
@@ -105,4 +109,12 @@ editor.once('load', () => {
         tooltip.attach(button.dom);
         window.removeEventListener('mousedown', onOutside);
     });
+
+    // reconnect automatically if the user was connected before a page reload
+    // (branch switch / checkpoint restore reload the editor and drop the socket)
+    if (editor.call('localStorage:get', 'editor:mcp:connected')) {
+        const port = editor.call('localStorage:get', 'editor:mcp:port') || DEFAULT_PORT;
+        portField.value = String(port);
+        editor.call('mcp:connect', port);
+    }
 });


### PR DESCRIPTION
Editor-side `mcp.method` handlers backing the MCP VCS tools (see paired PR: playcanvas/editor-mcp-server#97).

## What's added
- `src/editor/mcp/methods-vcs.ts` — VCS method handlers: branches (list/create/switch/close/open/delete), checkpoints (list/create/restore/hard-reset), and the merge lifecycle (start/resolve-conflicts/apply/cancel, diff, conflict files).
- `src/editor/mcp/toolbar.ts` — auto-reconnect of the MCP link after an editor reload (branch switch / restore / hard-reset reload the editor).
- `src/editor/index.ts` — registers the VCS methods.

Every method here pairs 1:1 with a tool in the editor-mcp-server PR.
