### PR TITLE
refactor: move MCP handlers behind editor driver

### DIFF
--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -1,7 +1,6 @@
 import { config } from '@/editor/config';
 
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { api, log, rest, entitySummary, paginate } from './shared';
 
 /**
@@ -22,7 +21,7 @@ const assetSummary = (asset: any) => {
 };
 
 // assets
-mcp.method('assets:create', async (assets) => {
+driver.method('assets:create', async (assets) => {
     try {
         const assetCreationPromises = assets.map(async ({ type, options }: any) => {
             if (options?.folder) {
@@ -84,7 +83,7 @@ mcp.method('assets:create', async (assets) => {
         return { error: errorMessage };
     }
 });
-mcp.method('assets:delete', (ids) => {
+driver.method('assets:delete', (ids) => {
     const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
     if (!assets.length) {
         return { error: 'No valid assets to delete. Call list_assets to obtain valid asset ids.' };
@@ -93,7 +92,7 @@ mcp.method('assets:delete', (ids) => {
     log(`Deleted assets: ${ids.join(', ')}`);
     return { data: { deleted: assets.length } };
 });
-mcp.method('assets:list', (options: any = {}) => {
+driver.method('assets:list', (options: any = {}) => {
     let assets = api.assets.list();
 
     // apply filters
@@ -121,7 +120,7 @@ mcp.method('assets:list', (options: any = {}) => {
     // summary mode: return minimal data
     return { data: page.map(assetSummary), meta };
 });
-mcp.method('assets:instantiate', async (ids) => {
+driver.method('assets:instantiate', async (ids) => {
     const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
     if (!assets.length) {
         return {
@@ -137,7 +136,7 @@ mcp.method('assets:instantiate', async (ids) => {
     log(`Instantiated assets: ${ids.join(', ')}`);
     return { data: entities.map(entitySummary) };
 });
-mcp.method('assets:property:set', (id, prop, value) => {
+driver.method('assets:property:set', (id, prop, value) => {
     const asset = api.assets.get(id);
     if (!asset) {
         return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
@@ -146,7 +145,7 @@ mcp.method('assets:property:set', (id, prop, value) => {
     log(`Set asset(${id}) property(${prop}) to: ${JSON.stringify(value)}`);
     return { data: { id, [prop]: value } };
 });
-mcp.method('assets:data:set', (id, props) => {
+driver.method('assets:data:set', (id, props) => {
     const asset = api.assets.get(id);
     if (!asset) {
         return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
@@ -161,7 +160,7 @@ mcp.method('assets:data:set', (id, props) => {
     log(`Set asset(${id}) properties(${keys.join(', ')})`);
     return { data: assetSummary(asset) };
 });
-mcp.method('assets:script:text:set', async (id, text) => {
+driver.method('assets:script:text:set', async (id, text) => {
     const asset = api.assets.get(id);
     if (!asset) {
         return {
@@ -185,7 +184,7 @@ mcp.method('assets:script:text:set', async (id, text) => {
         return { error: e.message };
     }
 });
-mcp.method('assets:file:text:get', async (id) => {
+driver.method('assets:file:text:get', async (id) => {
     const asset = api.assets.get(id);
     if (!asset) {
         return { error: `Asset not found: ${id}. Call list_assets to obtain a valid asset id.` };
@@ -215,7 +214,7 @@ mcp.method('assets:file:text:get', async (id) => {
         return { error: e instanceof Error ? e.message : String(e) };
     }
 });
-mcp.method('assets:script:parse', async (id) => {
+driver.method('assets:script:parse', async (id) => {
     const asset = api.assets.get(id);
     if (!asset) {
         return {

--- a/src/editor/driver/driver.ts
+++ b/src/editor/driver/driver.ts
@@ -1,0 +1,5 @@
+import { Caller } from '@/common/caller';
+
+const driver = new Caller<Record<string, (...args: any[]) => any>>('Editor Driver');
+
+export { driver };

--- a/src/editor/driver/editor.ts
+++ b/src/editor/driver/editor.ts
@@ -1,19 +1,15 @@
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { api, log } from './shared';
 
-// general
-mcp.method('ping', () => ({ data: 'pong' }));
-
 // selection
-mcp.method('selection:get', () => {
+driver.method('selection:get', () => {
     const items = api.selection.items || [];
     const type = editor.call('selector:type');
     const ids = items.map((it) => (type === 'asset' ? it.get('id') : it.get('resource_id')));
     log('Queried selection');
     return { data: { type, ids } };
 });
-mcp.method('selection:set', (type, ids) => {
+driver.method('selection:set', (type, ids) => {
     const items = (ids || [])
         .map((id) => (type === 'asset' ? api.assets.get(id) : api.entities.get(id)))
         .filter(Boolean);
@@ -21,14 +17,14 @@ mcp.method('selection:set', (type, ids) => {
     log(`Set ${type} selection (${items.length})`);
     return { data: { type, ids: items.map((it) => (type === 'asset' ? it.get('id') : it.get('resource_id'))) } };
 });
-mcp.method('selection:clear', () => {
+driver.method('selection:clear', () => {
     api.selection.clear();
     log('Cleared selection');
     return { data: { type: null, ids: [] } };
 });
 
 // history (undo/redo)
-mcp.method('history:undo', () => {
+driver.method('history:undo', () => {
     const undone = api.history.canUndo;
     if (undone) {
         api.history.undo();
@@ -36,7 +32,7 @@ mcp.method('history:undo', () => {
     log(undone ? 'Undo' : 'Undo (nothing to undo)');
     return { data: { undone, canUndo: api.history.canUndo, canRedo: api.history.canRedo } };
 });
-mcp.method('history:redo', () => {
+driver.method('history:redo', () => {
     const redone = api.history.canRedo;
     if (redone) {
         api.history.redo();
@@ -46,7 +42,7 @@ mcp.method('history:redo', () => {
 });
 
 // transform gizmo
-mcp.method('gizmo:state:set', (state) => {
+driver.method('gizmo:state:set', (state) => {
     const s = state || {};
     if (s.mode !== undefined) {
         editor.call('gizmo:type', s.mode);

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -1,5 +1,4 @@
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { api, log, entitySummary, paginate } from './shared';
 
 // top-level entity properties that entities:modify may set directly. Anything
@@ -40,7 +39,7 @@ const validateEntityPath = (entity: any, path: string) => {
 };
 
 // entities
-mcp.method('entities:create', (entityDataArray) => {
+driver.method('entities:create', (entityDataArray) => {
     const entities = [];
     for (const entityData of entityDataArray) {
         if (Object.hasOwn(entityData, 'parent')) {
@@ -68,7 +67,7 @@ mcp.method('entities:create', (entityDataArray) => {
     // ids + hierarchy paths without a follow-up list_entities call
     return { data: entities.map(entitySummary) };
 });
-mcp.method('entities:modify', (edits) => {
+driver.method('entities:modify', (edits) => {
     const modified = new Map();
     for (const { id, path, value } of edits) {
         const entity = api.entities.get(id);
@@ -92,7 +91,7 @@ mcp.method('entities:modify', (edits) => {
     // return the post-edit summaries of every touched entity
     return { data: Array.from(modified.values()).map(entitySummary) };
 });
-mcp.method('entities:duplicate', async (ids, options: any = {}) => {
+driver.method('entities:duplicate', async (ids, options: any = {}) => {
     const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
         return {
@@ -103,7 +102,7 @@ mcp.method('entities:duplicate', async (ids, options: any = {}) => {
     log(`Duplicated entities: ${res.map((entity: any) => entity.get('resource_id')).join(', ')}`);
     return { data: res.map(entitySummary) };
 });
-mcp.method('entities:reparent', (options) => {
+driver.method('entities:reparent', (options) => {
     const entity = api.entities.get(options.id);
     if (!entity) {
         return {
@@ -122,7 +121,7 @@ mcp.method('entities:reparent', (options) => {
     log(`Reparented entity(${options.id}) to entity(${options.parent})`);
     return { data: entitySummary(entity) };
 });
-mcp.method('entities:delete', async (ids) => {
+driver.method('entities:delete', async (ids) => {
     const entities = ids
         .map((id: string) => api.entities.get(id))
         .filter((entity: any) => entity && entity !== api.entities.root);
@@ -135,7 +134,7 @@ mcp.method('entities:delete', async (ids) => {
     log(`Deleted entities: ${ids.join(', ')}`);
     return { data: { deleted: entities.length } };
 });
-mcp.method('entities:resolve', (options: any = {}) => {
+driver.method('entities:resolve', (options: any = {}) => {
     const name = (options.name || '').toLowerCase();
     if (!name) {
         return { error: 'Provide a non-empty "name" to resolve.' };
@@ -149,7 +148,7 @@ mcp.method('entities:resolve', (options: any = {}) => {
     // empty match is a valid result, not an error
     return { data: matches.map(entitySummary), meta: { total: matches.length, count: matches.length } };
 });
-mcp.method('entities:list', (options: any = {}) => {
+driver.method('entities:list', (options: any = {}) => {
     let entities = api.entities.list();
 
     // apply filters
@@ -177,7 +176,7 @@ mcp.method('entities:list', (options: any = {}) => {
     // summary mode: compact, semantic data
     return { data: page.map(entitySummary), meta };
 });
-mcp.method('entities:components:add', (id, components) => {
+driver.method('entities:components:add', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
         return {
@@ -190,7 +189,7 @@ mcp.method('entities:components:add', (id, components) => {
     log(`Added components(${Object.keys(components).join(', ')}) to entity(${id})`);
     return { data: entitySummary(entity) };
 });
-mcp.method('entities:components:remove', (id, components) => {
+driver.method('entities:components:remove', (id, components) => {
     const entity = api.entities.get(id);
     if (!entity) {
         return {
@@ -203,7 +202,7 @@ mcp.method('entities:components:remove', (id, components) => {
     log(`Removed components(${components.join(', ')}) from entity(${id})`);
     return { data: entitySummary(entity) };
 });
-mcp.method('entities:components:script:add', (id, scriptName) => {
+driver.method('entities:components:script:add', (id, scriptName) => {
     const entity = api.entities.get(id);
     if (!entity) {
         return {
@@ -219,7 +218,7 @@ mcp.method('entities:components:script:add', (id, scriptName) => {
     log(`Added script(${scriptName}) to component(script) of entity(${id})`);
     return { data: entitySummary(entity) };
 });
-mcp.method('entities:script:attach', (id, scriptName) => {
+driver.method('entities:script:attach', (id, scriptName) => {
     const entity = api.entities.get(id);
     if (!entity) {
         return {
@@ -237,7 +236,7 @@ mcp.method('entities:script:attach', (id, scriptName) => {
 });
 
 // entity search
-mcp.method('entities:search', (query, limit) => {
+driver.method('entities:search', (query, limit) => {
     let results = editor.call('entities:fuzzy-search', query) || [];
     if (typeof limit === 'number') {
         results = results.slice(0, limit);
@@ -245,7 +244,7 @@ mcp.method('entities:search', (query, limit) => {
     log(`Searched entities for "${query}" (${results.length})`);
     return { data: results.map(entitySummary) };
 });
-mcp.method('entities:byScript', (script) => {
+driver.method('entities:byScript', (script) => {
     const results = editor.call('entities:list:byScript', script) || [];
     log(`Listed entities by script "${script}" (${results.length})`);
     return { data: results.map(entitySummary) };

--- a/src/editor/driver/index.ts
+++ b/src/editor/driver/index.ts
@@ -3,7 +3,8 @@ import './asset';
 import './scene';
 import './project';
 import './viewport';
-import './runtime';
 import './store';
 import './editor';
 import './vcs';
+
+export { driver } from './driver';

--- a/src/editor/driver/project.ts
+++ b/src/editor/driver/project.ts
@@ -1,9 +1,8 @@
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { log, iterateObject } from './shared';
 
 // project settings
-mcp.method('project:settings:modify', (settings) => {
+driver.method('project:settings:modify', (settings) => {
     const project = editor.call('settings:project');
     iterateObject(settings, (path, value) => {
         project.set(path, value);
@@ -13,7 +12,7 @@ mcp.method('project:settings:modify', (settings) => {
     // return the resulting settings snapshot inline
     return { data: project.json() };
 });
-mcp.method('project:settings:query', () => {
+driver.method('project:settings:query', () => {
     const project = editor.call('settings:project');
     log('Queried project settings');
     return { data: project.json() };

--- a/src/editor/driver/scene.ts
+++ b/src/editor/driver/scene.ts
@@ -1,9 +1,8 @@
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { api, log, iterateObject } from './shared';
 
 // scene settings
-mcp.method('scene:settings:modify', (settings) => {
+driver.method('scene:settings:modify', (settings) => {
     const scene = api.settings.scene;
     iterateObject(settings, (path, value) => {
         scene.set(path, value);
@@ -13,21 +12,21 @@ mcp.method('scene:settings:modify', (settings) => {
     // return the resulting settings snapshot inline
     return { data: scene.json() };
 });
-mcp.method('scene:settings:query', () => {
+driver.method('scene:settings:query', () => {
     const scene = api.settings.scene;
     log('Queried scene settings');
     return { data: scene.json() };
 });
 
 // scene management
-mcp.method('scenes:list', async () => {
+driver.method('scenes:list', async () => {
     const data = await new Promise((resolve) => {
         editor.call('scenes:list', (result: unknown) => resolve(result));
     });
     log('Listed scenes');
     return { data };
 });
-mcp.method('scenes:get', async (id) => {
+driver.method('scenes:get', async (id) => {
     const [err, data] = await new Promise<unknown[]>((resolve) => {
         editor.call('scenes:get', String(id), (e: unknown, d: unknown) => resolve([e, d]));
     });
@@ -37,28 +36,28 @@ mcp.method('scenes:get', async (id) => {
     log(`Got scene(${id})`);
     return { data };
 });
-mcp.method('scenes:new', async (name) => {
+driver.method('scenes:new', async (name) => {
     const data = await new Promise((resolve) => {
         editor.call('scenes:new', name, (d: unknown) => resolve(d));
     });
     log(`Created scene: ${name ?? '(unnamed)'}`);
     return { data };
 });
-mcp.method('scenes:duplicate', async (id, name) => {
+driver.method('scenes:duplicate', async (id, name) => {
     const data = await new Promise((resolve) => {
         editor.call('scenes:duplicate', String(id), name, (d: unknown) => resolve(d));
     });
     log(`Duplicated scene(${id})`);
     return { data };
 });
-mcp.method('scenes:delete', async (id) => {
+driver.method('scenes:delete', async (id) => {
     await new Promise<void>((resolve) => {
         editor.call('scenes:delete', String(id), () => resolve());
     });
     log(`Deleted scene(${id})`);
     return { data: { deleted: id } };
 });
-mcp.method('scene:load', (uniqueId) => {
+driver.method('scene:load', (uniqueId) => {
     // scene:load defers until realtime is authenticated, so this returns before
     // the switch completes; the editor loads the scene asynchronously.
     editor.call('scene:load', uniqueId);

--- a/src/editor/driver/shared.ts
+++ b/src/editor/driver/shared.ts
@@ -1,6 +1,6 @@
 const api = editor.api.globals;
 
-const log = (msg: string) => console.log(`[MCP] ${msg}`);
+const log = (msg: string) => console.log(`[Editor Driver] ${msg}`);
 
 /**
  * PlayCanvas REST API wrapper.

--- a/src/editor/driver/store.ts
+++ b/src/editor/driver/store.ts
@@ -1,11 +1,10 @@
 import { config } from '@/editor/config';
 
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { log, rest } from './shared';
 
 // store - playcanvas
-mcp.method('store:playcanvas:list', async (options: any = {}) => {
+driver.method('store:playcanvas:list', async (options: any = {}) => {
     const params = [];
     if (options.search) {
         params.push(`search=${options.search}`);
@@ -32,7 +31,7 @@ mcp.method('store:playcanvas:list', async (options: any = {}) => {
         return { error: e.message };
     }
 });
-mcp.method('store:playcanvas:get', async (id) => {
+driver.method('store:playcanvas:get', async (id) => {
     try {
         const data = await rest('GET', `store/${id}`);
         if (data.error) {
@@ -44,7 +43,7 @@ mcp.method('store:playcanvas:get', async (id) => {
         return { error: e.message };
     }
 });
-mcp.method('store:playcanvas:clone', async (id, name, license) => {
+driver.method('store:playcanvas:clone', async (id, name, license) => {
     try {
         const data = await rest('POST', `store/${id}/clone`, {
             scope: {
@@ -67,7 +66,7 @@ mcp.method('store:playcanvas:clone', async (id, name, license) => {
 });
 
 // store - sketchfab
-mcp.method('store:sketchfab:list', async (options: any = {}) => {
+driver.method('store:sketchfab:list', async (options: any = {}) => {
     const params = ['restricted=0', 'type=models', 'downloadable=true'];
     if (options.search) {
         params.push(`q=${options.search}`);
@@ -94,7 +93,7 @@ mcp.method('store:sketchfab:list', async (options: any = {}) => {
         return { error: e.message };
     }
 });
-mcp.method('store:sketchfab:get', async (uid) => {
+driver.method('store:sketchfab:get', async (uid) => {
     try {
         const res = await fetch(`https://api.sketchfab.com/v3/models/${uid}`);
         const data = await res.json();
@@ -107,7 +106,7 @@ mcp.method('store:sketchfab:get', async (uid) => {
         return { error: e.message };
     }
 });
-mcp.method('store:sketchfab:clone', async (uid, name, license) => {
+driver.method('store:sketchfab:clone', async (uid, name, license) => {
     try {
         const data = await rest('POST', `store/${uid}/clone`, {
             scope: {

--- a/src/editor/driver/vcs.ts
+++ b/src/editor/driver/vcs.ts
@@ -2,7 +2,7 @@ import { MERGE_STATUS_AUTO_ENDED, MERGE_STATUS_READY_FOR_REVIEW } from '@/core/c
 import { config } from '@/editor/config';
 import { checkpointCreate, diffCreate } from '@/editor/messenger/jobs';
 
-import { mcp } from '../connection';
+import { driver } from './driver';
 
 const api = editor.api.globals;
 
@@ -46,7 +46,7 @@ const listMeta = (result: { id: string }[], pagination?: { hasMore?: boolean }) 
     nextCursor: result.length ? result[result.length - 1].id : null
 });
 
-mcp.method('vcs:status', () => {
+driver.method('vcs:status', () => {
     const b = config.self.branch;
     return {
         data: {
@@ -57,7 +57,7 @@ mcp.method('vcs:status', () => {
     };
 });
 
-mcp.method('vcs:branch:list', async (opts: any = {}) => {
+driver.method('vcs:branch:list', async (opts: any = {}) => {
     try {
         const res: any = await api.rest.projects
             .projectBranches({
@@ -73,7 +73,7 @@ mcp.method('vcs:branch:list', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:branch:create', async (opts: any = {}) => {
+driver.method('vcs:branch:create', async (opts: any = {}) => {
     try {
         const branch = await api.rest.branches
             .branchCreate({
@@ -90,7 +90,7 @@ mcp.method('vcs:branch:create', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:branch:checkout', async (branchId: string) => {
+driver.method('vcs:branch:checkout', async (branchId: string) => {
     try {
         await api.rest.branches.branchCheckout({ branchId }).promisify();
         // the version-control messenger switches branch and reloads the page
@@ -100,7 +100,7 @@ mcp.method('vcs:branch:checkout', async (branchId: string) => {
     }
 });
 
-mcp.method('vcs:checkpoint:list', async (opts: any = {}) => {
+driver.method('vcs:checkpoint:list', async (opts: any = {}) => {
     try {
         const res: any = await api.rest.branches
             .branchCheckpoints({
@@ -115,7 +115,7 @@ mcp.method('vcs:checkpoint:list', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:checkpoint:create', async (opts: any = {}) => {
+driver.method('vcs:checkpoint:create', async (opts: any = {}) => {
     try {
         const checkpoint = await checkpointCreate({
             projectId: config.project.id,
@@ -128,7 +128,7 @@ mcp.method('vcs:checkpoint:create', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:checkpoint:restore', async (opts: any = {}) => {
+driver.method('vcs:checkpoint:restore', async (opts: any = {}) => {
     try {
         await api.rest.checkpoints
             .checkpointRestore({
@@ -143,7 +143,7 @@ mcp.method('vcs:checkpoint:restore', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
+driver.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
     try {
         await api.rest.checkpoints
             .checkpointHardReset({
@@ -158,7 +158,7 @@ mcp.method('vcs:checkpoint:hardreset', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:checkpoint:get', async (opts: any = {}) => {
+driver.method('vcs:checkpoint:get', async (opts: any = {}) => {
     try {
         const checkpoint = await api.rest.checkpoints.checkpointGet({ checkpointId: opts.checkpointId }).promisify();
         return { data: checkpoint };
@@ -167,7 +167,7 @@ mcp.method('vcs:checkpoint:get', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:branch:close', async (opts: any = {}) => {
+driver.method('vcs:branch:close', async (opts: any = {}) => {
     try {
         const branch = await api.rest.branches.branchClose({ branchId: opts.branchId }).promisify();
         return { data: branch };
@@ -176,7 +176,7 @@ mcp.method('vcs:branch:close', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:branch:open', async (opts: any = {}) => {
+driver.method('vcs:branch:open', async (opts: any = {}) => {
     try {
         const branch = await api.rest.branches.branchOpen({ branchId: opts.branchId }).promisify();
         return { data: branch };
@@ -185,7 +185,7 @@ mcp.method('vcs:branch:open', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:branch:delete', async (opts: any = {}) => {
+driver.method('vcs:branch:delete', async (opts: any = {}) => {
     try {
         const branch = await api.rest.branches.branchDelete({ branchId: opts.branchId }).promisify();
         return { data: branch };
@@ -194,7 +194,7 @@ mcp.method('vcs:branch:delete', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:merge:create', async (opts: any = {}) => {
+driver.method('vcs:merge:create', async (opts: any = {}) => {
     try {
         // subscribe before firing so we can't miss the auto-merge-done event
         const settled = waitForMergeStatus([MERGE_STATUS_AUTO_ENDED, MERGE_STATUS_READY_FOR_REVIEW]);
@@ -214,7 +214,7 @@ mcp.method('vcs:merge:create', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:merge:get', async (opts: any = {}) => {
+driver.method('vcs:merge:get', async (opts: any = {}) => {
     try {
         const merge = await api.rest.merge.mergeGet({ mergeId: opts.mergeId }).promisify();
         return { data: merge };
@@ -223,7 +223,7 @@ mcp.method('vcs:merge:get', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:merge:apply', async (opts: any = {}) => {
+driver.method('vcs:merge:apply', async (opts: any = {}) => {
     try {
         if (opts.finalize) {
             // finalize commits the merge checkpoint onto the current branch; the messenger
@@ -242,7 +242,7 @@ mcp.method('vcs:merge:apply', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:merge:delete', async (opts: any = {}) => {
+driver.method('vcs:merge:delete', async (opts: any = {}) => {
     try {
         const merge = await api.rest.merge.mergeDelete({ mergeId: opts.mergeId }).promisify();
         return { data: merge };
@@ -251,7 +251,7 @@ mcp.method('vcs:merge:delete', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:conflict:resolve', async (opts: any = {}) => {
+driver.method('vcs:conflict:resolve', async (opts: any = {}) => {
     try {
         const flags =
             opts.resolution === 'source'
@@ -272,7 +272,7 @@ mcp.method('vcs:conflict:resolve', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:conflict:getfile', async (opts: any = {}) => {
+driver.method('vcs:conflict:getfile', async (opts: any = {}) => {
     try {
         const content = await api.rest.merge
             .mergeConflicts({
@@ -288,7 +288,7 @@ mcp.method('vcs:conflict:getfile', async (opts: any = {}) => {
     }
 });
 
-mcp.method('vcs:diff', async (opts: any = {}) => {
+driver.method('vcs:diff', async (opts: any = {}) => {
     try {
         // diffCreate posts /diff then awaits the job-done event and fetches the result
         const diff = await diffCreate({

--- a/src/editor/driver/viewport.ts
+++ b/src/editor/driver/viewport.ts
@@ -1,14 +1,13 @@
 import { Vec3 } from 'playcanvas';
 
-import { mcp } from '../connection';
-
+import { driver } from './driver';
 import { api, log } from './shared';
 
 // reused scratch vector — camera:focus copies it synchronously, no listener retains it
 const tmpVec3 = new Vec3();
 
 // viewport
-mcp.method('viewport:capture', () => {
+driver.method('viewport:capture', () => {
     const app = editor.call('viewport:app');
     if (!app) {
         return { error: 'Viewport app not found' };
@@ -76,7 +75,7 @@ mcp.method('viewport:capture', () => {
         };
     }
 });
-mcp.method('viewport:focus', (ids, options: any = {}) => {
+driver.method('viewport:focus', (ids, options: any = {}) => {
     const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
     if (!entities.length) {
         return {
@@ -128,7 +127,7 @@ mcp.method('viewport:focus', (ids, options: any = {}) => {
 });
 
 // camera framing
-mcp.method('camera:focus:point', (point, distance) => {
+driver.method('camera:focus:point', (point, distance) => {
     if (!Array.isArray(point) || point.length !== 3) {
         return { error: 'point must be an array [x, y, z].' };
     }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -302,7 +302,7 @@ import './toolbar/toolbar-code-editor';
 
 // mcp
 import './mcp/connection';
-import './mcp/methods';
+import './mcp/register';
 import './mcp/toolbar';
 
 // viewport controls

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -1,8 +1,8 @@
 import { config } from '@/editor/config';
 
-import { mcp } from '../connection';
+import { mcp } from './connection';
 
-import { log } from './shared';
+const log = (msg: string) => console.log(`[MCP] ${msg}`);
 
 // remember a handle to the launched runtime window so we can stop it later
 let runtimeWindow: Window | null = null;

--- a/src/editor/mcp/register.ts
+++ b/src/editor/mcp/register.ts
@@ -1,0 +1,10 @@
+import { driver } from '@/editor/driver';
+
+import { mcp } from './connection';
+import './launch';
+
+mcp.method('ping', () => ({ data: 'pong' }));
+
+for (const [name, fn] of driver.methods) {
+    mcp.method(name, fn);
+}


### PR DESCRIPTION
### What's Changed

- Move edit-time operations behind an internal editor driver.
- Keep MCP as the transport adapter while preserving method names and response envelopes.
- Leave the public `editor.api` surface unchanged.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

### Manual smoke test

1. Open a project in the Editor with the MCP server running and confirm it connects.
2. List entities, modify one entity, and confirm the response and Editor state update.
3. Launch and stop the runtime, and confirm the launch window lifecycle is unchanged.