### PR TITLE
feat: complete MCP editor content coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 The PlayCanvas Editor is a visual editing environment for building WebGL/WebGPU/WebXR apps. It can be accessed at https://playcanvas.com.
 
+The Editor also includes a built-in [Model Context Protocol (MCP) integration](https://github.com/playcanvas/editor-mcp-server) for AI-assisted automation.
+
 ![Editor](https://raw.githubusercontent.com/playcanvas/editor/refs/heads/main/images/editor.png)
 
 You can see more projects built using the Editor on the [PlayCanvas website](https://playcanvas.com/explore).

--- a/src/editor-api/assets.ts
+++ b/src/editor-api/assets.ts
@@ -968,7 +968,7 @@ class Assets extends Events {
         const defaultData = api.schema.assets.getDefaultData('material') as any;
         if (options.data) {
             for (const key in defaultData) {
-                if (options.data[key]) {
+                if (Object.hasOwn(options.data, key)) {
                     defaultData[key] = options.data[key];
                 }
             }

--- a/src/editor-api/entities/reparent.ts
+++ b/src/editor-api/entities/reparent.ts
@@ -14,6 +14,37 @@ function reparentEntities(data: ReparentArguments[], options: { preserveTransfor
         options.history = true;
     }
 
+    const parents = new Map(data.map(({ entity, parent }) => [entity, parent]));
+    if (parents.size !== data.length) {
+        throw new Error('An entity cannot be reparented more than once in one operation.');
+    }
+    const sizes = new Map<Entity, number>();
+    data.forEach(({ entity, parent }) => {
+        if (!entity.parent) {
+            throw new Error('The root entity cannot be reparented.');
+        }
+        sizes.set(entity.parent, sizes.get(entity.parent) ?? entity.parent.get('children').length);
+        sizes.set(parent, sizes.get(parent) ?? parent.get('children').length);
+        sizes.set(entity.parent, sizes.get(entity.parent) - 1);
+        sizes.set(parent, sizes.get(parent) + 1);
+    });
+    data.forEach(({ entity, parent, index }) => {
+        let current: Entity | null = parent;
+        while (current && current !== entity) {
+            current = parents.get(current) || current.parent;
+        }
+        if (current === entity) {
+            throw new Error('An entity cannot be parented to itself or its descendant.');
+        }
+        if (
+            index !== undefined &&
+            index !== null &&
+            (!Number.isInteger(index) || index < 0 || index > sizes.get(parent))
+        ) {
+            throw new Error(`Invalid child index: ${index}.`);
+        }
+    });
+
     const records = data.map((entry: any) => {
         const parentOld = entry.entity.parent;
         const indexOld = parentOld.get('children').indexOf(entry.entity.get('resource_id'));

--- a/src/editor-api/entities/reparent.ts
+++ b/src/editor-api/entities/reparent.ts
@@ -14,21 +14,24 @@ function reparentEntities(data: ReparentArguments[], options: { preserveTransfor
         options.history = true;
     }
 
-    const parents = new Map(data.map(({ entity, parent }) => [entity, parent]));
-    if (parents.size !== data.length) {
-        throw new Error('An entity cannot be reparented more than once in one operation.');
-    }
+    const parents = new Map<Entity, Entity>();
     const sizes = new Map<Entity, number>();
-    data.forEach(({ entity, parent }) => {
+    for (let i = 0; i < data.length; i++) {
+        const { entity, parent } = data[i];
+        if (parents.has(entity)) {
+            throw new Error('An entity cannot be reparented more than once in one operation.');
+        }
         if (!entity.parent) {
             throw new Error('The root entity cannot be reparented.');
         }
+        parents.set(entity, parent);
         sizes.set(entity.parent, sizes.get(entity.parent) ?? entity.parent.get('children').length);
         sizes.set(parent, sizes.get(parent) ?? parent.get('children').length);
         sizes.set(entity.parent, sizes.get(entity.parent) - 1);
         sizes.set(parent, sizes.get(parent) + 1);
-    });
-    data.forEach(({ entity, parent, index }) => {
+    }
+    for (let i = 0; i < data.length; i++) {
+        const { entity, parent, index } = data[i];
         let current: Entity | null = parent;
         while (current && current !== entity) {
             current = parents.get(current) || current.parent;
@@ -43,7 +46,7 @@ function reparentEntities(data: ReparentArguments[], options: { preserveTransfor
         ) {
             throw new Error(`Invalid child index: ${index}.`);
         }
-    });
+    }
 
     const records = data.map((entry: any) => {
         const parentOld = entry.entity.parent;

--- a/src/editor-api/rest/assets.ts
+++ b/src/editor-api/rest/assets.ts
@@ -88,7 +88,7 @@ export type AssetPasteData = {
     /**
      * The ID of the project to paste the assets to
      */
-    targetProjectId: string;
+    targetProjectId: number;
 
     /**
      * The ID of the branch to paste the assets to
@@ -411,7 +411,7 @@ export const assetClone = (assetId: string, data: AssetCloneData) => {
  * @returns A request that responds with the result of the paste
  */
 export const assetPaste = (data: AssetPasteData) => {
-    return Ajax.post({
+    return Ajax.post<{ result: { id: number }[] }>({
         url: `${api.apiUrl}/assets/paste`,
         auth: true,
         data

--- a/src/editor-api/rest/assets.ts
+++ b/src/editor-api/rest/assets.ts
@@ -52,72 +52,7 @@ export type AssetGetFileOptions = {
     immutableBackup?: string;
 };
 
-export type AssetReimportData = {
-    /**
-     * Whether to use power of two textures
-     */
-    pow2?: boolean;
-
-    /**
-     * The animation sample rate
-     */
-    searchRelatedAssets?: boolean;
-
-    /**
-     * Whether to search for related assets
-     */
-    overwriteModel?: boolean;
-
-    /**
-     * Whether to overwrite the model
-     */
-    overwriteAnimation?: boolean;
-
-    /**
-     * Whether to overwrite the animation
-     */
-    overwriteMaterial?: boolean;
-
-    /**
-     * Whether to overwrite the material
-     */
-    overwriteTexture?: boolean;
-
-    /**
-     * Whether to overwrite the texture
-     */
-    preserveMapping?: boolean;
-
-    /**
-     * Whether to preserve the mapping
-     */
-    useGlb?: boolean;
-
-    /**
-     * The animation sample rate
-     */
-    useContainers?: boolean;
-
-    /**
-     * Whether to use containers
-     */
-    meshCompression?: boolean;
-
-    /**
-     * Whether to use mesh compression
-     */
-    dracoDecodeSpeed?: number;
-
-    /**
-     * The speed of Draco decoding
-     */
-    dracoMeshSize?: number;
-
-    /**
-     * The size of Draco meshes
-     */
-    animUseFbxFilename?: boolean;
-};
+export type AssetReimportData = AssetPipelineOptions;
 
 export type AssetDuplicateData = {
     /**
@@ -299,9 +234,9 @@ export type AssetPipelineOptions = {
     useContainers?: boolean;
 
     /**
-     * Whether to use mesh compression
+     * The mesh compression mode
      */
-    meshCompression?: boolean;
+    meshCompression?: 'none' | 'draco';
 
     /**
      * The speed of Draco decoding
@@ -327,6 +262,11 @@ export type AssetPipelineOptions = {
      * Whether to import morph normals
      */
     importMorphNormals?: boolean;
+
+    /**
+     * Whether to use unique mesh indices
+     */
+    useUniqueIndices?: boolean;
 };
 
 /**
@@ -511,6 +451,7 @@ const assetUpdateFields = (form: FormData, data: AssetUpdateData, pipeline: Asse
                 form.append('unwrapUv', `${pipeline.unwrapUv}`);
                 form.append('unwrapUvTexelsPerMeter', `${pipeline.unwrapUvTexelsPerMeter}`);
                 form.append('importMorphNormals', `${pipeline.importMorphNormals}`);
+                form.append('useUniqueIndices', `${pipeline.useUniqueIndices}`);
                 break;
             case 'font':
                 break;

--- a/src/editor-api/rest/assets.ts
+++ b/src/editor-api/rest/assets.ts
@@ -66,6 +66,14 @@ export type AssetDuplicateData = {
     branchId: string;
 };
 
+export type AssetCloneData = {
+    scope: {
+        type: string;
+        id: number;
+    };
+    targetFolderId?: number | null;
+};
+
 export type AssetPasteData = {
     /**
      * The ID of the project the assets are from
@@ -377,6 +385,21 @@ export const assetDuplicate = (assetId: string, data: AssetDuplicateData) => {
         headers: {
             Accept: 'application/json'
         }
+    });
+};
+
+/**
+ * Clones a user-owned asset into a project.
+ *
+ * @param assetId - The ID of the asset to clone
+ * @param data - The target project and folder
+ * @returns A request that responds with the clone result
+ */
+export const assetClone = (assetId: string, data: AssetCloneData) => {
+    return Ajax.post({
+        url: `${api.apiUrl}/assets/${assetId}/clone`,
+        auth: true,
+        data
     });
 };
 

--- a/src/editor-api/rest/assets.ts
+++ b/src/editor-api/rest/assets.ts
@@ -304,6 +304,16 @@ export type AssetPipelineOptions = {
     meshCompression?: boolean;
 
     /**
+     * The speed of Draco decoding
+     */
+    dracoDecodeSpeed?: number;
+
+    /**
+     * The size of Draco meshes
+     */
+    dracoMeshSize?: number;
+
+    /**
      * Whether to unwrap UVs
      */
     unwrapUv?: boolean;
@@ -496,6 +506,8 @@ const assetUpdateFields = (form: FormData, data: AssetUpdateData, pipeline: Asse
                 form.append('animUseFbxFilename', `${pipeline.animUseFbxFilename}`);
                 form.append('useContainers', `${pipeline.useContainers}`);
                 form.append('meshCompression', `${pipeline.meshCompression}`);
+                form.append('dracoDecodeSpeed', `${pipeline.dracoDecodeSpeed}`);
+                form.append('dracoMeshSize', `${pipeline.dracoMeshSize}`);
                 form.append('unwrapUv', `${pipeline.unwrapUv}`);
                 form.append('unwrapUvTexelsPerMeter', `${pipeline.unwrapUvTexelsPerMeter}`);
                 form.append('importMorphNormals', `${pipeline.importMorphNormals}`);

--- a/src/editor-api/rest/store.ts
+++ b/src/editor-api/rest/store.ts
@@ -32,11 +32,13 @@ export type StoreCloneData = {
     /**
      * The license of the store item
      */
-    license?: string | {
-        author: string;
-        authorUrl: string;
-        license: string;
-    };
+    license?:
+        | string
+        | {
+              author: string;
+              authorUrl: string;
+              license: string;
+          };
 };
 
 export type StoreListOptions = {

--- a/src/editor-api/rest/store.ts
+++ b/src/editor-api/rest/store.ts
@@ -27,12 +27,16 @@ export type StoreCloneData = {
     /**
      * The ID of the folder to clone the item to
      */
-    targetFolderId?: string;
+    targetFolderId?: string | null;
 
     /**
      * The license of the store item
      */
-    license?: string;
+    license?: string | {
+        author: string;
+        authorUrl: string;
+        license: string;
+    };
 };
 
 export type StoreListOptions = {
@@ -124,7 +128,7 @@ export const storeUpload = (data: object, mimeType: string) => {
  * @param data - The data for the new store item
  * @returns A request that responds with the new store item
  */
-export const storeClone = (storeId: number, data: StoreCloneData) => {
+export const storeClone = (storeId: number | string, data: StoreCloneData) => {
     return Ajax.post({
         url: `${api.apiUrl}/store/${storeId}/clone`,
         auth: true,

--- a/src/editor-api/rest/store.ts
+++ b/src/editor-api/rest/store.ts
@@ -38,6 +38,11 @@ export type StoreCloneData = {
               author: string;
               authorUrl: string;
               license: string;
+          }
+        | {
+              id: string;
+              author: string;
+              authorUrl: string;
           };
 };
 

--- a/src/editor-api/schema/assets.ts
+++ b/src/editor-api/schema/assets.ts
@@ -47,6 +47,40 @@ class AssetsSchema {
         return result;
     }
 
+    resolvePath(type: string, path: string) {
+        let field = this._schema[`${type}Data`];
+        let open = false;
+
+        if (!field) {
+            return null;
+        }
+        for (const part of path.split('.')) {
+            if (!part) {
+                return null;
+            }
+            if (field.$type === 'map' || field.$type === 'mixed') {
+                open = true;
+                if (!field.$of) {
+                    return { field: null, default: undefined, hasDefault: false, open };
+                }
+                field = field.$of;
+            } else if (Array.isArray(field.$type)) {
+                if (!Number.isInteger(Number(part)) || Number(part) < 0) {
+                    return null;
+                }
+                field = field.$type[0];
+            } else if (Object.hasOwn(field, part)) {
+                field = field[part];
+                continue;
+            } else {
+                return null;
+            }
+        }
+
+        const hasDefault = Object.hasOwn(field, '$default');
+        return { field, default: hasDefault ? utils.deepCopy(field.$default) : undefined, hasDefault, open };
+    }
+
     /**
      * Gets a list of fields of a particular type for an asset type
      *

--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -63,6 +63,46 @@ class ComponentSchema {
         return result;
     }
 
+    resolvePath(component: string, path: string) {
+        let field = this._schema[component];
+        let open = false;
+
+        if (!field) {
+            return null;
+        }
+        for (const part of path.split('.')) {
+            if (!part) {
+                return null;
+            }
+            if (field.$type === 'map' || field.$type === 'mixed') {
+                open = true;
+                if (!field.$of) {
+                    return { field: null, default: undefined, hasDefault: false, open };
+                }
+                field = field.$of;
+            } else if (Array.isArray(field.$type)) {
+                if (!Number.isInteger(Number(part)) || Number(part) < 0) {
+                    return null;
+                }
+                field = field.$type[0];
+            } else if (Object.hasOwn(field, part)) {
+                field = field[part];
+                continue;
+            } else {
+                return null;
+            }
+        }
+
+        const hasDefault = Object.hasOwn(field, '$default');
+        const value = hasDefault ? field.$default : undefined;
+        return {
+            field,
+            default: hasDefault ? (typeof value === 'function' ? value() : utils.deepCopy(value)) : undefined,
+            hasDefault,
+            open
+        };
+    }
+
     /**
      * Gets a list of fields of a particular type for a component
      *

--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -44,6 +44,9 @@ class ComponentSchema {
      * ```
      */
     getDefaultData(component: string) {
+        if (!Object.hasOwn(this._schema, component)) {
+            throw new Error(`Unsupported component: ${component}`);
+        }
         const result: Record<string, any> = {};
         for (const fieldName in this._schema[component]) {
             if (fieldName.startsWith('$')) {

--- a/src/editor/animstategraph/data.ts
+++ b/src/editor/animstategraph/data.ts
@@ -103,6 +103,20 @@ const animStateKeys = (data: Data) => {
     return keys;
 };
 
+const remapAnimStateAssets = (current: Record<string, any>, changes: { key: string; next?: string }[]) => {
+    const result = structuredClone(current);
+    for (let i = 0; i < changes.length; i++) {
+        delete result[changes[i].key];
+    }
+    for (let i = 0; i < changes.length; i++) {
+        const { key, next } = changes[i];
+        if (next) {
+            result[next] = current[key] ?? { asset: null };
+        }
+    }
+    return result;
+};
+
 const parameter = (data: Data, name: string) => {
     const value = Object.values(data.parameters).find((item) => item.name === name);
     if (!value) {
@@ -688,5 +702,5 @@ const modifyAnimStateGraph = (value: Data, operations: Operation[]) => {
     return { data, ids };
 };
 
-export { animStateKeys, modifyAnimStateGraph };
+export { animStateKeys, modifyAnimStateGraph, remapAnimStateAssets };
 export type { Data as AnimStateGraphData, Operation as AnimStateGraphOperation };

--- a/src/editor/animstategraph/data.ts
+++ b/src/editor/animstategraph/data.ts
@@ -103,13 +103,16 @@ const animStateKeys = (data: Data) => {
     return keys;
 };
 
-const remapAnimStateAssets = (current: Record<string, any>, changes: { key: string; next?: string }[]) => {
+const remapAnimStateAssets = (
+    current: Record<string, any>,
+    changes: { key: string; next?: string; drop: boolean }[]
+) => {
     const result = structuredClone(current);
     for (let i = 0; i < changes.length; i++) {
-        delete result[changes[i].key];
-    }
-    for (let i = 0; i < changes.length; i++) {
-        const { key, next } = changes[i];
+        const { key, next, drop } = changes[i];
+        if (drop) {
+            delete result[key];
+        }
         if (next) {
             result[next] = current[key] ?? { asset: null };
         }

--- a/src/editor/animstategraph/data.ts
+++ b/src/editor/animstategraph/data.ts
@@ -103,23 +103,6 @@ const animStateKeys = (data: Data) => {
     return keys;
 };
 
-const remapAnimStateAssets = (
-    current: Record<string, any>,
-    changes: { key: string; next?: string; drop: boolean }[]
-) => {
-    const result = structuredClone(current);
-    for (let i = 0; i < changes.length; i++) {
-        const { key, next, drop } = changes[i];
-        if (drop) {
-            delete result[key];
-        }
-        if (next) {
-            result[next] = current[key] ?? { asset: null };
-        }
-    }
-    return result;
-};
-
 const parameter = (data: Data, name: string) => {
     const value = Object.values(data.parameters).find((item) => item.name === name);
     if (!value) {
@@ -705,5 +688,5 @@ const modifyAnimStateGraph = (value: Data, operations: Operation[]) => {
     return { data, ids };
 };
 
-export { animStateKeys, modifyAnimStateGraph, remapAnimStateAssets };
+export { animStateKeys, modifyAnimStateGraph };
 export type { Data as AnimStateGraphData, Operation as AnimStateGraphOperation };

--- a/src/editor/assets/assets-reimport.ts
+++ b/src/editor/assets/assets-reimport.ts
@@ -1,28 +1,11 @@
 editor.once('load', () => {
     let index = 0;
-    editor.method('assets:reimport', (assetId, type, callback) => {
-        const data = {};
-
-        // conversion pipeline specific parameters
-        const settings = editor.call('settings:projectUser');
-        if (type === 'texture' || type === 'textureatlas' || type === 'scene') {
-            data.pow2 = settings.get('editor.pipeline.texturePot');
-            data.searchRelatedAssets = settings.get('editor.pipeline.searchRelatedAssets');
-
-            if (type === 'scene') {
-                data.overwriteModel = settings.get('editor.pipeline.overwriteModel');
-                data.overwriteAnimation = settings.get('editor.pipeline.overwriteAnimation');
-                data.overwriteMaterial = settings.get('editor.pipeline.overwriteMaterial');
-                data.overwriteTexture = settings.get('editor.pipeline.overwriteTexture');
-                data.preserveMapping = settings.get('editor.pipeline.preserveMapping');
-                data.useGlb = settings.get('editor.pipeline.useGlb');
-                data.useContainers = settings.get('editor.pipeline.useContainers');
-                data.meshCompression = settings.get('editor.pipeline.meshCompression');
-                data.dracoDecodeSpeed = settings.get('editor.pipeline.dracoDecodeSpeed');
-                data.dracoMeshSize = settings.get('editor.pipeline.dracoMeshSize');
-                data.animUseFbxFilename = settings.get('editor.pipeline.animUseFbxFilename');
-            }
+    editor.method('assets:reimport', (assetId, type, overrides, callback) => {
+        if (typeof overrides === 'function') {
+            callback = overrides;
+            overrides = {};
         }
+        const data = editor.call('assets:pipeline:options', overrides);
 
         const jobId = ++index;
         const jobName = `asset-reimport:${jobId}`;

--- a/src/editor/assets/assets-textures-compress.ts
+++ b/src/editor/assets/assets-textures-compress.ts
@@ -117,7 +117,8 @@ const TextureCompressor = {
      * @param force - Force recompression. If false then the method will
      * check if recompression is needed first.
      */
-    compress(assets: Observer[], formats: string[], force: boolean): void {
+    compress(assets: Observer[], formats: string[], force = false) {
+        let scheduled = false;
         for (let i = 0; i < assets.length; i++) {
             const asset = assets[i];
             if (!asset.get('file')) {
@@ -127,7 +128,8 @@ const TextureCompressor = {
             const variants = [];
             const toDelete = [];
 
-            for (const format of formats) {
+            for (let j = 0; j < formats.length; j++) {
+                const format = formats[j];
                 if (format !== 'original') {
                     switch (this.determineRequiredProcessing(asset, format, force)) {
                         case 'compress':
@@ -143,6 +145,7 @@ const TextureCompressor = {
             }
 
             if (toDelete.length) {
+                scheduled = true;
                 editor.call('realtime:send', 'pipeline', {
                     name: 'delete-variant',
                     data: {
@@ -155,6 +158,7 @@ const TextureCompressor = {
             }
 
             if (variants.length) {
+                scheduled = true;
                 const task = {
                     asset: parseInt(asset.get('uniqueId'), 10),
                     options: {
@@ -189,6 +193,7 @@ const TextureCompressor = {
                 });
             }
         }
+        return scheduled;
     }
 };
 

--- a/src/editor/assets/assets-upload.ts
+++ b/src/editor/assets/assets-upload.ts
@@ -96,6 +96,8 @@ editor.once('load', () => {
             animUseFbxFilename: projectUserSettings.get('editor.pipeline.animUseFbxFilename'),
             useContainers: projectUserSettings.get('editor.pipeline.useContainers'),
             meshCompression: projectUserSettings.get('editor.pipeline.meshCompression'),
+            dracoDecodeSpeed: projectUserSettings.get('editor.pipeline.dracoDecodeSpeed'),
+            dracoMeshSize: projectUserSettings.get('editor.pipeline.dracoMeshSize'),
             unwrapUv: projectUserSettings.get('editor.pipeline.unwrapUv'),
             unwrapUvTexelsPerMeter: projectUserSettings.get('editor.pipeline.unwrapUvTexelsPerMeter'),
             importMorphNormals: projectUserSettings.get('editor.pipeline.importMorphNormals'),

--- a/src/editor/assets/assets-upload.ts
+++ b/src/editor/assets/assets-upload.ts
@@ -80,7 +80,7 @@ editor.once('load', () => {
     });
 
     // returns the pipeline options for assets
-    const pipelineOptions = () => {
+    const pipelineOptions = (overrides = {}) => {
         return {
             pow2: projectUserSettings.get('editor.pipeline.texturePot'),
             searchRelatedAssets: projectUserSettings.get('editor.pipeline.searchRelatedAssets'),
@@ -99,20 +99,22 @@ editor.once('load', () => {
             unwrapUv: projectUserSettings.get('editor.pipeline.unwrapUv'),
             unwrapUvTexelsPerMeter: projectUserSettings.get('editor.pipeline.unwrapUvTexelsPerMeter'),
             importMorphNormals: projectUserSettings.get('editor.pipeline.importMorphNormals'),
-            useUniqueIndices: projectUserSettings.get('editor.pipeline.useUniqueIndices')
+            useUniqueIndices: projectUserSettings.get('editor.pipeline.useUniqueIndices'),
+            ...overrides
         };
     };
+    editor.method('assets:pipeline:options', pipelineOptions);
 
     editor.method('assets:uploadFile', (args, fn) => {
         let request;
         if (args.asset) {
             const assetId = args.asset.get('id');
-            request = editor.api.globals.rest.assets.assetUpdate(assetId, args, pipelineOptions());
+            request = editor.api.globals.rest.assets.assetUpdate(assetId, args, pipelineOptions(args.settings));
         } else {
             // default preload scripts to true
             args.preloadDefault =
                 args.type === 'script' ? true : projectUserSettings.get('editor.pipeline.defaultAssetPreload');
-            request = editor.api.globals.rest.assets.assetCreate(args, pipelineOptions());
+            request = editor.api.globals.rest.assets.assetCreate(args, pipelineOptions(args.settings));
         }
 
         const job = ++uploadJobs;

--- a/src/editor/console/console.ts
+++ b/src/editor/console/console.ts
@@ -10,6 +10,7 @@ editor.on('load', () => {
     const workerClient = new WorkerClient(`${config.url.frontend}js/console.worker.js`);
     let workerReady = false;
     let pendingHistory = false;
+    let queryId = 0;
 
     workerClient.once('init', () => {
         workerClient.on('prune', (progress: number) => {
@@ -141,6 +142,20 @@ editor.on('load', () => {
         }
         return new Promise((resolve) => {
             submit(resolve);
+        });
+    });
+    editor.method('console:query', (options = {}) => {
+        const id = ++queryId;
+        const submit = (resolve: (value: unknown) => void) => {
+            workerClient.once(`query:${id}`, (data, meta) => resolve({ data, meta }));
+            workerClient.send('query', id, options);
+        };
+        return new Promise((resolve) => {
+            if (workerReady) {
+                submit(resolve);
+            } else {
+                workerClient.once('init', () => submit(resolve));
+            }
         });
     });
 

--- a/src/editor/driver/animstategraph.ts
+++ b/src/editor/driver/animstategraph.ts
@@ -19,11 +19,12 @@ const mappings = (assetId: number, prev: any, next: any) => {
         }
         const oldMap = structuredClone(entity.get('components.anim.animationAssets') || {});
         const newMap = structuredClone(oldMap);
-        changes.forEach(({ key, next }) => {
-            const value = oldMap[key] ?? { asset: null };
+        changes.forEach(({ key }) => {
             delete newMap[key];
+        });
+        changes.forEach(({ key, next }) => {
             if (next) {
-                newMap[next] = value;
+                newMap[next] = oldMap[key] ?? { asset: null };
             }
         });
         return [{ id: entity.get('resource_id'), before: oldMap, after: newMap }];

--- a/src/editor/driver/animstategraph.ts
+++ b/src/editor/driver/animstategraph.ts
@@ -1,4 +1,4 @@
-import { animStateKeys, modifyAnimStateGraph } from '../animstategraph/data';
+import { animStateKeys, modifyAnimStateGraph, remapAnimStateAssets } from '../animstategraph/data';
 
 import { driver } from './driver';
 import { api, log } from './shared';
@@ -6,29 +6,35 @@ import { api, log } from './shared';
 const mappings = (assetId: number, prev: any, next: any) => {
     const before = animStateKeys(prev);
     const after = animStateKeys(next);
-    const changes = Array.from(before).flatMap(([id, key]) => {
+    const changes = [];
+    for (const [id, key] of before) {
         const next = after.get(id);
-        return next !== key ? [{ key, next }] : [];
-    });
+        if (next !== key) {
+            changes.push({ key, next });
+        }
+    }
     if (!changes.length) {
         return [];
     }
-    return api.entities.list().flatMap((entity: any) => {
-        if (entity.get('components.anim.stateGraphAsset') !== assetId) {
-            return [];
+    const refs = editor.call('assets:used:index')?.[assetId]?.ref || {};
+    const ids = Object.keys(refs);
+    const maps = [];
+    for (let i = 0; i < ids.length; i++) {
+        if (refs[ids[i]].type !== 'entity') {
+            continue;
+        }
+        const entity = api.entities.get(ids[i]);
+        if (!entity || entity.get('components.anim.stateGraphAsset') !== assetId) {
+            continue;
         }
         const oldMap = structuredClone(entity.get('components.anim.animationAssets') || {});
-        const newMap = structuredClone(oldMap);
-        changes.forEach(({ key }) => {
-            delete newMap[key];
+        maps.push({
+            id: ids[i],
+            before: oldMap,
+            after: remapAnimStateAssets(oldMap, changes)
         });
-        changes.forEach(({ key, next }) => {
-            if (next) {
-                newMap[next] = oldMap[key] ?? { asset: null };
-            }
-        });
-        return [{ id: entity.get('resource_id'), before: oldMap, after: newMap }];
-    });
+    }
+    return maps;
 };
 
 const write = (asset: any, data: any, maps: any[], side: 'before' | 'after') => {
@@ -40,16 +46,16 @@ const write = (asset: any, data: any, maps: any[], side: 'before' | 'after') => 
     current.history.enabled = false;
     current.set('data', structuredClone(data));
     current.history.enabled = history;
-    maps.forEach((map) => {
-        const entity = api.entities.get(map.id);
+    for (let i = 0; i < maps.length; i++) {
+        const entity = api.entities.get(maps[i].id);
         if (!entity) {
-            return;
+            continue;
         }
         const enabled = entity.history.enabled;
         entity.history.enabled = false;
-        entity.set('components.anim.animationAssets', structuredClone(map[side]));
+        entity.set('components.anim.animationAssets', structuredClone(maps[i][side]));
         entity.history.enabled = enabled;
-    });
+    }
 };
 
 driver.method('animstategraph:get', (assetId) => {

--- a/src/editor/driver/animstategraph.ts
+++ b/src/editor/driver/animstategraph.ts
@@ -1,4 +1,4 @@
-import { animStateKeys, modifyAnimStateGraph, remapAnimStateAssets } from '../animstategraph/data';
+import { animStateKeys, modifyAnimStateGraph } from '../animstategraph/data';
 
 import { driver } from './driver';
 import { api, log } from './shared';
@@ -32,10 +32,20 @@ const mappings = (assetId: number, prev: any, next: any) => {
             continue;
         }
         const oldMap = structuredClone(entity.get('components.anim.animationAssets') || {});
+        const newMap = structuredClone(oldMap);
+        for (let j = 0; j < changes.length; j++) {
+            const { key, next, drop } = changes[j];
+            if (drop) {
+                delete newMap[key];
+            }
+            if (next) {
+                newMap[next] = oldMap[key] ?? { asset: null };
+            }
+        }
         maps.push({
             id: ids[i],
             before: oldMap,
-            after: remapAnimStateAssets(oldMap, changes)
+            after: newMap
         });
     }
     return maps;

--- a/src/editor/driver/animstategraph.ts
+++ b/src/editor/driver/animstategraph.ts
@@ -7,10 +7,14 @@ const mappings = (assetId: number, prev: any, next: any) => {
     const before = animStateKeys(prev);
     const after = animStateKeys(next);
     const changes = [];
+    const targets = new Set<string>();
     for (const [id, key] of before) {
         const next = after.get(id);
         if (next !== key) {
-            changes.push({ key, next });
+            changes.push({ key, next, drop: !targets.has(key) });
+            if (next) {
+                targets.add(next);
+            }
         }
     }
     if (!changes.length) {

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -58,6 +58,40 @@ const getAsset = (id: number) => {
     return asset;
 };
 
+const uploadAsset = (data: any, overrides: any = {}) => {
+    const settings = editor.call('settings:projectUser');
+    const pipeline = settings.get('editor.pipeline') || {};
+    const options = { ...pipeline, pow2: pipeline.texturePot, ...overrides };
+    return new Promise<any>((resolve, reject) => {
+        const payload = {
+            ...data,
+            parent: data.folder?.observer,
+            preloadDefault: data.type === 'script' ? true : pipeline.defaultAssetPreload
+        };
+        const request = data.id
+            ? api.rest.assets.assetUpdate(String(data.id), payload, options)
+            : api.rest.assets.assetCreate(payload, options);
+        request
+            .on('load', (_status: number, result: { id: number }) => {
+                const id = data.id || result.id;
+                const asset = api.assets.get(id);
+                if (asset) {
+                    resolve(asset);
+                    return;
+                }
+                const timer = setTimeout(() => {
+                    event.unbind();
+                    reject(new Error(`Timed out waiting for uploaded asset ${id}.`));
+                }, OPERATION_TIMEOUT);
+                const event = api.assets.once(`add[${id}]`, (value: any) => {
+                    clearTimeout(timer);
+                    resolve(value);
+                });
+            })
+            .on('error', (_status: number, error: unknown) => reject(error));
+    });
+};
+
 const prepareCreate = ({ type, options = {} }: any) => {
     const method = CREATE_METHODS[type];
     if (!method) {
@@ -288,8 +322,13 @@ driver.method('assets:upload', async (items) => {
         if (folder && folder.get('type') !== 'folder') {
             throw new Error(`Asset ${item.folder} is not a folder.`);
         }
+        const asset = item.id === undefined ? null : getAsset(item.id);
+        if (asset && asset.get('type') !== item.type) {
+            throw new Error(`Asset ${item.id} is type ${asset.get('type')}, not ${item.type}.`);
+        }
         return {
             data: {
+                id: item.id,
                 name: item.name,
                 type: item.type,
                 folder,
@@ -305,7 +344,7 @@ driver.method('assets:upload', async (items) => {
     const results = await Promise.all(
         prepared.map(({ data, settings }, index) =>
             Promise.resolve()
-                .then(() => api.assets.upload(data, settings))
+                .then(() => uploadAsset(data, settings))
                 .then(
                     (asset) => ({ result: { index, asset: assetSummary(asset) } }),
                     (error) => ({

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -1,14 +1,17 @@
 import { config } from '@/editor/config';
 
 import { driver } from './driver';
-import { api, log, rest, entitySummary, paginate, writeError } from './shared';
+import { api, log, rest, entitySummary, paginate, validatePath, writeError } from './shared';
 
-// ponytail: base64 keeps one transport; add streaming if 20 mib imports are common
 const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const MAX_CHUNK_BYTES = 1024 * 1024;
+const MAX_TRANSFER_BYTES = 512 * 1024 * 1024;
+const MAX_TRANSFERS = 1;
+const MAX_TRANSFER_MEMORY = 512 * 1024 * 1024;
 const MAX_BASE64_LENGTH = Math.ceil(MAX_FILE_BYTES / 3) * 4;
-const OPERATION_TIMEOUT = 30_000;
+const OPERATION_TIMEOUT = 60_000;
+const TRANSFER_TIMEOUT = 60_000;
 const TEXT_TYPES = ['css', 'html', 'json', 'script', 'shader', 'text'];
-let uploadId = 0;
 const MIME_TYPES: Record<string, string> = {
     css: 'text/css',
     html: 'text/html',
@@ -33,6 +36,9 @@ const CREATE_METHODS: Record<string, string> = {
     template: 'createTemplate',
     text: 'createText'
 };
+const transfers = new Map<string, any>();
+let reserved = 0;
+let pendingDownload = false;
 
 /**
  * Compact summary for an asset.
@@ -59,49 +65,144 @@ const getAsset = (id: number) => {
     return asset;
 };
 
-const uploadAsset = (data: any, overrides: any = {}) => {
-    const settings = editor.call('settings:projectUser');
-    const pipeline = settings.get('editor.pipeline') || {};
-    const options = { ...pipeline, pow2: pipeline.texturePot, ...overrides };
+const waitForAsset = (id: number) => {
+    const asset = api.assets.get(id);
+    if (asset) {
+        return Promise.resolve(asset);
+    }
     return new Promise<any>((resolve, reject) => {
-        const job = --uploadId;
-        const finish = (asset: any) => {
-            api.assets.defaultUploadCompletedCallback?.(job, asset);
-            resolve(asset);
-        };
-        const fail = (error: unknown) => {
-            api.assets.defaultUploadErrorCallback?.(job, error instanceof Error ? error : new Error(String(error)));
-            reject(error);
-        };
-        const payload = {
-            ...data,
-            parent: data.folder?.observer,
-            preloadDefault: data.type === 'script' ? true : pipeline.defaultAssetPreload
-        };
-        const request = data.id
-            ? api.rest.assets.assetUpdate(String(data.id), payload, options)
-            : api.rest.assets.assetCreate(payload, options);
-        api.assets.defaultUploadProgressCallback?.(job, 0);
-        request
-            .on('load', (_status: number, result: { id: number }) => {
-                const id = data.id || result.id;
-                const asset = api.assets.get(id);
-                if (asset) {
-                    finish(asset);
+        const event = api.assets.once(`add[${id}]`, (value: any) => {
+            clearTimeout(timer);
+            resolve(value);
+        });
+        const timer = setTimeout(() => {
+            event.unbind();
+            reject(new Error(`Timed out waiting for asset ${id}.`));
+        }, OPERATION_TIMEOUT);
+    });
+};
+
+const uploadAsset = (data: any, settings: any = {}) =>
+    new Promise<any>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`Timed out uploading ${data.filename}.`)), OPERATION_TIMEOUT);
+        editor.call(
+            'assets:uploadFile',
+            {
+                ...data,
+                asset: data.id === undefined ? undefined : getAsset(data.id).observer,
+                parent: data.folder?.observer,
+                settings
+            },
+            (error: unknown, result: { id: number }) => {
+                clearTimeout(timer);
+                if (error) {
+                    reject(error);
                     return;
                 }
-                const timer = setTimeout(() => {
-                    event.unbind();
-                    fail(new Error(`Timed out waiting for uploaded asset ${id}.`));
-                }, OPERATION_TIMEOUT);
-                const event = api.assets.once(`add[${id}]`, (value: any) => {
-                    clearTimeout(timer);
-                    finish(value);
-                });
-            })
-            .on('progress', (progress: number) => api.assets.defaultUploadProgressCallback?.(job, progress))
-            .on('error', (_status: number, error: unknown) => fail(error));
+                waitForAsset(result.id).then(resolve, reject);
+            }
+        );
     });
+
+const uploadBytes = (item: any, bytes: Uint8Array) => {
+    if (!bytes.length) {
+        throw new Error(`Cannot upload empty file: ${item.filename}.`);
+    }
+    const folder = item.folder === undefined || item.folder === null ? undefined : getAsset(item.folder);
+    if (folder && folder.get('type') !== 'folder') {
+        throw new Error(`Asset ${item.folder} is not a folder.`);
+    }
+    const asset = item.id === undefined ? null : getAsset(item.id);
+    if (asset && asset.get('type') !== item.type) {
+        throw new Error(`Asset ${item.id} is type ${asset.get('type')}, not ${item.type}.`);
+    }
+    return uploadAsset(
+        {
+            id: item.id,
+            name: item.name,
+            type: item.type,
+            folder,
+            filename: item.filename,
+            file: new Blob([bytes.buffer as ArrayBuffer], { type: item.mime || 'application/octet-stream' }),
+            tags: item.tags,
+            data: item.data,
+            preload: item.preload
+        },
+        item.settings
+    );
+};
+
+const bytesToBase64 = (bytes: Uint8Array) => {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 0x8000) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    }
+    return btoa(binary);
+};
+
+const dropTransfer = (id: string) => {
+    const transfer = transfers.get(id);
+    if (!transfer) {
+        return false;
+    }
+    clearTimeout(transfer.timer);
+    transfers.delete(id);
+    reserved -= transfer.size;
+    return true;
+};
+
+const touchTransfer = (transfer: any) => {
+    clearTimeout(transfer.timer);
+    transfer.timer = setTimeout(() => dropTransfer(transfer.id), TRANSFER_TIMEOUT);
+};
+
+const addTransfer = (transfer: any) => {
+    if (
+        !Number.isInteger(transfer.size) ||
+        transfer.size < 0 ||
+        (transfer.direction === 'upload' && transfer.size === 0) ||
+        transfer.size > MAX_TRANSFER_BYTES ||
+        transfers.size >= MAX_TRANSFERS ||
+        reserved + transfer.size > MAX_TRANSFER_MEMORY
+    ) {
+        throw new Error('Transfer exceeds the configured size, concurrency, or memory limit.');
+    }
+    transfer.id = crypto.randomUUID();
+    transfer.offset = 0;
+    transfers.set(transfer.id, transfer);
+    reserved += transfer.size;
+    touchTransfer(transfer);
+    return transfer;
+};
+
+const downloadAsset = async (id: number) => {
+    const asset = getAsset(id);
+    const type = asset.get('type');
+    let blob;
+    let filename = asset.get('file.filename') || asset.get('name');
+    if (type === 'animstategraph') {
+        filename = `${filename}.json`;
+        blob = new Blob([JSON.stringify(asset.get('data'), null, 4)], { type: 'application/json' });
+    } else {
+        const res = await fetch(`/api/assets/${id}/download?branchId=${config.self.branch.id}`);
+        if (!res.ok) {
+            throw new Error(`Failed to download asset: ${res.status} ${res.statusText}`);
+        }
+        const length = Number(res.headers.get('content-length'));
+        if (length > MAX_TRANSFER_BYTES) {
+            throw new Error(`Asset download exceeds the ${MAX_TRANSFER_BYTES / 1024 / 1024} MiB limit.`);
+        }
+        blob = await res.blob();
+    }
+    if (blob.size > MAX_TRANSFER_BYTES) {
+        throw new Error(`Asset download exceeds the ${MAX_TRANSFER_BYTES / 1024 / 1024} MiB limit.`);
+    }
+    return {
+        id,
+        filename,
+        mime: blob.type || 'application/octet-stream',
+        bytes: new Uint8Array(await blob.arrayBuffer())
+    };
 };
 
 const prepareCreate = ({ type, options = {} }: any) => {
@@ -142,15 +243,40 @@ const modifyAssets = async (edits: any[]) => {
     if (denied) {
         return denied;
     }
+    const arrays = new Map<string, any[]>();
     const prepared = edits.map((edit) => {
         const asset = getAsset(edit.id);
         const root = edit.path?.split('.')[0];
-        if (!['name', 'tags', 'preload', 'data'].includes(root)) {
-            throw new Error(`Invalid asset path: ${edit.path}. Use name, tags, preload, or data.*.`);
+        validatePath(edit.path);
+        if (!['name', 'tags', 'preload', 'exclude', 'i18n', 'data', 'meta'].includes(root)) {
+            throw new Error(
+                `Invalid asset path: ${edit.path}. Use name, tags, preload, exclude, i18n.*, data.*, meta.compress.*, or meta.invert.`
+            );
+        }
+        const resolved = root === 'data'
+            ? api.schema.assets.resolvePath(asset.get('type'), edit.path.slice(5))
+            : null;
+        if (root === 'data' && !resolved) {
+            throw new Error(`Unknown ${asset.get('type')} asset path: ${edit.path}.`);
+        }
+        if (
+            (root === 'i18n' && !edit.path.startsWith('i18n.')) ||
+            (root === 'meta' && edit.path !== 'meta.invert' && !edit.path.startsWith('meta.compress.'))
+        ) {
+            throw new Error(`Invalid asset path: ${edit.path}.`);
         }
         const op = edit.op || 'set';
-        if (op !== 'set' && !edit.path.startsWith('data.')) {
+        if (!['set', 'unset', 'insert', 'remove', 'move'].includes(op)) {
+            throw new Error(`Invalid asset operation: ${op}.`);
+        }
+        if (['insert', 'remove', 'move'].includes(op) && !edit.path.startsWith('data.')) {
             throw new Error(`Operation ${op} is only supported under data.*.`);
+        }
+        if (op === 'unset' && ['name', 'tags', 'preload', 'exclude'].includes(root)) {
+            throw new Error(`Asset path ${edit.path} cannot be unset.`);
+        }
+        if (op === 'unset' && root === 'data' && !resolved.hasDefault && !resolved.open) {
+            throw new Error(`Asset path ${edit.path} cannot be unset.`);
         }
         if (asset.get('type') === 'animstategraph' && edit.path.startsWith('data.')) {
             throw new Error(
@@ -182,7 +308,8 @@ const modifyAssets = async (edits: any[]) => {
                 throw new Error('Asset preload must be a boolean.');
             }
         } else if (op !== 'unset') {
-            const value = asset.get(edit.path);
+            const key = `${edit.id}:${edit.path}`;
+            const value = arrays.get(key) || structuredClone(asset.get(edit.path));
             if (!Array.isArray(value)) {
                 throw new Error(`Asset path ${edit.path} is not an array.`);
             }
@@ -198,23 +325,50 @@ const modifyAssets = async (edits: any[]) => {
             if (op === 'move' && (!Number.isInteger(edit.to) || edit.to < 0 || edit.to >= value.length)) {
                 throw new Error(`Invalid destination index ${edit.to} for asset path ${edit.path}.`);
             }
+            arrays.set(key, value);
+            if (op === 'insert') {
+                value.splice(edit.index ?? value.length, 0, structuredClone(edit.value));
+            } else if (op === 'remove') {
+                value.splice(edit.index, 1);
+            } else {
+                value.splice(edit.to, 0, value.splice(edit.index, 1)[0]);
+            }
         }
-        return { asset, edit, op };
+        const nextOp = op === 'unset' && resolved?.hasDefault ? 'set' : op;
+        const value = op === 'unset' && resolved?.hasDefault ? resolved.default : edit.value;
+        if (nextOp === 'set' && Array.isArray(value)) {
+            arrays.set(`${edit.id}:${edit.path}`, structuredClone(value));
+        } else if (nextOp === 'unset') {
+            arrays.delete(`${edit.id}:${edit.path}`);
+        }
+        return {
+            asset,
+            edit,
+            op: nextOp,
+            value
+        };
     });
 
     const modified = new Map();
-    for (const { asset, edit, op } of prepared) {
-        if (op === 'set') {
-            if (edit.path === 'name') {
-                const error = await new Promise((resolve) =>
-                    editor.call('assets:rename', asset.observer, edit.value, resolve)
-                );
-                if (error) {
-                    return { error: String(error) };
+    const renamed = [];
+    for (const { asset, edit } of prepared.filter(({ edit, op }) => op === 'set' && edit.path === 'name')) {
+        const error = await new Promise((resolve) => editor.call('assets:rename', asset.observer, edit.value, resolve));
+        if (error) {
+            return {
+                error: String(error),
+                meta: {
+                    partial: renamed.length > 0,
+                    succeeded: renamed,
+                    failed: [{ id: edit.id, path: edit.path, message: String(error) }]
                 }
-            } else {
-                asset.set(edit.path, edit.value);
-            }
+            };
+        }
+        renamed.push({ id: edit.id, path: edit.path });
+        modified.set(edit.id, asset);
+    }
+    for (const { asset, edit, op, value } of prepared.filter(({ edit }) => edit.path !== 'name')) {
+        if (op === 'set') {
+            asset.set(edit.path, value);
         } else if (op === 'unset') {
             asset.unset(edit.path);
         } else if (op === 'insert') {
@@ -323,46 +477,21 @@ driver.method('assets:upload', async (items) => {
             throw new Error(`Asset upload exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.`);
         }
         const binary = atob(item.base64);
-        if (!binary.length) {
-            throw new Error(`Cannot upload empty file: ${item.filename}.`);
-        }
         if (binary.length > MAX_FILE_BYTES) {
             throw new Error(`Asset upload exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.`);
         }
-        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-        const folder = item.folder === undefined || item.folder === null ? undefined : getAsset(item.folder);
-        if (folder && folder.get('type') !== 'folder') {
-            throw new Error(`Asset ${item.folder} is not a folder.`);
-        }
-        const asset = item.id === undefined ? null : getAsset(item.id);
-        if (asset && asset.get('type') !== item.type) {
-            throw new Error(`Asset ${item.id} is type ${asset.get('type')}, not ${item.type}.`);
-        }
-        return {
-            data: {
-                id: item.id,
-                name: item.name,
-                type: item.type,
-                folder,
-                filename: item.filename,
-                file: new Blob([bytes], { type: item.mime || 'application/octet-stream' }),
-                tags: item.tags,
-                data: item.data,
-                preload: item.preload
-            },
-            settings: item.settings
-        };
+        return { item, bytes: Uint8Array.from(binary, (char) => char.charCodeAt(0)) };
     });
     const results = await Promise.all(
-        prepared.map(({ data, settings }, index) =>
+        prepared.map(({ item, bytes }, index) =>
             Promise.resolve()
-                .then(() => uploadAsset(data, settings))
+                .then(() => uploadBytes(item, bytes))
                 .then(
                     (asset) => ({ result: { index, asset: assetSummary(asset) } }),
                     (error) => ({
                         error: {
                             index,
-                            filename: data.filename,
+                            filename: item.filename,
                             message: error instanceof Error ? error.message : String(error)
                         }
                     })
@@ -421,11 +550,20 @@ driver.method('assets:duplicate', (ids) => {
         return denied;
     }
     const assets = ids.map(getAsset);
-    editor.call(
-        'assets:fs:duplicate',
-        assets.map((asset: any) => asset.observer)
-    );
-    return { data: { accepted: ids } };
+    return Promise.all(
+        assets.map(
+            (asset: any) =>
+                new Promise<number>((resolve, reject) => {
+                    api.rest.assets
+                        .assetDuplicate(String(asset.get('id')), {
+                            type: asset.get('type'),
+                            branchId: config.self.branch.id
+                        })
+                        .on('load', (_status: number, result: { id: number }) => resolve(result.id))
+                        .on('error', (_status: number, error: unknown) => reject(error));
+                }).then(waitForAsset)
+        )
+    ).then((created) => ({ data: created.map(assetSummary) }));
 });
 driver.method('assets:replace', (id, replacementId) => {
     const denied = writeError('replace asset references');
@@ -443,33 +581,31 @@ driver.method('assets:reimport', async (ids, settings = {}) => {
         return denied;
     }
     ids.forEach(getAsset);
-    const results = await Promise.all(
-        ids.map(
-            (id: number) =>
-                new Promise((resolve) => {
-                    api.rest.assets
-                        .assetReimport(String(id), settings)
-                        .on('load', (_status: number, result: unknown) => resolve({ result: { id, result } }))
-                        .on('error', (_status: number, error: unknown) =>
-                            resolve({
-                                error: { id, message: error instanceof Error ? error.message : String(error) }
-                            })
-                        );
-                })
-        )
-    );
+    const results = await Promise.all(ids.map((id: number) => {
+        const asset = getAsset(id);
+        return new Promise((resolve) => {
+            editor.call('assets:reimport', id, asset.get('type'), settings, (error: unknown, result: unknown) =>
+                resolve(error
+                    ? { error: { id, message: error instanceof Error ? error.message : String(error) } }
+                    : { result: { id, result } }));
+        });
+    }));
     const succeeded = results.flatMap((item: any) => (item.result ? [item.result] : []));
     const failed = results.flatMap((item: any) => (item.error ? [item.error] : []));
     return { data: { succeeded, failed }, meta: { partial: failed.length > 0 } };
 });
-driver.method('assets:delete', async (ids) => {
+driver.method('assets:delete', async (ids, options: any = {}) => {
     const denied = writeError('delete assets');
     if (denied) {
         return denied;
     }
-    const assets = ids.map((id: number) => api.assets.get(id)).filter(Boolean);
-    if (!assets.length) {
-        return { error: 'No valid assets to delete. Call list_assets to obtain valid asset ids.' };
+    const assets = ids.map(getAsset);
+    if (options.rejectReferenced) {
+        const index = editor.call('assets:used:index') || {};
+        const referenced = ids.filter((id: number) => index[id]?.count);
+        if (referenced.length) {
+            throw new Error(`Referenced assets cannot be deleted: ${referenced.join(', ')}.`);
+        }
     }
     await api.assets.delete(assets);
     log(`Deleted assets: ${ids.join(', ')}`);
@@ -502,6 +638,20 @@ driver.method('assets:list', (options: any = {}) => {
 
     // summary mode: return minimal data
     return { data: page.map(assetSummary), meta };
+});
+driver.method('assets:get', (id) => ({ data: getAsset(id).json() }));
+driver.method('assets:references:get', (id) => {
+    getAsset(id);
+    const ref = editor.call('assets:used:index')?.[id]?.ref || {};
+    return {
+        data: {
+            id,
+            references: Object.entries(ref).map(([resourceId, value]: any) => ({
+                type: value.type,
+                id: resourceId
+            }))
+        }
+    };
 });
 driver.method('templates:instantiate', instantiateTemplates);
 driver.method('assets:instantiate', (ids) => instantiateTemplates({ assetIds: ids, ignoreMissing: true }));
@@ -550,33 +700,143 @@ driver.method('assets:file:text:get', async (id) => {
     }
 });
 driver.method('assets:file:get', async (id) => {
-    const asset = getAsset(id);
-    const type = asset.get('type');
-    let blob;
-    let filename = asset.get('file.filename') || asset.get('name');
-    if (type === 'animstategraph') {
-        filename = `${filename}.json`;
-        blob = new Blob([JSON.stringify(asset.get('data'), null, 4)], { type: 'application/json' });
-    } else {
-        const res = await fetch(`/api/assets/${id}/download?branchId=${config.self.branch.id}`);
-        if (!res.ok) {
-            return { error: `Failed to download asset: ${res.status} ${res.statusText}` };
-        }
-        const length = Number(res.headers.get('content-length'));
-        if (length > MAX_FILE_BYTES) {
-            return { error: `Asset download exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.` };
-        }
-        blob = await res.blob();
-    }
-    if (blob.size > MAX_FILE_BYTES) {
+    const data = await downloadAsset(id);
+    if (data.bytes.length > MAX_FILE_BYTES) {
         return { error: `Asset download exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.` };
     }
-    const bytes = new Uint8Array(await blob.arrayBuffer());
-    let binary = '';
-    for (let i = 0; i < bytes.length; i += 0x8000) {
-        binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    return { data: { id, filename: data.filename, mime: data.mime, base64: bytesToBase64(data.bytes) } };
+});
+
+driver.method('files:upload:start', (item, size) => {
+    const denied = writeError('upload assets');
+    if (denied) {
+        return denied;
     }
-    return { data: { id, filename, mime: blob.type || 'application/octet-stream', base64: btoa(binary) } };
+    if (!item?.filename || !item?.type) {
+        throw new Error('Upload transfer requires filename and type.');
+    }
+    if (item.folder !== undefined && item.folder !== null && getAsset(item.folder).get('type') !== 'folder') {
+        throw new Error(`Asset ${item.folder} is not a folder.`);
+    }
+    if (item.id !== undefined && getAsset(item.id).get('type') !== item.type) {
+        throw new Error(`Asset ${item.id} does not match upload type ${item.type}.`);
+    }
+    const transfer = addTransfer({ direction: 'upload', size, item, bytes: new Uint8Array(size) });
+    return { data: { transferId: transfer.id, size, chunkSize: MAX_CHUNK_BYTES } };
+});
+
+driver.method('files:upload:append', (id, offset, base64) => {
+    const transfer = transfers.get(id);
+    if (!transfer || transfer.direction !== 'upload') {
+        throw new Error(`Upload transfer not found: ${id}.`);
+    }
+    if (offset !== transfer.offset || typeof base64 !== 'string' || base64.length > Math.ceil(MAX_CHUNK_BYTES / 3) * 4) {
+        throw new Error(`Invalid upload offset or chunk for transfer ${id}.`);
+    }
+    const binary = atob(base64);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    if (!bytes.length || bytes.length > MAX_CHUNK_BYTES || transfer.offset + bytes.length > transfer.size) {
+        throw new Error(`Invalid upload chunk length for transfer ${id}.`);
+    }
+    transfer.bytes.set(bytes, transfer.offset);
+    transfer.offset += bytes.length;
+    touchTransfer(transfer);
+    return { data: { transferId: id, offset: transfer.offset } };
+});
+
+driver.method('files:upload:finish', async (id) => {
+    const transfer = transfers.get(id);
+    if (!transfer || transfer.direction !== 'upload' || transfer.offset !== transfer.size) {
+        throw new Error(`Incomplete upload transfer: ${id}.`);
+    }
+    clearTimeout(transfer.timer);
+    transfer.direction = 'finishing';
+    touchTransfer(transfer);
+    const [error, asset] = await uploadBytes(transfer.item, transfer.bytes).then(
+        (value) => [null, value],
+        (value) => [value, null]
+    );
+    dropTransfer(id);
+    if (error) {
+        throw error;
+    }
+    return { data: assetSummary(asset) };
+});
+
+driver.method('files:download:start', async (id, inlineLimit = 0) => {
+    if (transfers.size || pendingDownload) {
+        throw new Error('Finish or cancel the active file transfer before starting another.');
+    }
+    pendingDownload = true;
+    const [error, data] = await downloadAsset(id).then(
+        (value) => [null, value],
+        (value) => [value, null]
+    );
+    pendingDownload = false;
+    if (error) {
+        throw error;
+    }
+    if (data.bytes.length <= Math.min(inlineLimit, MAX_FILE_BYTES)) {
+        return {
+            data: {
+                size: data.bytes.length,
+                filename: data.filename,
+                mime: data.mime,
+                base64: bytesToBase64(data.bytes)
+            }
+        };
+    }
+    const transfer = addTransfer({ direction: 'download', size: data.bytes.length, data });
+    return {
+        data: {
+            transferId: transfer.id,
+            size: transfer.size,
+            chunkSize: MAX_CHUNK_BYTES,
+            filename: data.filename,
+            mime: data.mime
+        }
+    };
+});
+
+driver.method('files:download:read', (id, offset, length = MAX_CHUNK_BYTES) => {
+    const transfer = transfers.get(id);
+    if (!transfer || transfer.direction !== 'download') {
+        throw new Error(`Download transfer not found: ${id}.`);
+    }
+    if (offset !== transfer.offset || !Number.isInteger(length) || length <= 0 || length > MAX_CHUNK_BYTES) {
+        throw new Error(`Invalid download offset or chunk length for transfer ${id}.`);
+    }
+    const bytes = transfer.data.bytes.subarray(offset, Math.min(offset + length, transfer.size));
+    transfer.offset += bytes.length;
+    touchTransfer(transfer);
+    return {
+        data: {
+            transferId: id,
+            offset: transfer.offset,
+            base64: bytesToBase64(bytes),
+            done: transfer.offset === transfer.size
+        }
+    };
+});
+
+driver.method('files:transfer:finish', (id) => {
+    const transfer = transfers.get(id);
+    if (!transfer || transfer.offset !== transfer.size) {
+        throw new Error(`Incomplete transfer: ${id}.`);
+    }
+    dropTransfer(id);
+    return { data: { transferId: id, size: transfer.size } };
+});
+
+driver.method('files:transfer:cancel', (id) => ({
+    data: {
+        transferId: id,
+        cancelled: transfers.get(id)?.direction === 'finishing' ? false : dropTransfer(id)
+    }
+}));
+driver.method('files:transfer:clear', () => {
+    [...transfers.keys()].forEach(dropTransfer);
+    return { data: { cleared: true } };
 });
 driver.method('templates:apply', async ({ entityId, overrides }: any) => {
     const denied = writeError('apply template overrides');
@@ -670,10 +930,10 @@ driver.method('assets:script:parse', async (id) => {
         editor.call('scripts:parse', (asset as any).observer, (...d: any[]) => resolve(d));
     });
     if (err) {
-        return { error: err };
+        return { error: err?.message || err?.error || String(err) };
     }
-    if (Object.keys(data.scripts).length === 0) {
-        return { error: 'Failed to parse script' };
+    if (!data?.scripts || Object.keys(data.scripts).length === 0) {
+        return { error: `Script parser returned no declarations for asset ${id}.` };
     }
     log(`Parsed asset(${id}) script`);
     return { data };

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -583,25 +583,24 @@ driver.method('assets:move', async (ids, folderId) => {
     const failure = await complete;
     return failure ? { error: failure } : { data: assets.map(assetSummary) };
 });
-driver.method('assets:duplicate', (ids) => {
+driver.method('assets:duplicate', async (ids) => {
     const denied = writeError('duplicate assets');
     if (denied) {
         return denied;
     }
-    const assets = ids.map(getAsset);
-    return Promise.all(
-        assets.map((asset: any) =>
-            new Promise<number>((resolve, reject) => {
-                api.rest.assets
-                    .assetDuplicate(String(asset.get('id')), {
-                        type: asset.get('type'),
-                        branchId: config.self.branch.id
-                    })
-                    .on('load', (_status: number, result: { id: number }) => resolve(result.id))
-                    .on('error', (_status: number, error: unknown) => reject(error));
-            }).then(waitForAsset)
-        )
-    ).then((created) => ({ data: created.map(assetSummary) }));
+    ids.forEach(getAsset);
+    const result = await api.rest.assets
+        .assetPaste({
+            projectId: config.project.id,
+            branchId: config.self.branch.id,
+            targetProjectId: config.project.id,
+            targetBranchId: config.self.branch.id,
+            keepFolderStructure: true,
+            assets: ids.map(String)
+        })
+        .promisify();
+    const created = await Promise.all(result.result.map((asset: { id: number }) => waitForAsset(asset.id)));
+    return { data: created.map(assetSummary) };
 });
 driver.method('assets:replace', (id, replacementId) => {
     const denied = writeError('replace asset references');

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -7,9 +7,7 @@ const MAX_FILE_BYTES = 20 * 1024 * 1024;
 const MAX_CHUNK_BYTES = 1024 * 1024;
 const MAX_TRANSFER_BYTES = 512 * 1024 * 1024;
 const MAX_TRANSFERS = 1;
-const MAX_TRANSFER_MEMORY = 512 * 1024 * 1024;
 const MAX_BASE64_LENGTH = Math.ceil(MAX_FILE_BYTES / 3) * 4;
-const OPERATION_TIMEOUT = 60_000;
 const TRANSFER_TIMEOUT = 60_000;
 const TEXT_TYPES = ['css', 'html', 'json', 'script', 'shader', 'text'];
 const MIME_TYPES: Record<string, string> = {
@@ -37,7 +35,6 @@ const CREATE_METHODS: Record<string, string> = {
     text: 'createText'
 };
 const transfers = new Map<string, any>();
-let reserved = 0;
 let pendingDownload = false;
 
 /**
@@ -70,21 +67,11 @@ const waitForAsset = (id: number) => {
     if (asset) {
         return Promise.resolve(asset);
     }
-    return new Promise<any>((resolve, reject) => {
-        const event = api.assets.once(`add[${id}]`, (value: any) => {
-            clearTimeout(timer);
-            resolve(value);
-        });
-        const timer = setTimeout(() => {
-            event.unbind();
-            reject(new Error(`Timed out waiting for asset ${id}.`));
-        }, OPERATION_TIMEOUT);
-    });
+    return new Promise<any>((resolve) => api.assets.once(`add[${id}]`, resolve));
 };
 
 const uploadAsset = (data: any, settings: any = {}) =>
     new Promise<any>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error(`Timed out uploading ${data.filename}.`)), OPERATION_TIMEOUT);
         editor.call(
             'assets:uploadFile',
             {
@@ -94,7 +81,6 @@ const uploadAsset = (data: any, settings: any = {}) =>
                 settings
             },
             (error: unknown, result: { id: number }) => {
-                clearTimeout(timer);
                 if (error) {
                     reject(error);
                     return;
@@ -104,8 +90,8 @@ const uploadAsset = (data: any, settings: any = {}) =>
         );
     });
 
-const uploadBytes = (item: any, bytes: Uint8Array) => {
-    if (!bytes.length) {
+const uploadFile = (item: any, file: File) => {
+    if (!file.size) {
         throw new Error(`Cannot upload empty file: ${item.filename}.`);
     }
     const folder = item.folder === undefined || item.folder === null ? undefined : getAsset(item.folder);
@@ -123,13 +109,22 @@ const uploadBytes = (item: any, bytes: Uint8Array) => {
             type: item.type,
             folder,
             filename: item.filename,
-            file: new Blob([bytes.buffer as ArrayBuffer], { type: item.mime || 'application/octet-stream' }),
+            file: new File([file], item.filename, { type: item.mime || 'application/octet-stream' }),
             tags: item.tags,
             data: item.data,
             preload: item.preload
         },
         item.settings
     );
+};
+
+const base64ToBytes = (base64: string) => {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
 };
 
 const bytesToBase64 = (bytes: Uint8Array) => {
@@ -140,20 +135,22 @@ const bytesToBase64 = (bytes: Uint8Array) => {
     return btoa(binary);
 };
 
-const dropTransfer = (id: string) => {
+const dropTransfer = async (id: string) => {
     const transfer = transfers.get(id);
     if (!transfer) {
         return false;
     }
     clearTimeout(transfer.timer);
     transfers.delete(id);
-    reserved -= transfer.size;
+    await transfer.writer?.abort().catch(() => false);
+    await transfer.reader?.cancel().catch(() => false);
+    await transfer.root?.removeEntry(id).catch(() => false);
     return true;
 };
 
 const touchTransfer = (transfer: any) => {
     clearTimeout(transfer.timer);
-    transfer.timer = setTimeout(() => dropTransfer(transfer.id), TRANSFER_TIMEOUT);
+    transfer.timer = setTimeout(() => void dropTransfer(transfer.id), TRANSFER_TIMEOUT);
 };
 
 const addTransfer = (transfer: any) => {
@@ -162,47 +159,78 @@ const addTransfer = (transfer: any) => {
         transfer.size < 0 ||
         (transfer.direction === 'upload' && transfer.size === 0) ||
         transfer.size > MAX_TRANSFER_BYTES ||
-        transfers.size >= MAX_TRANSFERS ||
-        reserved + transfer.size > MAX_TRANSFER_MEMORY
+        transfers.size >= MAX_TRANSFERS
     ) {
-        throw new Error('Transfer exceeds the configured size, concurrency, or memory limit.');
+        throw new Error('Transfer exceeds the configured size or concurrency limit.');
     }
     transfer.id = crypto.randomUUID();
     transfer.offset = 0;
     transfers.set(transfer.id, transfer);
-    reserved += transfer.size;
     touchTransfer(transfer);
     return transfer;
 };
 
-const downloadAsset = async (id: number) => {
+const openDownload = async (id: number) => {
     const asset = getAsset(id);
     const type = asset.get('type');
-    let blob;
     let filename = asset.get('file.filename') || asset.get('name');
     if (type === 'animstategraph') {
         filename = `${filename}.json`;
-        blob = new Blob([JSON.stringify(asset.get('data'), null, 4)], { type: 'application/json' });
-    } else {
-        const res = await fetch(`/api/assets/${id}/download?branchId=${config.self.branch.id}`);
-        if (!res.ok) {
-            throw new Error(`Failed to download asset: ${res.status} ${res.statusText}`);
-        }
-        const length = Number(res.headers.get('content-length'));
-        if (length > MAX_TRANSFER_BYTES) {
+        const file = new Blob([JSON.stringify(asset.get('data'), null, 4)], { type: 'application/json' });
+        if (file.size > MAX_TRANSFER_BYTES) {
             throw new Error(`Asset download exceeds the ${MAX_TRANSFER_BYTES / 1024 / 1024} MiB limit.`);
         }
-        blob = await res.blob();
+        return { id, filename, mime: file.type, size: file.size, stream: file.stream() };
     }
-    if (blob.size > MAX_TRANSFER_BYTES) {
+    const res = await fetch(`/api/assets/${id}/download?branchId=${config.self.branch.id}`);
+    if (!res.ok) {
+        await res.body?.cancel();
+        throw new Error(`Failed to download asset: ${res.status} ${res.statusText}`);
+    }
+    const header = res.headers.get('content-length');
+    const size = header === null ? Number(asset.get('file.size')) : Number(header);
+    if (!Number.isInteger(size) || size < 0) {
+        await res.body?.cancel();
+        throw new Error('Asset download size is unavailable.');
+    }
+    if (size > MAX_TRANSFER_BYTES) {
+        await res.body?.cancel();
         throw new Error(`Asset download exceeds the ${MAX_TRANSFER_BYTES / 1024 / 1024} MiB limit.`);
+    }
+    if (!res.body) {
+        throw new Error('Asset download body is unavailable.');
     }
     return {
         id,
         filename,
-        mime: blob.type || 'application/octet-stream',
-        bytes: new Uint8Array(await blob.arrayBuffer())
+        mime: res.headers.get('content-type') || 'application/octet-stream',
+        size,
+        stream: res.body
     };
+};
+
+const readDownload = async (transfer: any, length: number) => {
+    const size = Math.min(length, transfer.size - transfer.offset);
+    const bytes = new Uint8Array(size);
+    let offset = 0;
+    while (offset < size) {
+        let chunk = transfer.pending;
+        if (!chunk?.length) {
+            const result = await transfer.reader.read();
+            if (result.done) {
+                break;
+            }
+            chunk = result.value;
+        }
+        const count = Math.min(chunk.length, size - offset);
+        bytes.set(chunk.subarray(0, count), offset);
+        offset += count;
+        transfer.pending = count < chunk.length ? chunk.subarray(count) : null;
+    }
+    if (offset !== size) {
+        throw new Error(`Asset download ended at ${transfer.offset + offset} of ${transfer.size} bytes.`);
+    }
+    return bytes;
 };
 
 const prepareCreate = ({ type, options = {} }: any) => {
@@ -349,7 +377,11 @@ const modifyAssets = async (edits: any[]) => {
 
     const modified = new Map();
     const renamed = [];
-    for (const { asset, edit } of prepared.filter(({ edit, op }) => op === 'set' && edit.path === 'name')) {
+    for (let i = 0; i < prepared.length; i++) {
+        const { asset, edit, op } = prepared[i];
+        if (op !== 'set' || edit.path !== 'name') {
+            continue;
+        }
         const error = await new Promise((resolve) => editor.call('assets:rename', asset.observer, edit.value, resolve));
         if (error) {
             return {
@@ -364,7 +396,11 @@ const modifyAssets = async (edits: any[]) => {
         renamed.push({ id: edit.id, path: edit.path });
         modified.set(edit.id, asset);
     }
-    for (const { asset, edit, op, value } of prepared.filter(({ edit }) => edit.path !== 'name')) {
+    for (let i = 0; i < prepared.length; i++) {
+        const { asset, edit, op, value } = prepared[i];
+        if (edit.path === 'name') {
+            continue;
+        }
         if (op === 'set') {
             asset.set(edit.path, value);
         } else if (op === 'unset') {
@@ -474,16 +510,21 @@ driver.method('assets:upload', async (items) => {
         if (typeof item.base64 !== 'string' || item.base64.length > MAX_BASE64_LENGTH) {
             throw new Error(`Asset upload exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.`);
         }
-        const binary = atob(item.base64);
-        if (binary.length > MAX_FILE_BYTES) {
+        const bytes = base64ToBytes(item.base64);
+        if (bytes.length > MAX_FILE_BYTES) {
             throw new Error(`Asset upload exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.`);
         }
-        return { item, bytes: Uint8Array.from(binary, (char) => char.charCodeAt(0)) };
+        return { item, bytes };
     });
     const results = await Promise.all(
         prepared.map(({ item, bytes }, index) =>
             Promise.resolve()
-                .then(() => uploadBytes(item, bytes))
+                .then(() =>
+                    uploadFile(
+                        item,
+                        new File([bytes], item.filename, { type: item.mime || 'application/octet-stream' })
+                    )
+                )
                 .then(
                     (asset) => ({ result: { index, asset: assetSummary(asset) } }),
                     (error) => ({
@@ -514,8 +555,9 @@ driver.method('assets:move', async (ids, folderId) => {
     let finish: (error: string | null) => void;
     const events = assets.map((asset: any) => asset.on('path:set', check));
     const cleanup = () => {
-        clearTimeout(timer);
-        events.forEach((event: any) => event.unbind());
+        for (let i = 0; i < events.length; i++) {
+            events[i].unbind();
+        }
     };
     const complete = new Promise<string | null>((resolve) => {
         finish = (error) => {
@@ -528,7 +570,6 @@ driver.method('assets:move', async (ids, folderId) => {
             finish?.(null);
         }
     }
-    const timer = setTimeout(() => finish('Timed out waiting for moved assets to update.'), OPERATION_TIMEOUT);
     const error = editor.call(
         'assets:fs:move',
         assets.map((asset: any) => asset.observer),
@@ -577,7 +618,9 @@ driver.method('assets:reimport', async (ids, settings = {}) => {
     if (denied) {
         return denied;
     }
-    ids.forEach(getAsset);
+    for (let i = 0; i < ids.length; i++) {
+        getAsset(ids[i]);
+    }
     const results = await Promise.all(
         ids.map((id: number) => {
             const asset = getAsset(id);
@@ -702,17 +745,25 @@ driver.method('assets:file:text:get', async (id) => {
     }
 });
 driver.method('assets:file:get', async (id) => {
-    const data = await downloadAsset(id);
-    if (data.bytes.length > MAX_FILE_BYTES) {
+    const data = await openDownload(id);
+    if (data.size > MAX_FILE_BYTES) {
+        await data.stream.cancel();
         return { error: `Asset download exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB limit.` };
     }
-    return { data: { id, filename: data.filename, mime: data.mime, base64: bytesToBase64(data.bytes) } };
+    const bytes = new Uint8Array(await new Response(data.stream).arrayBuffer());
+    if (bytes.length !== data.size) {
+        throw new Error(`Asset download ended at ${bytes.length} of ${data.size} bytes.`);
+    }
+    return { data: { id, filename: data.filename, mime: data.mime, base64: bytesToBase64(bytes) } };
 });
 
-driver.method('files:upload:start', (item, size) => {
+driver.method('files:upload:start', async (item, size) => {
     const denied = writeError('upload assets');
     if (denied) {
         return denied;
+    }
+    if (transfers.size || pendingDownload) {
+        throw new Error('Finish or cancel the active file transfer before starting another.');
     }
     if (!item?.filename || !item?.type) {
         throw new Error('Upload transfer requires filename and type.');
@@ -723,11 +774,26 @@ driver.method('files:upload:start', (item, size) => {
     if (item.id !== undefined && getAsset(item.id).get('type') !== item.type) {
         throw new Error(`Asset ${item.id} does not match upload type ${item.type}.`);
     }
-    const transfer = addTransfer({ direction: 'upload', size, item, bytes: new Uint8Array(size) });
+    const transfer = addTransfer({ direction: 'upload', size, item });
+    const [error, data] = await navigator.storage
+        .getDirectory()
+        .then(async (root) => {
+            const file = await root.getFileHandle(transfer.id, { create: true });
+            return { root, file, writer: await file.createWritable() };
+        })
+        .then(
+            (value) => [null, value],
+            (value) => [value, null]
+        );
+    if (error) {
+        await dropTransfer(transfer.id);
+        throw error;
+    }
+    Object.assign(transfer, data);
     return { data: { transferId: transfer.id, size, chunkSize: MAX_CHUNK_BYTES } };
 });
 
-driver.method('files:upload:append', (id, offset, base64) => {
+driver.method('files:upload:append', async (id, offset, base64) => {
     const transfer = transfers.get(id);
     if (!transfer || transfer.direction !== 'upload') {
         throw new Error(`Upload transfer not found: ${id}.`);
@@ -739,12 +805,11 @@ driver.method('files:upload:append', (id, offset, base64) => {
     ) {
         throw new Error(`Invalid upload offset or chunk for transfer ${id}.`);
     }
-    const binary = atob(base64);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const bytes = base64ToBytes(base64);
     if (!bytes.length || bytes.length > MAX_CHUNK_BYTES || transfer.offset + bytes.length > transfer.size) {
         throw new Error(`Invalid upload chunk length for transfer ${id}.`);
     }
-    transfer.bytes.set(bytes, transfer.offset);
+    await transfer.writer.write(bytes);
     transfer.offset += bytes.length;
     touchTransfer(transfer);
     return { data: { transferId: id, offset: transfer.offset } };
@@ -757,12 +822,17 @@ driver.method('files:upload:finish', async (id) => {
     }
     clearTimeout(transfer.timer);
     transfer.direction = 'finishing';
-    touchTransfer(transfer);
-    const [error, asset] = await uploadBytes(transfer.item, transfer.bytes).then(
-        (value) => [null, value],
-        (value) => [value, null]
-    );
-    dropTransfer(id);
+    const [error, asset] = await Promise.resolve()
+        .then(async () => {
+            await transfer.writer.close();
+            transfer.writer = null;
+            return uploadFile(transfer.item, await transfer.file.getFile());
+        })
+        .then(
+            (value) => [null, value],
+            (value) => [value, null]
+        );
+    await dropTransfer(id);
     if (error) {
         throw error;
     }
@@ -774,37 +844,56 @@ driver.method('files:download:start', async (id, inlineLimit = 0) => {
         throw new Error('Finish or cancel the active file transfer before starting another.');
     }
     pendingDownload = true;
-    const [error, data] = await downloadAsset(id).then(
-        (value) => [null, value],
-        (value) => [value, null]
-    );
-    pendingDownload = false;
+    const [error, result] = await Promise.resolve()
+        .then(async () => {
+            const data = await openDownload(id);
+            if (data.size <= Math.min(inlineLimit, MAX_FILE_BYTES)) {
+                const bytes = new Uint8Array(await new Response(data.stream).arrayBuffer());
+                if (bytes.length !== data.size) {
+                    throw new Error(`Asset download ended at ${bytes.length} of ${data.size} bytes.`);
+                }
+                return {
+                    data: {
+                        size: data.size,
+                        filename: data.filename,
+                        mime: data.mime,
+                        base64: bytesToBase64(bytes)
+                    }
+                };
+            }
+            const transfer = addTransfer({
+                direction: 'download',
+                size: data.size,
+                reader: data.stream.getReader(),
+                pending: null
+            });
+            return {
+                data: {
+                    transferId: transfer.id,
+                    size: transfer.size,
+                    chunkSize: MAX_CHUNK_BYTES,
+                    filename: data.filename,
+                    mime: data.mime
+                }
+            };
+        })
+        .then(
+            (value) => {
+                pendingDownload = false;
+                return [null, value];
+            },
+            (value) => {
+                pendingDownload = false;
+                return [value, null];
+            }
+        );
     if (error) {
         throw error;
     }
-    if (data.bytes.length <= Math.min(inlineLimit, MAX_FILE_BYTES)) {
-        return {
-            data: {
-                size: data.bytes.length,
-                filename: data.filename,
-                mime: data.mime,
-                base64: bytesToBase64(data.bytes)
-            }
-        };
-    }
-    const transfer = addTransfer({ direction: 'download', size: data.bytes.length, data });
-    return {
-        data: {
-            transferId: transfer.id,
-            size: transfer.size,
-            chunkSize: MAX_CHUNK_BYTES,
-            filename: data.filename,
-            mime: data.mime
-        }
-    };
+    return result;
 });
 
-driver.method('files:download:read', (id, offset, length = MAX_CHUNK_BYTES) => {
+driver.method('files:download:read', async (id, offset, length = MAX_CHUNK_BYTES) => {
     const transfer = transfers.get(id);
     if (!transfer || transfer.direction !== 'download') {
         throw new Error(`Download transfer not found: ${id}.`);
@@ -812,7 +901,7 @@ driver.method('files:download:read', (id, offset, length = MAX_CHUNK_BYTES) => {
     if (offset !== transfer.offset || !Number.isInteger(length) || length <= 0 || length > MAX_CHUNK_BYTES) {
         throw new Error(`Invalid download offset or chunk length for transfer ${id}.`);
     }
-    const bytes = transfer.data.bytes.subarray(offset, Math.min(offset + length, transfer.size));
+    const bytes = await readDownload(transfer, length);
     transfer.offset += bytes.length;
     touchTransfer(transfer);
     return {
@@ -825,23 +914,24 @@ driver.method('files:download:read', (id, offset, length = MAX_CHUNK_BYTES) => {
     };
 });
 
-driver.method('files:transfer:finish', (id) => {
+driver.method('files:transfer:finish', async (id) => {
     const transfer = transfers.get(id);
     if (!transfer || transfer.offset !== transfer.size) {
         throw new Error(`Incomplete transfer: ${id}.`);
     }
-    dropTransfer(id);
+    await dropTransfer(id);
     return { data: { transferId: id, size: transfer.size } };
 });
 
-driver.method('files:transfer:cancel', (id) => ({
-    data: {
-        transferId: id,
-        cancelled: transfers.get(id)?.direction === 'finishing' ? false : dropTransfer(id)
+driver.method('files:transfer:cancel', async (id) => {
+    const cancelled = transfers.get(id)?.direction === 'finishing' ? false : await dropTransfer(id);
+    return { data: { transferId: id, cancelled } };
+});
+driver.method('files:transfer:clear', async () => {
+    const ids = [...transfers.keys()];
+    for (let i = 0; i < ids.length; i++) {
+        await dropTransfer(ids[i]);
     }
-}));
-driver.method('files:transfer:clear', () => {
-    [...transfers.keys()].forEach(dropTransfer);
     return { data: { cleared: true } };
 });
 driver.method('templates:apply', async ({ entityId, overrides }: any) => {

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -253,9 +253,7 @@ const modifyAssets = async (edits: any[]) => {
                 `Invalid asset path: ${edit.path}. Use name, tags, preload, exclude, i18n.*, data.*, meta.compress.*, or meta.invert.`
             );
         }
-        const resolved = root === 'data'
-            ? api.schema.assets.resolvePath(asset.get('type'), edit.path.slice(5))
-            : null;
+        const resolved = root === 'data' ? api.schema.assets.resolvePath(asset.get('type'), edit.path.slice(5)) : null;
         if (root === 'data' && !resolved) {
             throw new Error(`Unknown ${asset.get('type')} asset path: ${edit.path}.`);
         }
@@ -551,17 +549,16 @@ driver.method('assets:duplicate', (ids) => {
     }
     const assets = ids.map(getAsset);
     return Promise.all(
-        assets.map(
-            (asset: any) =>
-                new Promise<number>((resolve, reject) => {
-                    api.rest.assets
-                        .assetDuplicate(String(asset.get('id')), {
-                            type: asset.get('type'),
-                            branchId: config.self.branch.id
-                        })
-                        .on('load', (_status: number, result: { id: number }) => resolve(result.id))
-                        .on('error', (_status: number, error: unknown) => reject(error));
-                }).then(waitForAsset)
+        assets.map((asset: any) =>
+            new Promise<number>((resolve, reject) => {
+                api.rest.assets
+                    .assetDuplicate(String(asset.get('id')), {
+                        type: asset.get('type'),
+                        branchId: config.self.branch.id
+                    })
+                    .on('load', (_status: number, result: { id: number }) => resolve(result.id))
+                    .on('error', (_status: number, error: unknown) => reject(error));
+            }).then(waitForAsset)
         )
     ).then((created) => ({ data: created.map(assetSummary) }));
 });
@@ -581,15 +578,20 @@ driver.method('assets:reimport', async (ids, settings = {}) => {
         return denied;
     }
     ids.forEach(getAsset);
-    const results = await Promise.all(ids.map((id: number) => {
-        const asset = getAsset(id);
-        return new Promise((resolve) => {
-            editor.call('assets:reimport', id, asset.get('type'), settings, (error: unknown, result: unknown) =>
-                resolve(error
-                    ? { error: { id, message: error instanceof Error ? error.message : String(error) } }
-                    : { result: { id, result } }));
-        });
-    }));
+    const results = await Promise.all(
+        ids.map((id: number) => {
+            const asset = getAsset(id);
+            return new Promise((resolve) => {
+                editor.call('assets:reimport', id, asset.get('type'), settings, (error: unknown, result: unknown) =>
+                    resolve(
+                        error
+                            ? { error: { id, message: error instanceof Error ? error.message : String(error) } }
+                            : { result: { id, result } }
+                    )
+                );
+            });
+        })
+    );
     const succeeded = results.flatMap((item: any) => (item.result ? [item.result] : []));
     const failed = results.flatMap((item: any) => (item.error ? [item.error] : []));
     return { data: { succeeded, failed }, meta: { partial: failed.length > 0 } };
@@ -730,7 +732,11 @@ driver.method('files:upload:append', (id, offset, base64) => {
     if (!transfer || transfer.direction !== 'upload') {
         throw new Error(`Upload transfer not found: ${id}.`);
     }
-    if (offset !== transfer.offset || typeof base64 !== 'string' || base64.length > Math.ceil(MAX_CHUNK_BYTES / 3) * 4) {
+    if (
+        offset !== transfer.offset ||
+        typeof base64 !== 'string' ||
+        base64.length > Math.ceil(MAX_CHUNK_BYTES / 3) * 4
+    ) {
         throw new Error(`Invalid upload offset or chunk for transfer ${id}.`);
     }
     const binary = atob(base64);

--- a/src/editor/driver/asset.ts
+++ b/src/editor/driver/asset.ts
@@ -8,6 +8,7 @@ const MAX_FILE_BYTES = 20 * 1024 * 1024;
 const MAX_BASE64_LENGTH = Math.ceil(MAX_FILE_BYTES / 3) * 4;
 const OPERATION_TIMEOUT = 30_000;
 const TEXT_TYPES = ['css', 'html', 'json', 'script', 'shader', 'text'];
+let uploadId = 0;
 const MIME_TYPES: Record<string, string> = {
     css: 'text/css',
     html: 'text/html',
@@ -63,6 +64,15 @@ const uploadAsset = (data: any, overrides: any = {}) => {
     const pipeline = settings.get('editor.pipeline') || {};
     const options = { ...pipeline, pow2: pipeline.texturePot, ...overrides };
     return new Promise<any>((resolve, reject) => {
+        const job = --uploadId;
+        const finish = (asset: any) => {
+            api.assets.defaultUploadCompletedCallback?.(job, asset);
+            resolve(asset);
+        };
+        const fail = (error: unknown) => {
+            api.assets.defaultUploadErrorCallback?.(job, error instanceof Error ? error : new Error(String(error)));
+            reject(error);
+        };
         const payload = {
             ...data,
             parent: data.folder?.observer,
@@ -71,24 +81,26 @@ const uploadAsset = (data: any, overrides: any = {}) => {
         const request = data.id
             ? api.rest.assets.assetUpdate(String(data.id), payload, options)
             : api.rest.assets.assetCreate(payload, options);
+        api.assets.defaultUploadProgressCallback?.(job, 0);
         request
             .on('load', (_status: number, result: { id: number }) => {
                 const id = data.id || result.id;
                 const asset = api.assets.get(id);
                 if (asset) {
-                    resolve(asset);
+                    finish(asset);
                     return;
                 }
                 const timer = setTimeout(() => {
                     event.unbind();
-                    reject(new Error(`Timed out waiting for uploaded asset ${id}.`));
+                    fail(new Error(`Timed out waiting for uploaded asset ${id}.`));
                 }, OPERATION_TIMEOUT);
                 const event = api.assets.once(`add[${id}]`, (value: any) => {
                     clearTimeout(timer);
-                    resolve(value);
+                    finish(value);
                 });
             })
-            .on('error', (_status: number, error: unknown) => reject(error));
+            .on('progress', (progress: number) => api.assets.defaultUploadProgressCallback?.(job, progress))
+            .on('error', (_status: number, error: unknown) => fail(error));
     });
 };
 

--- a/src/editor/driver/build.ts
+++ b/src/editor/driver/build.ts
@@ -140,7 +140,7 @@ driver.method('builds:primary:set', async (id) => {
     }
     const result: any = await driver.invoke('builds:get', id);
     const build = result?.data;
-    if (!build || build.type !== 'publish' || build.task?.status !== 'complete' || !build.app_id) {
+    if (!build || build.type !== 'publish' || build.status !== 'complete' || !build.app_id) {
         return { error: `Completed publish build not found: ${id}.` };
     }
     const error = await new Promise<unknown>((resolve) =>

--- a/src/editor/driver/build.ts
+++ b/src/editor/driver/build.ts
@@ -144,7 +144,8 @@ driver.method('builds:primary:set', async (id) => {
         return { error: `Completed publish build not found: ${id}.` };
     }
     const error = await new Promise<unknown>((resolve) =>
-        editor.call('projects:setPrimaryApp', String(build.app_id), () => resolve(null), resolve));
+        editor.call('projects:setPrimaryApp', String(build.app_id), () => resolve(null), resolve)
+    );
     if (error) {
         return { error: String(error) };
     }

--- a/src/editor/driver/build.ts
+++ b/src/editor/driver/build.ts
@@ -15,6 +15,7 @@ type Options = {
     description?: string;
     version?: string;
     releaseNotes?: string;
+    imageS3Key?: string;
     concatenate?: boolean;
     minify?: boolean;
     sourceMaps?: boolean;
@@ -45,6 +46,9 @@ const payload = async (options: Options, format = 'playcanvas') => {
         ids.splice(ids.indexOf(primary), 1);
         ids.unshift(primary);
     }
+    if (options.sourceMaps && (!options.concatenate || !options.minify)) {
+        throw new Error('Source maps require concatenate and minify.');
+    }
     const key = options.engineVersion || editor.call('settings:session').get('engineVersion');
     const engine = config.engineVersions[key as keyof typeof config.engineVersions]?.version || key;
     const versions = Object.values(config.engineVersions).map((item) => item?.version);
@@ -60,9 +64,10 @@ const payload = async (options: Options, format = 'playcanvas') => {
         ...(options.description ? { description: options.description } : {}),
         ...(options.version ? { version: options.version } : {}),
         ...(options.releaseNotes ? { release_notes: options.releaseNotes } : {}),
+        ...(options.imageS3Key ? { image_s3_key: options.imageS3Key } : {}),
         scripts_concatenate: !npm && !!options.concatenate,
         scripts_minify: !npm && !!options.minify,
-        scripts_sourcemaps: !npm && !!options.minify && !!options.sourceMaps,
+        scripts_sourcemaps: !npm && !!options.concatenate && !!options.minify && !!options.sourceMaps,
         optimize_scene_format: !npm && !!options.optimizeSceneFormat,
         engine_version: engine,
         format
@@ -127,4 +132,21 @@ driver.method('builds:delete', async (id) => {
     const data = await api.rest.projects.projectBuildDelete(Number(id)).promisify();
     log(`Deleted build(${id})`);
     return { data };
+});
+
+driver.method('builds:primary:set', async (id) => {
+    if (!editor.call('permissions:write')) {
+        return { error: 'Write permission is required to set the primary build.' };
+    }
+    const result: any = await driver.invoke('builds:get', id);
+    const build = result?.data;
+    if (!build || build.type !== 'publish' || build.task?.status !== 'complete' || !build.app_id) {
+        return { error: `Completed publish build not found: ${id}.` };
+    }
+    const error = await new Promise<unknown>((resolve) =>
+        editor.call('projects:setPrimaryApp', String(build.app_id), () => resolve(null), resolve));
+    if (error) {
+        return { error: String(error) };
+    }
+    return { data: { buildId: Number(id), appId: Number(build.app_id) } };
 });

--- a/src/editor/driver/editor.ts
+++ b/src/editor/driver/editor.ts
@@ -40,6 +40,7 @@ driver.method('history:redo', () => {
     log(redone ? 'Redo' : 'Redo (nothing to redo)');
     return { data: { redone, canUndo: api.history.canUndo, canRedo: api.history.canRedo } };
 });
+driver.method('editor:logs', (options: any = {}) => editor.call('console:query', options));
 
 // transform gizmo
 driver.method('gizmo:state:set', (state) => {

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -1,5 +1,5 @@
 import { driver } from './driver';
-import { api, log, entitySummary, paginate, writeError } from './shared';
+import { api, log, entitySummary, paginate, validatePath, writeError } from './shared';
 
 const ENTITY_TOP_LEVEL_PATHS = ['name', 'enabled', 'position', 'rotation', 'scale', 'tags'];
 
@@ -9,6 +9,7 @@ const validateEntityPath = (entity: any, path: string) => {
     if (typeof path !== 'string' || !path.length) {
         return `Missing path. Valid top-level paths: ${ENTITY_TOP_LEVEL_PATHS.join(', ')}; or component paths like components.<type>.<prop>. This entity has components: [${componentList}].`;
     }
+    validatePath(path);
     if (path.startsWith('components.')) {
         const parts = path.split('.');
         const component = parts[1];
@@ -195,20 +196,23 @@ driver.method('entities:modify', (edits) => {
     api.history.add({
         name: 'modify entities',
         combine: false,
-        undo: () =>
-            prepared
-                .slice()
-                .reverse()
-                .forEach(({ entity, path, previous, exists }) => write({ entity, path, value: previous, exists })),
-        redo: () =>
-            prepared.forEach(({ entity, path, value, op }) =>
+        undo: () => {
+            for (let i = prepared.length - 1; i >= 0; i--) {
+                const { entity, path, previous, exists } = prepared[i];
+                write({ entity, path, value: previous, exists });
+            }
+        },
+        redo: () => {
+            for (let i = 0; i < prepared.length; i++) {
+                const { entity, path, value, op } = prepared[i];
                 write({
                     entity,
                     path,
                     value,
                     exists: op === 'set'
-                })
-            )
+                });
+            }
+        }
     });
 
     // return the post-edit summaries of every touched entity
@@ -318,11 +322,14 @@ driver.method('entities:components:add', (id, components) => {
     if (existing.length) {
         return { error: `Entity ${id} already has components: ${existing.join(', ')}.` };
     }
-    Object.keys(components).forEach((component) => api.schema.components.getDefaultData(component));
-    Object.entries(components).forEach(([name, data]) => {
-        entity.addComponent(name, data);
-    });
-    log(`Added components(${Object.keys(components).join(', ')}) to entity(${id})`);
+    const names = Object.keys(components);
+    for (let i = 0; i < names.length; i++) {
+        api.schema.components.getDefaultData(names[i]);
+    }
+    for (let i = 0; i < names.length; i++) {
+        entity.addComponent(names[i], components[names[i]]);
+    }
+    log(`Added components(${names.join(', ')}) to entity(${id})`);
     return { data: entitySummary(entity) };
 });
 driver.method('entities:components:remove', (id, components) => {
@@ -340,9 +347,9 @@ driver.method('entities:components:remove', (id, components) => {
     if (missing.length) {
         return { error: `Entity ${id} does not have components: ${missing.join(', ')}.` };
     }
-    components.forEach((component: string) => {
-        entity.removeComponent(component);
-    });
+    for (let i = 0; i < components.length; i++) {
+        entity.removeComponent(components[i]);
+    }
     log(`Removed components(${components.join(', ')}) from entity(${id})`);
     return { data: entitySummary(entity) };
 });

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -22,8 +22,9 @@ const validateEntityPath = (entity: any, path: string) => {
         return `Missing path. Valid top-level paths: ${ENTITY_TOP_LEVEL_PATHS.join(', ')}; or component paths like components.<type>.<prop>. This entity has components: [${componentList}].`;
     }
     if (path.startsWith('components.')) {
-        const component = path.split('.')[1];
-        if (!component) {
+        const parts = path.split('.');
+        const component = parts[1];
+        if (!component || parts.length < 3) {
             return `Incomplete path '${path}'. Component paths look like components.<type>.<prop>, e.g. components.light.intensity. This entity has components: [${componentList}].`;
         }
         if (!entity.get(`components.${component}`)) {
@@ -142,7 +143,8 @@ driver.method('entities:modify', (edits) => {
     if (denied) {
         return denied;
     }
-    const prepared = edits.map(({ id, path, value }: any) => {
+    const prepared = edits.map((edit: any) => {
+        const { id, path, value } = edit;
         const entity = api.entities.get(id);
         if (!entity) {
             throw new Error(`Entity not found: ${id}. Call list_entities to obtain a valid resource_id.`);
@@ -151,7 +153,25 @@ driver.method('entities:modify', (edits) => {
         if (error) {
             throw new Error(error);
         }
-        return { entity, id, path, value, exists: entity.has(path), previous: structuredClone(entity.get(path)) };
+        const op = edit.op || 'set';
+        if (op !== 'set' && op !== 'unset') {
+            throw new Error(`Invalid entity operation: ${op}.`);
+        }
+        if (op === 'set' && !Object.hasOwn(edit, 'value')) {
+            throw new Error(`Missing value for entity ${id} path ${path}.`);
+        }
+        if (op === 'unset' && !path.startsWith('components.')) {
+            throw new Error('Only component properties can be unset; set top-level entity properties explicitly.');
+        }
+        return {
+            entity,
+            id,
+            path,
+            value,
+            op,
+            exists: entity.has(path),
+            previous: structuredClone(entity.get(path))
+        };
     });
     const write = ({ entity, path, value, exists }: any) => {
         const target = entity.latest ? entity.latest() : entity;
@@ -169,10 +189,12 @@ driver.method('entities:modify', (edits) => {
     };
     const modified = new Map();
     for (const item of prepared) {
-        const { entity, id, path, value } = item;
-        write({ entity, path, value, exists: true });
+        const { entity, id, path, value, op } = item;
+        write({ entity, path, value, exists: op === 'set' });
         modified.set(id, entity);
-        log(`Set property(${path}) of entity(${id}) to: ${JSON.stringify(value)}`);
+        log(
+            `${op === 'set' ? 'Set' : 'Unset'} property(${path}) of entity(${id})${op === 'set' ? ` to: ${JSON.stringify(value)}` : ''}`
+        );
     }
     api.history.add({
         name: 'modify entities',
@@ -182,7 +204,15 @@ driver.method('entities:modify', (edits) => {
                 .slice()
                 .reverse()
                 .forEach(({ entity, path, previous, exists }) => write({ entity, path, value: previous, exists })),
-        redo: () => prepared.forEach(({ entity, path, value }) => write({ entity, path, value, exists: true }))
+        redo: () =>
+            prepared.forEach(({ entity, path, value, op }) =>
+                write({
+                    entity,
+                    path,
+                    value,
+                    exists: op === 'set'
+                })
+            )
     });
 
     // return the post-edit summaries of every touched entity

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -1,20 +1,8 @@
 import { driver } from './driver';
 import { api, log, entitySummary, paginate, writeError } from './shared';
 
-// top-level entity properties that entities:modify may set directly. Anything
-// else must be addressed under `components.<type>.…` (or is not settable).
 const ENTITY_TOP_LEVEL_PATHS = ['name', 'enabled', 'position', 'rotation', 'scale', 'tags'];
 
-/**
- * Validate an entities:modify path against an entity BEFORE writing, so an invalid path
- * fails fast with an actionable message instead of silently "succeeding". Only rejects
- * paths that are provably wrong (unknown top-level key, or a component path for a
- * component the entity does not have) — valid edits are never blocked.
- *
- * @param entity - The entity API instance.
- * @param path - The dot-notation path the caller wants to set.
- * @returns An actionable error string if the path is invalid, otherwise null.
- */
 const validateEntityPath = (entity: any, path: string) => {
     const components = Object.keys(entity.get('components') || {});
     const componentList = components.length ? components.join(', ') : 'none';
@@ -30,10 +18,10 @@ const validateEntityPath = (entity: any, path: string) => {
         if (!entity.get(`components.${component}`)) {
             return `Entity ${entity.get('resource_id')} (${entity.get('name')}) has no '${component}' component, so '${path}' cannot be set. This entity has components: [${componentList}]. Add it first with add_components, or target an existing component.`;
         }
-        return null;
+        const resolved = api.schema.components.resolvePath(component, parts.slice(2).join('.'));
+        return resolved ? null : `Unknown component path '${path}'.`;
     }
-    const top = path.split('.')[0];
-    if (!ENTITY_TOP_LEVEL_PATHS.includes(top)) {
+    if (!ENTITY_TOP_LEVEL_PATHS.includes(path)) {
         return `Unknown path '${path}'. Valid top-level paths: ${ENTITY_TOP_LEVEL_PATHS.join(', ')} (vectors are arrays e.g. position [0,1,0], euler rotation in degrees). For component properties use components.<type>.<prop>; this entity has components: [${componentList}].`;
     }
     return null;
@@ -144,7 +132,7 @@ driver.method('entities:modify', (edits) => {
         return denied;
     }
     const prepared = edits.map((edit: any) => {
-        const { id, path, value } = edit;
+        const { id, path } = edit;
         const entity = api.entities.get(id);
         if (!entity) {
             throw new Error(`Entity not found: ${id}. Call list_entities to obtain a valid resource_id.`);
@@ -163,12 +151,20 @@ driver.method('entities:modify', (edits) => {
         if (op === 'unset' && !path.startsWith('components.')) {
             throw new Error('Only component properties can be unset; set top-level entity properties explicitly.');
         }
+        const resolved = path.startsWith('components.')
+            ? api.schema.components.resolvePath(path.split('.')[1], path.split('.').slice(2).join('.'))
+            : null;
+        if (op === 'unset' && !resolved?.hasDefault && !resolved?.open) {
+            throw new Error(`Component path ${path} cannot be unset.`);
+        }
+        const nextOp = op === 'unset' && resolved?.hasDefault ? 'set' : op;
+        const value = nextOp === 'set' && op === 'unset' ? resolved.default : edit.value;
         return {
             entity,
             id,
             path,
             value,
-            op,
+            op: nextOp,
             exists: entity.has(path),
             previous: structuredClone(entity.get(path))
         };
@@ -223,12 +219,7 @@ driver.method('entities:duplicate', async (ids, options: any = {}) => {
     if (denied) {
         return denied;
     }
-    const entities = ids.map((id: string) => api.entities.get(id)).filter(Boolean);
-    if (!entities.length) {
-        return {
-            error: 'No valid entities to duplicate. Call list_entities (or resolve_entities) to obtain valid resource_ids.'
-        };
-    }
+    const entities = getEntities(ids);
     const res = await api.entities.duplicate(entities, options);
     log(`Duplicated entities: ${res.map((entity: any) => entity.get('resource_id')).join(', ')}`);
     return { data: res.map(entitySummary) };
@@ -261,13 +252,9 @@ driver.method('entities:delete', async (ids) => {
     if (denied) {
         return denied;
     }
-    const entities = ids
-        .map((id: string) => api.entities.get(id))
-        .filter((entity: any) => entity && entity !== api.entities.root);
-    if (!entities.length) {
-        return {
-            error: 'No deletable entities found (the root entity cannot be deleted). Call list_entities to obtain valid, non-root resource_ids.'
-        };
+    const entities = getEntities(ids);
+    if (entities.includes(api.entities.root)) {
+        throw new Error('The root entity cannot be deleted.');
     }
     await api.entities.delete(entities);
     log(`Deleted entities: ${ids.join(', ')}`);
@@ -315,6 +302,7 @@ driver.method('entities:list', (options: any = {}) => {
     // summary mode: compact, semantic data
     return { data: page.map(entitySummary), meta };
 });
+driver.method('entities:get', (id) => ({ data: getEntities([id])[0].json() }));
 driver.method('entities:components:add', (id, components) => {
     const denied = writeError('add entity components');
     if (denied) {
@@ -330,6 +318,7 @@ driver.method('entities:components:add', (id, components) => {
     if (existing.length) {
         return { error: `Entity ${id} already has components: ${existing.join(', ')}.` };
     }
+    Object.keys(components).forEach((component) => api.schema.components.getDefaultData(component));
     Object.entries(components).forEach(([name, data]) => {
         entity.addComponent(name, data);
     });

--- a/src/editor/driver/processing.ts
+++ b/src/editor/driver/processing.ts
@@ -1,3 +1,4 @@
+import { TextureCompressor } from '@/editor/assets/assets-textures-compress';
 import type { Asset } from '@/editor-api';
 
 import { driver } from './driver';
@@ -11,6 +12,8 @@ type SpriteProps = {
     textureAtlasAsset?: number;
     frames?: Record<string, Frame>;
 };
+const OPERATION_TIMEOUT = 60_000;
+const VARIANTS = ['basis', 'dxt', 'etc1', 'etc2', 'pvr'];
 
 const summary = (asset: Asset) => ({
     id: asset.get('id'),
@@ -32,6 +35,56 @@ const setData = (id: number, data: Record<string, unknown>) => {
 const writable = () =>
     editor.call('permissions:write') || { error: 'Write permission is required for asset processing.' };
 
+const bounded = (name: string, start: (done: (error?: unknown, data?: any) => void) => void, cancel?: () => void) =>
+    new Promise<any[]>((resolve) => {
+        let active = true;
+        const finish = (error?: unknown, data?: any) => {
+            if (!active) {
+                return;
+            }
+            active = false;
+            clearTimeout(timer);
+            resolve([error, data]);
+        };
+        const timer = setTimeout(() => {
+            cancel?.();
+            finish(new Error(`Timed out waiting for ${name}.`));
+        }, OPERATION_TIMEOUT);
+        Promise.resolve().then(() => start(finish)).catch(finish);
+    });
+
+const waitAsset = async (id: number, name: string) => {
+    const current = api.assets.get(id);
+    if (current) {
+        return [null, current];
+    }
+    let event: any;
+    return bounded(name, (done) => {
+        event = api.assets.once(`add[${id}]`, (asset: Asset) => {
+            event.unbind();
+            done(null, asset);
+        });
+    }, () => event?.unbind());
+};
+
+const waitTask = (asset: any, name: string, start: () => void) =>
+    new Promise<any[]>((resolve) => {
+        let running = asset.get('task') !== null;
+        const finish = (error?: unknown) => {
+            clearTimeout(timer);
+            event.unbind();
+            resolve([error]);
+        };
+        const event = asset.on('task:set', (value: unknown) => {
+            running ||= value !== null;
+            if (running && value === null) {
+                finish();
+            }
+        });
+        const timer = setTimeout(() => finish(new Error(`Timed out waiting for ${name}.`)), OPERATION_TIMEOUT);
+        Promise.resolve().then(start).catch(finish);
+    });
+
 driver.method('lightmapper:bake', async (ids?: string[]) => {
     const permission = writable();
     if (permission !== true) {
@@ -45,15 +98,23 @@ driver.method('lightmapper:bake', async (ids?: string[]) => {
     const missing = targets
         .map((entity) => entity.get('components.model.asset'))
         .filter((id) => id && !api.assets.get(id)?.has('meta.attributes.texCoord1'));
-    const baked = new Promise<void>((resolve) => editor.once('lightmapper:baked', resolve));
-    editor.call('lightmapper:bake', targets);
-    await baked;
+    let event: any;
+    const [error] = await bounded('lightmap bake', (done) => {
+        event = editor.once('lightmapper:baked', () => {
+            event.unbind();
+            done();
+        });
+        editor.call('lightmapper:bake', targets);
+    }, () => event?.unbind());
+    if (error) {
+        return { error: error.message };
+    }
     editor.call('entities:shadows:update');
     log('Baked lightmaps');
     return { data: { baked: targets.length, missingUv1: [...new Set(missing)] } };
 });
 
-driver.method('assets:model:unwrap', (id, options: { padding?: number } = {}) => {
+driver.method('assets:model:unwrap', async (id, options: { padding?: number } = {}) => {
     const permission = writable();
     if (permission !== true) {
         return permission;
@@ -62,11 +123,12 @@ driver.method('assets:model:unwrap', (id, options: { padding?: number } = {}) =>
     if (!asset || asset.get('type') !== 'model' || !asset.has('file.filename')) {
         return { error: `Model asset not found or has no source file: ${id}.` };
     }
-    return new Promise((resolve) => {
-        editor.call('assets:model:unwrap', asset, options, (err, result) => {
-            resolve(err ? { error: String(err) } : { data: summary(result || asset) });
-        });
-    });
+    const [error, result] = await bounded(
+        'model unwrap',
+        (done) => editor.call('assets:model:unwrap', asset, options, done),
+        () => editor.call('assets:model:unwrap:cancel', asset)
+    );
+    return error ? { error: String(error) } : { data: summary(result || asset) };
 });
 
 driver.method('assets:model:unwrap:cancel', (id) => {
@@ -79,7 +141,7 @@ driver.method('assets:model:unwrap:cancel', (id) => {
         : { error: `Model asset ${id} is not being unwrapped.` };
 });
 
-driver.method('assets:texture:convert', (id, format) => {
+driver.method('assets:texture:convert', async (id, format) => {
     const permission = writable();
     if (permission !== true) {
         return permission;
@@ -91,15 +153,17 @@ driver.method('assets:texture:convert', (id, format) => {
     if (!['avif', 'jpeg', 'png', 'webp'].includes(format)) {
         return { error: `Unsupported texture format: ${format}.` };
     }
-    return new Promise((resolve) => {
-        editor.call('assets:texture:convert', id, format, (err, data) => {
-            const result = data?.asset ? api.assets.get(data.asset.id) : data?.id ? api.assets.get(data.id) : null;
-            resolve(err ? { error: String(err) } : { data: result ? summary(result) : data || null });
-        });
-    });
+    const [error, data] = await bounded('texture conversion', (done) =>
+        editor.call('assets:texture:convert', id, format, done));
+    if (error) {
+        return { error: String(error) };
+    }
+    const createdId = data?.asset?.id || data?.id;
+    const [settleError, result] = createdId ? await waitAsset(createdId, 'converted texture settlement') : [null, null];
+    return settleError ? { error: String(settleError) } : { data: result ? summary(result) : data || null };
 });
 
-driver.method('assets:texture:toAtlas', (id) => {
+driver.method('assets:texture:toAtlas', async (id) => {
     const permission = writable();
     if (permission !== true) {
         return permission;
@@ -108,15 +172,16 @@ driver.method('assets:texture:toAtlas', (id) => {
     if (!asset || asset.get('type') !== 'texture' || asset.get('source')) {
         return { error: `Editable texture asset not found: ${id}.` };
     }
-    return new Promise((resolve) => {
-        editor.call('assets:textureToAtlas', asset, (err, atlasId) => {
-            const atlas = atlasId ? api.assets.get(atlasId) : null;
-            resolve(err ? { error: String(err) } : { data: atlas ? summary(atlas) : { id: atlasId } });
-        });
-    });
+    const [error, atlasId] = await bounded('texture atlas creation', (done) =>
+        editor.call('assets:textureToAtlas', asset, done));
+    if (error) {
+        return { error: String(error) };
+    }
+    const [settleError, atlas] = await waitAsset(atlasId, 'texture atlas settlement');
+    return settleError ? { error: String(settleError) } : { data: summary(atlas) };
 });
 
-driver.method('assets:texture:toCubemap', (id) => {
+driver.method('assets:texture:toCubemap', async (id) => {
     const permission = writable();
     if (permission !== true) {
         return permission;
@@ -125,11 +190,144 @@ driver.method('assets:texture:toCubemap', (id) => {
     if (!asset || asset.get('type') !== 'texture' || asset.get('source')) {
         return { error: `Editable texture asset not found: ${id}.` };
     }
-    return new Promise((resolve) => {
-        editor.call('assets:textureToCubemap', asset, (err, cubemap) => {
-            resolve(err ? { error: String(err) } : { data: summary(cubemap) });
+    const [error, cubemap] = await bounded('cubemap creation', (done) =>
+        editor.call('assets:textureToCubemap', asset, done));
+    return error ? { error: String(error) } : { data: summary(cubemap) };
+});
+
+driver.method('assets:font:process', async (id, options: { characters: string; invert?: boolean }) => {
+    const permission = writable();
+    if (permission !== true) {
+        return permission;
+    }
+    const asset = api.assets.get(id);
+    const source = asset && api.assets.get(asset.get('source_asset_id'));
+    if (!asset || asset.get('type') !== 'font' || !source) {
+        return { error: `Font asset or source not found: ${id}.` };
+    }
+    const characters = [...new Set(Array.from(options.characters || ''))].join('');
+    asset.set('meta.chars', characters);
+    if (options.invert !== undefined) {
+        asset.set('meta.invert', options.invert);
+    }
+    const [error] = await waitTask(asset, 'font processing', () =>
+        editor.call('realtime:send', 'pipeline', {
+            name: 'convert',
+            data: {
+                source: Number(source.get('uniqueId')),
+                target: Number(asset.get('uniqueId')),
+                chars: characters,
+                invert: !!asset.get('meta.invert')
+            }
+        }));
+    return error ? { error: error.message } : { data: summary(asset) };
+});
+
+driver.method('assets:texture:metadata', async (id) => {
+    const permission = writable();
+    if (permission !== true) {
+        return permission;
+    }
+    const asset = api.assets.get(id);
+    if (!asset || asset.get('type') !== 'texture') {
+        return { error: `Texture asset not found: ${id}.` };
+    }
+    if (asset.get('meta')) {
+        return { data: summary(asset) };
+    }
+    let event: any;
+    const [error] = await bounded('texture metadata', (done) => {
+        event = asset.once('meta:set', () => {
+            event.unbind();
+            done();
         });
-    });
+        editor.call('realtime:send', 'pipeline', { name: 'meta', id: asset.get('uniqueId') });
+    }, () => event?.unbind());
+    return error ? { error: error.message } : { data: summary(asset) };
+});
+
+driver.method(
+    'assets:texture:variants',
+    async (id, options: { formats: string[]; remove?: boolean; force?: boolean }) => {
+        const permission = writable();
+        if (permission !== true) {
+            return permission;
+        }
+        const asset = api.assets.get(id);
+        if (!asset || asset.get('type') !== 'texture' || !asset.get('file')) {
+            return { error: `Texture asset not found or has no file: ${id}.` };
+        }
+        const formats = [...new Set(options.formats || [])];
+        const invalid = formats.filter((format) => !VARIANTS.includes(format));
+        if (!formats.length || invalid.length) {
+            return { error: `Texture formats must be one or more of: ${VARIANTS.join(', ')}.` };
+        }
+        formats.forEach((format) => asset.set(`meta.compress.${format}`, !options.remove));
+        const [error] = await waitTask(asset, 'texture variant processing', () =>
+            TextureCompressor.compress([asset.observer], formats, !!options.force));
+        return error
+            ? { error: error.message }
+            : { data: { ...summary(asset), variants: asset.get('file.variants') || {} } };
+    }
+);
+
+driver.method('assets:cubemap:prefilter', async (id, legacy = false) => {
+    const permission = writable();
+    if (permission !== true) {
+        return permission;
+    }
+    const asset = api.assets.get(id);
+    if (!asset || asset.get('type') !== 'cubemap') {
+        return { error: `Cubemap asset not found: ${id}.` };
+    }
+    const [error] = await bounded('cubemap prefiltering', (done) =>
+        editor.call('assets:cubemaps:prefilter', asset.observer, legacy, done));
+    if (error) {
+        return { error: String(error) };
+    }
+    if (!asset.get('file')) {
+        let event: any;
+        const [settleError] = await bounded('cubemap prefilter settlement', (done) => {
+            event = asset.on('file:set', (file: unknown) => {
+                if (file) {
+                    event.unbind();
+                    done();
+                }
+            });
+        }, () => event?.unbind());
+        if (settleError) {
+            return { error: String(settleError) };
+        }
+    }
+    return { data: summary(asset) };
+});
+
+driver.method('assets:cubemap:prefilter:clear', async (id) => {
+    const permission = writable();
+    if (permission !== true) {
+        return permission;
+    }
+    const asset = api.assets.get(id);
+    if (!asset || asset.get('type') !== 'cubemap') {
+        return { error: `Cubemap asset not found: ${id}.` };
+    }
+    if (!asset.get('file')) {
+        return { data: summary(asset) };
+    }
+    let event: any;
+    const [error] = await bounded('cubemap prefilter clear', (done) => {
+        event = asset.on('file:set', (file: unknown) => {
+            if (file === null) {
+                event.unbind();
+                done();
+            }
+        });
+        editor.call('realtime:send', 'cubemap:clear:', Number(asset.get('uniqueId')));
+    }, () => event?.unbind());
+    if (error) {
+        return { error: String(error) };
+    }
+    return { data: summary(asset) };
 });
 
 driver.method('assets:sprite:modify', (id, props: SpriteProps) => {

--- a/src/editor/driver/processing.ts
+++ b/src/editor/driver/processing.ts
@@ -50,7 +50,9 @@ const bounded = (name: string, start: (done: (error?: unknown, data?: any) => vo
             cancel?.();
             finish(new Error(`Timed out waiting for ${name}.`));
         }, OPERATION_TIMEOUT);
-        Promise.resolve().then(() => start(finish)).catch(finish);
+        Promise.resolve()
+            .then(() => start(finish))
+            .catch(finish);
     });
 
 const waitAsset = async (id: number, name: string) => {
@@ -59,12 +61,16 @@ const waitAsset = async (id: number, name: string) => {
         return [null, current];
     }
     let event: any;
-    return bounded(name, (done) => {
-        event = api.assets.once(`add[${id}]`, (asset: Asset) => {
-            event.unbind();
-            done(null, asset);
-        });
-    }, () => event?.unbind());
+    return bounded(
+        name,
+        (done) => {
+            event = api.assets.once(`add[${id}]`, (asset: Asset) => {
+                event.unbind();
+                done(null, asset);
+            });
+        },
+        () => event?.unbind()
+    );
 };
 
 const waitTask = (asset: any, name: string, start: () => void) =>
@@ -99,13 +105,17 @@ driver.method('lightmapper:bake', async (ids?: string[]) => {
         .map((entity) => entity.get('components.model.asset'))
         .filter((id) => id && !api.assets.get(id)?.has('meta.attributes.texCoord1'));
     let event: any;
-    const [error] = await bounded('lightmap bake', (done) => {
-        event = editor.once('lightmapper:baked', () => {
-            event.unbind();
-            done();
-        });
-        editor.call('lightmapper:bake', targets);
-    }, () => event?.unbind());
+    const [error] = await bounded(
+        'lightmap bake',
+        (done) => {
+            event = editor.once('lightmapper:baked', () => {
+                event.unbind();
+                done();
+            });
+            editor.call('lightmapper:bake', targets);
+        },
+        () => event?.unbind()
+    );
     if (error) {
         return { error: error.message };
     }
@@ -154,7 +164,8 @@ driver.method('assets:texture:convert', async (id, format) => {
         return { error: `Unsupported texture format: ${format}.` };
     }
     const [error, data] = await bounded('texture conversion', (done) =>
-        editor.call('assets:texture:convert', id, format, done));
+        editor.call('assets:texture:convert', id, format, done)
+    );
     if (error) {
         return { error: String(error) };
     }
@@ -173,7 +184,8 @@ driver.method('assets:texture:toAtlas', async (id) => {
         return { error: `Editable texture asset not found: ${id}.` };
     }
     const [error, atlasId] = await bounded('texture atlas creation', (done) =>
-        editor.call('assets:textureToAtlas', asset, done));
+        editor.call('assets:textureToAtlas', asset, done)
+    );
     if (error) {
         return { error: String(error) };
     }
@@ -191,7 +203,8 @@ driver.method('assets:texture:toCubemap', async (id) => {
         return { error: `Editable texture asset not found: ${id}.` };
     }
     const [error, cubemap] = await bounded('cubemap creation', (done) =>
-        editor.call('assets:textureToCubemap', asset, done));
+        editor.call('assets:textureToCubemap', asset, done)
+    );
     return error ? { error: String(error) } : { data: summary(cubemap) };
 });
 
@@ -219,7 +232,8 @@ driver.method('assets:font:process', async (id, options: { characters: string; i
                 chars: characters,
                 invert: !!asset.get('meta.invert')
             }
-        }));
+        })
+    );
     return error ? { error: error.message } : { data: summary(asset) };
 });
 
@@ -236,13 +250,17 @@ driver.method('assets:texture:metadata', async (id) => {
         return { data: summary(asset) };
     }
     let event: any;
-    const [error] = await bounded('texture metadata', (done) => {
-        event = asset.once('meta:set', () => {
-            event.unbind();
-            done();
-        });
-        editor.call('realtime:send', 'pipeline', { name: 'meta', id: asset.get('uniqueId') });
-    }, () => event?.unbind());
+    const [error] = await bounded(
+        'texture metadata',
+        (done) => {
+            event = asset.once('meta:set', () => {
+                event.unbind();
+                done();
+            });
+            editor.call('realtime:send', 'pipeline', { name: 'meta', id: asset.get('uniqueId') });
+        },
+        () => event?.unbind()
+    );
     return error ? { error: error.message } : { data: summary(asset) };
 });
 
@@ -264,7 +282,8 @@ driver.method(
         }
         formats.forEach((format) => asset.set(`meta.compress.${format}`, !options.remove));
         const [error] = await waitTask(asset, 'texture variant processing', () =>
-            TextureCompressor.compress([asset.observer], formats, !!options.force));
+            TextureCompressor.compress([asset.observer], formats, !!options.force)
+        );
         return error
             ? { error: error.message }
             : { data: { ...summary(asset), variants: asset.get('file.variants') || {} } };
@@ -281,20 +300,25 @@ driver.method('assets:cubemap:prefilter', async (id, legacy = false) => {
         return { error: `Cubemap asset not found: ${id}.` };
     }
     const [error] = await bounded('cubemap prefiltering', (done) =>
-        editor.call('assets:cubemaps:prefilter', asset.observer, legacy, done));
+        editor.call('assets:cubemaps:prefilter', asset.observer, legacy, done)
+    );
     if (error) {
         return { error: String(error) };
     }
     if (!asset.get('file')) {
         let event: any;
-        const [settleError] = await bounded('cubemap prefilter settlement', (done) => {
-            event = asset.on('file:set', (file: unknown) => {
-                if (file) {
-                    event.unbind();
-                    done();
-                }
-            });
-        }, () => event?.unbind());
+        const [settleError] = await bounded(
+            'cubemap prefilter settlement',
+            (done) => {
+                event = asset.on('file:set', (file: unknown) => {
+                    if (file) {
+                        event.unbind();
+                        done();
+                    }
+                });
+            },
+            () => event?.unbind()
+        );
         if (settleError) {
             return { error: String(settleError) };
         }
@@ -315,15 +339,19 @@ driver.method('assets:cubemap:prefilter:clear', async (id) => {
         return { data: summary(asset) };
     }
     let event: any;
-    const [error] = await bounded('cubemap prefilter clear', (done) => {
-        event = asset.on('file:set', (file: unknown) => {
-            if (file === null) {
-                event.unbind();
-                done();
-            }
-        });
-        editor.call('realtime:send', 'cubemap:clear:', Number(asset.get('uniqueId')));
-    }, () => event?.unbind());
+    const [error] = await bounded(
+        'cubemap prefilter clear',
+        (done) => {
+            event = asset.on('file:set', (file: unknown) => {
+                if (file === null) {
+                    event.unbind();
+                    done();
+                }
+            });
+            editor.call('realtime:send', 'cubemap:clear:', Number(asset.get('uniqueId')));
+        },
+        () => event?.unbind()
+    );
     if (error) {
         return { error: String(error) };
     }

--- a/src/editor/driver/processing.ts
+++ b/src/editor/driver/processing.ts
@@ -12,7 +12,6 @@ type SpriteProps = {
     textureAtlasAsset?: number;
     frames?: Record<string, Frame>;
 };
-const OPERATION_TIMEOUT = 60_000;
 const VARIANTS = ['basis', 'dxt', 'etc1', 'etc2', 'pvr'];
 
 const summary = (asset: Asset) => ({
@@ -35,7 +34,7 @@ const setData = (id: number, data: Record<string, unknown>) => {
 const writable = () =>
     editor.call('permissions:write') || { error: 'Write permission is required for asset processing.' };
 
-const bounded = (name: string, start: (done: (error?: unknown, data?: any) => void) => void, cancel?: () => void) =>
+const bounded = (start: (done: (error?: unknown, data?: any) => void) => void, cleanup?: () => void) =>
     new Promise<any[]>((resolve) => {
         let active = true;
         const finish = (error?: unknown, data?: any) => {
@@ -43,29 +42,23 @@ const bounded = (name: string, start: (done: (error?: unknown, data?: any) => vo
                 return;
             }
             active = false;
-            clearTimeout(timer);
+            cleanup?.();
             resolve([error, data]);
         };
-        const timer = setTimeout(() => {
-            cancel?.();
-            finish(new Error(`Timed out waiting for ${name}.`));
-        }, OPERATION_TIMEOUT);
         Promise.resolve()
             .then(() => start(finish))
             .catch(finish);
     });
 
-const waitAsset = async (id: number, name: string) => {
+const waitAsset = async (id: number) => {
     const current = api.assets.get(id);
     if (current) {
         return [null, current];
     }
     let event: any;
     return bounded(
-        name,
         (done) => {
             event = api.assets.once(`add[${id}]`, (asset: Asset) => {
-                event.unbind();
                 done(null, asset);
             });
         },
@@ -73,11 +66,15 @@ const waitAsset = async (id: number, name: string) => {
     );
 };
 
-const waitTask = (asset: any, name: string, start: () => void) =>
+const waitTask = (asset: any, start: () => boolean | void) =>
     new Promise<any[]>((resolve) => {
+        let active = true;
         let running = asset.get('task') !== null;
         const finish = (error?: unknown) => {
-            clearTimeout(timer);
+            if (!active) {
+                return;
+            }
+            active = false;
             event.unbind();
             resolve([error]);
         };
@@ -87,8 +84,14 @@ const waitTask = (asset: any, name: string, start: () => void) =>
                 finish();
             }
         });
-        const timer = setTimeout(() => finish(new Error(`Timed out waiting for ${name}.`)), OPERATION_TIMEOUT);
-        Promise.resolve().then(start).catch(finish);
+        Promise.resolve()
+            .then(start)
+            .then((scheduled) => {
+                if (scheduled === false) {
+                    finish();
+                }
+            })
+            .catch(finish);
     });
 
 driver.method('lightmapper:bake', async (ids?: string[]) => {
@@ -106,10 +109,8 @@ driver.method('lightmapper:bake', async (ids?: string[]) => {
         .filter((id) => id && !api.assets.get(id)?.has('meta.attributes.texCoord1'));
     let event: any;
     const [error] = await bounded(
-        'lightmap bake',
         (done) => {
             event = editor.once('lightmapper:baked', () => {
-                event.unbind();
                 done();
             });
             editor.call('lightmapper:bake', targets);
@@ -133,11 +134,7 @@ driver.method('assets:model:unwrap', async (id, options: { padding?: number } = 
     if (!asset || asset.get('type') !== 'model' || !asset.has('file.filename')) {
         return { error: `Model asset not found or has no source file: ${id}.` };
     }
-    const [error, result] = await bounded(
-        'model unwrap',
-        (done) => editor.call('assets:model:unwrap', asset, options, done),
-        () => editor.call('assets:model:unwrap:cancel', asset)
-    );
+    const [error, result] = await bounded((done) => editor.call('assets:model:unwrap', asset, options, done));
     return error ? { error: String(error) } : { data: summary(result || asset) };
 });
 
@@ -163,14 +160,12 @@ driver.method('assets:texture:convert', async (id, format) => {
     if (!['avif', 'jpeg', 'png', 'webp'].includes(format)) {
         return { error: `Unsupported texture format: ${format}.` };
     }
-    const [error, data] = await bounded('texture conversion', (done) =>
-        editor.call('assets:texture:convert', id, format, done)
-    );
+    const [error, data] = await bounded((done) => editor.call('assets:texture:convert', id, format, done));
     if (error) {
         return { error: String(error) };
     }
     const createdId = data?.asset?.id || data?.id;
-    const [settleError, result] = createdId ? await waitAsset(createdId, 'converted texture settlement') : [null, null];
+    const [settleError, result] = createdId ? await waitAsset(createdId) : [null, null];
     return settleError ? { error: String(settleError) } : { data: result ? summary(result) : data || null };
 });
 
@@ -183,13 +178,11 @@ driver.method('assets:texture:toAtlas', async (id) => {
     if (!asset || asset.get('type') !== 'texture' || asset.get('source')) {
         return { error: `Editable texture asset not found: ${id}.` };
     }
-    const [error, atlasId] = await bounded('texture atlas creation', (done) =>
-        editor.call('assets:textureToAtlas', asset, done)
-    );
+    const [error, atlasId] = await bounded((done) => editor.call('assets:textureToAtlas', asset, done));
     if (error) {
         return { error: String(error) };
     }
-    const [settleError, atlas] = await waitAsset(atlasId, 'texture atlas settlement');
+    const [settleError, atlas] = await waitAsset(atlasId);
     return settleError ? { error: String(settleError) } : { data: summary(atlas) };
 });
 
@@ -202,9 +195,7 @@ driver.method('assets:texture:toCubemap', async (id) => {
     if (!asset || asset.get('type') !== 'texture' || asset.get('source')) {
         return { error: `Editable texture asset not found: ${id}.` };
     }
-    const [error, cubemap] = await bounded('cubemap creation', (done) =>
-        editor.call('assets:textureToCubemap', asset, done)
-    );
+    const [error, cubemap] = await bounded((done) => editor.call('assets:textureToCubemap', asset, done));
     return error ? { error: String(error) } : { data: summary(cubemap) };
 });
 
@@ -223,7 +214,7 @@ driver.method('assets:font:process', async (id, options: { characters: string; i
     if (options.invert !== undefined) {
         asset.set('meta.invert', options.invert);
     }
-    const [error] = await waitTask(asset, 'font processing', () =>
+    const [error] = await waitTask(asset, () => {
         editor.call('realtime:send', 'pipeline', {
             name: 'convert',
             data: {
@@ -232,8 +223,8 @@ driver.method('assets:font:process', async (id, options: { characters: string; i
                 chars: characters,
                 invert: !!asset.get('meta.invert')
             }
-        })
-    );
+        });
+    });
     return error ? { error: error.message } : { data: summary(asset) };
 });
 
@@ -251,10 +242,8 @@ driver.method('assets:texture:metadata', async (id) => {
     }
     let event: any;
     const [error] = await bounded(
-        'texture metadata',
         (done) => {
             event = asset.once('meta:set', () => {
-                event.unbind();
                 done();
             });
             editor.call('realtime:send', 'pipeline', { name: 'meta', id: asset.get('uniqueId') });
@@ -280,8 +269,10 @@ driver.method(
         if (!formats.length || invalid.length) {
             return { error: `Texture formats must be one or more of: ${VARIANTS.join(', ')}.` };
         }
-        formats.forEach((format) => asset.set(`meta.compress.${format}`, !options.remove));
-        const [error] = await waitTask(asset, 'texture variant processing', () =>
+        for (let i = 0; i < formats.length; i++) {
+            asset.set(`meta.compress.${formats[i]}`, !options.remove);
+        }
+        const [error] = await waitTask(asset, () =>
             TextureCompressor.compress([asset.observer], formats, !!options.force)
         );
         return error
@@ -299,20 +290,16 @@ driver.method('assets:cubemap:prefilter', async (id, legacy = false) => {
     if (!asset || asset.get('type') !== 'cubemap') {
         return { error: `Cubemap asset not found: ${id}.` };
     }
-    const [error] = await bounded('cubemap prefiltering', (done) =>
-        editor.call('assets:cubemaps:prefilter', asset.observer, legacy, done)
-    );
+    const [error] = await bounded((done) => editor.call('assets:cubemaps:prefilter', asset.observer, legacy, done));
     if (error) {
         return { error: String(error) };
     }
     if (!asset.get('file')) {
         let event: any;
         const [settleError] = await bounded(
-            'cubemap prefilter settlement',
             (done) => {
                 event = asset.on('file:set', (file: unknown) => {
                     if (file) {
-                        event.unbind();
                         done();
                     }
                 });
@@ -340,11 +327,9 @@ driver.method('assets:cubemap:prefilter:clear', async (id) => {
     }
     let event: any;
     const [error] = await bounded(
-        'cubemap prefilter clear',
         (done) => {
             event = asset.on('file:set', (file: unknown) => {
                 if (file === null) {
-                    event.unbind();
                     done();
                 }
             });

--- a/src/editor/driver/project.ts
+++ b/src/editor/driver/project.ts
@@ -1,11 +1,13 @@
 import { driver } from './driver';
-import { api, log, iterateObject, writeError } from './shared';
+import { api, log, iterateObject, validatePath, writeError } from './shared';
 
 const WRITE_SCOPES = new Set(['project', 'projectPrivate', 'scene']);
-const BLOCKED_PATHS = new Set(['__proto__', 'prototype', 'constructor']);
 
 const getSettings = (scope: string) => {
     if (scope === 'scene') {
+        if (!api.realtime.scenes.current?.data) {
+            throw new Error('No scene is currently loaded.');
+        }
         return api.settings.scene.observer;
     }
     if (['project', 'projectUser', 'projectPrivate', 'user', 'session'].includes(scope)) {
@@ -14,34 +16,7 @@ const getSettings = (scope: string) => {
     throw new Error(`Invalid settings scope: ${scope}.`);
 };
 
-const validatePath = (path: string) => {
-    if (!path || path.split('.').some((part) => !part || BLOCKED_PATHS.has(part))) {
-        throw new Error(`Invalid settings path: ${path}.`);
-    }
-};
-
-// project settings
-driver.method('project:settings:modify', (settings) => {
-    const denied = writeError('modify project settings');
-    if (denied) {
-        return denied;
-    }
-    const project = editor.call('settings:project');
-    iterateObject(settings, (path, value) => {
-        project.set(path, value);
-    });
-    log('Modified project settings');
-
-    // return the resulting settings snapshot inline
-    return { data: project.json() };
-});
-driver.method('project:settings:query', () => {
-    const project = editor.call('settings:project');
-    log('Queried project settings');
-    return { data: project.json() };
-});
-
-driver.method('settings:query', (scope, path) => {
+const querySettings = (scope: string, path?: string) => {
     const settings = getSettings(scope);
     if (path === undefined) {
         return { data: settings.json() };
@@ -51,9 +26,9 @@ driver.method('settings:query', (scope, path) => {
         return { error: `Settings path not found in ${scope}: ${path}.` };
     }
     return { data: settings.get(path) };
-});
+};
 
-driver.method('settings:modify', (scope, edits) => {
+const modifySettings = (scope: string, edits: any[]) => {
     if (WRITE_SCOPES.has(scope)) {
         const denied = writeError(`modify ${scope} settings`);
         if (denied) {
@@ -81,4 +56,13 @@ driver.method('settings:modify', (scope, edits) => {
     });
     log(`Modified ${scope} settings: ${prepared.map(({ path }) => path).join(', ')}`);
     return { data: settings.json() };
+};
+
+driver.method('settings:query', querySettings);
+driver.method('settings:modify', modifySettings);
+driver.method('project:settings:query', () => querySettings('project'));
+driver.method('project:settings:modify', (settings) => {
+    const edits: any[] = [];
+    iterateObject(settings, (path, value) => edits.push({ path, value }));
+    return modifySettings('project', edits);
 });

--- a/src/editor/driver/project.ts
+++ b/src/editor/driver/project.ts
@@ -47,13 +47,14 @@ const modifySettings = (scope: string, edits: any[]) => {
         }
         return { ...edit, op };
     });
-    prepared.forEach(({ path, op, value }) => {
+    for (let i = 0; i < prepared.length; i++) {
+        const { path, op, value } = prepared[i];
         if (op === 'unset') {
             settings.unset(path);
         } else {
             settings.set(path, value);
         }
-    });
+    }
     log(`Modified ${scope} settings: ${prepared.map(({ path }) => path).join(', ')}`);
     return { data: settings.json() };
 };

--- a/src/editor/driver/project.ts
+++ b/src/editor/driver/project.ts
@@ -1,5 +1,24 @@
 import { driver } from './driver';
-import { log, iterateObject, writeError } from './shared';
+import { api, log, iterateObject, writeError } from './shared';
+
+const WRITE_SCOPES = new Set(['project', 'projectPrivate', 'scene']);
+const BLOCKED_PATHS = new Set(['__proto__', 'prototype', 'constructor']);
+
+const getSettings = (scope: string) => {
+    if (scope === 'scene') {
+        return api.settings.scene.observer;
+    }
+    if (['project', 'projectUser', 'projectPrivate', 'user', 'session'].includes(scope)) {
+        return editor.call(`settings:${scope}`);
+    }
+    throw new Error(`Invalid settings scope: ${scope}.`);
+};
+
+const validatePath = (path: string) => {
+    if (!path || path.split('.').some((part) => !part || BLOCKED_PATHS.has(part))) {
+        throw new Error(`Invalid settings path: ${path}.`);
+    }
+};
 
 // project settings
 driver.method('project:settings:modify', (settings) => {
@@ -20,4 +39,46 @@ driver.method('project:settings:query', () => {
     const project = editor.call('settings:project');
     log('Queried project settings');
     return { data: project.json() };
+});
+
+driver.method('settings:query', (scope, path) => {
+    const settings = getSettings(scope);
+    if (path === undefined) {
+        return { data: settings.json() };
+    }
+    validatePath(path);
+    if (!settings.has(path)) {
+        return { error: `Settings path not found in ${scope}: ${path}.` };
+    }
+    return { data: settings.get(path) };
+});
+
+driver.method('settings:modify', (scope, edits) => {
+    if (WRITE_SCOPES.has(scope)) {
+        const denied = writeError(`modify ${scope} settings`);
+        if (denied) {
+            return denied;
+        }
+    }
+    const settings = getSettings(scope);
+    const prepared = edits.map((edit) => {
+        validatePath(edit.path);
+        const op = edit.op || 'set';
+        if (op !== 'set' && op !== 'unset') {
+            throw new Error(`Invalid settings operation: ${op}.`);
+        }
+        if (op === 'set' && !Object.hasOwn(edit, 'value')) {
+            throw new Error(`Missing value for settings path: ${edit.path}.`);
+        }
+        return { ...edit, op };
+    });
+    prepared.forEach(({ path, op, value }) => {
+        if (op === 'unset') {
+            settings.unset(path);
+        } else {
+            settings.set(path, value);
+        }
+    });
+    log(`Modified ${scope} settings: ${prepared.map(({ path }) => path).join(', ')}`);
+    return { data: settings.json() };
 });

--- a/src/editor/driver/scene.ts
+++ b/src/editor/driver/scene.ts
@@ -34,6 +34,24 @@ driver.method('scene:settings:query', () => {
     log('Queried scene settings');
     return { data: scene.json() };
 });
+driver.method('scene:name:set', (name) => {
+    const denied = writeError('rename the current scene');
+    if (denied) {
+        return denied;
+    }
+    const scene = api.realtime.scenes.current;
+    if (!scene?.data) {
+        return { error: 'No scene is loaded.' };
+    }
+    editor.call('realtime:scene:op', {
+        p: ['name'],
+        od: scene.data.name || '',
+        oi: name
+    });
+    editor.emit('scene:name', name);
+    log(`Renamed scene(${scene.id}) to: ${name}`);
+    return { data: { id: scene.id, uniqueId: scene.uniqueId, name } };
+});
 
 // scene management
 driver.method('scenes:list', async () => {

--- a/src/editor/driver/scene.ts
+++ b/src/editor/driver/scene.ts
@@ -16,24 +16,11 @@ const scenes = () =>
 
 // scene settings
 driver.method('scene:settings:modify', (settings) => {
-    const denied = writeError('modify scene settings');
-    if (denied) {
-        return denied;
-    }
-    const scene = api.settings.scene;
-    iterateObject(settings, (path, value) => {
-        scene.set(path, value);
-    });
-    log('Modified scene settings');
-
-    // return the resulting settings snapshot inline
-    return { data: scene.json() };
+    const edits: any[] = [];
+    iterateObject(settings, (path, value) => edits.push({ path, value }));
+    return driver.invoke('settings:modify', 'scene', edits);
 });
-driver.method('scene:settings:query', () => {
-    const scene = api.settings.scene;
-    log('Queried scene settings');
-    return { data: scene.json() };
-});
+driver.method('scene:settings:query', () => driver.invoke('settings:query', 'scene'));
 driver.method('scene:name:set', (name) => {
     const denied = writeError('rename the current scene');
     if (denied) {

--- a/src/editor/driver/shared.ts
+++ b/src/editor/driver/shared.ts
@@ -5,6 +5,14 @@ const log = (msg: string) => console.log(`[Editor Driver] ${msg}`);
 const writeError = (action = 'modify the designated project') =>
     editor.call('permissions:write') ? null : { error: `Write permission is required to ${action}.` };
 
+const BLOCKED_PATHS = new Set(['__proto__', 'prototype', 'constructor']);
+
+const validatePath = (path: string) => {
+    if (!path || path.split('.').some((part) => !part || BLOCKED_PATHS.has(part))) {
+        throw new Error(`Invalid path: ${path}.`);
+    }
+};
+
 /**
  * PlayCanvas REST API wrapper.
  *
@@ -37,6 +45,7 @@ const rest = (method: string, path: string, data?: FormData | object, auth = fal
 const iterateObject = (obj: Record<string, any>, callback: (path: string, value: any) => void, currentPath = '') => {
     Object.entries(obj).forEach(([key, value]) => {
         const path = currentPath ? `${currentPath}.${key}` : key;
+        validatePath(path);
         if (value && typeof value === 'object' && !Array.isArray(value)) {
             iterateObject(value, callback, path);
         } else {
@@ -112,4 +121,4 @@ const paginate = <T>(items: T[], options: { limit?: number; offset?: number } = 
     };
 };
 
-export { api, log, rest, iterateObject, entitySummary, paginate, writeError };
+export { api, log, rest, iterateObject, entitySummary, paginate, validatePath, writeError };

--- a/src/editor/driver/store.ts
+++ b/src/editor/driver/store.ts
@@ -84,15 +84,17 @@ driver.method('store:sketchfab:clone', async (uid, name, license, folder) => {
 });
 
 driver.method('store:myassets:list', async (options: any = {}) => {
-    const data = await api.rest.assets.assetsList({
-        search: options.search,
-        regex: !!options.search,
-        sort: options.sort,
-        order: options.order,
-        skip: options.skip,
-        limit: options.limit,
-        tags: options.tags
-    }).promisify();
+    const data = await api.rest.assets
+        .assetsList({
+            search: options.search,
+            regex: !!options.search,
+            sort: options.sort,
+            order: options.order,
+            skip: options.skip,
+            limit: options.limit,
+            tags: options.tags
+        })
+        .promisify();
     return { data };
 });
 

--- a/src/editor/driver/store.ts
+++ b/src/editor/driver/store.ts
@@ -1,137 +1,111 @@
 import { config } from '@/editor/config';
 
 import { driver } from './driver';
-import { log, rest, writeError } from './shared';
+import { api, log, writeError } from './shared';
+
+type License = string | { author: string; authorUrl: string; license: string };
+
+const clone = (store: string, id: string, name: string, license: License, folder?: number) =>
+    api.rest.store
+        .storeClone(id, {
+            scope: {
+                type: 'project',
+                id: String(config.project.id)
+            },
+            name,
+            store,
+            targetFolderId: folder === undefined ? null : String(folder),
+            license
+        })
+        .promisify();
 
 // store - playcanvas
 driver.method('store:playcanvas:list', async (options: any = {}) => {
-    const params = [];
-    if (options.search) {
-        params.push(`search=${options.search}`);
-    }
-    params.push('regexp=true');
-    if (options.order) {
-        params.push(`order=${options.order}`);
-    }
-    if (options.skip) {
-        params.push(`skip=${options.skip}`);
-    }
-    if (options.limit) {
-        params.push(`limit=${options.limit}`);
-    }
-
-    try {
-        const data = await rest('GET', `store?${params.join('&')}`);
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Searched store: ${JSON.stringify(options)}`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
-    }
+    const data = await api.rest.store.storeList({ ...options, regex: true, excludeTags: 'INTERNAL' }).promisify();
+    log(`Searched store: ${JSON.stringify(options)}`);
+    return { data };
 });
 driver.method('store:playcanvas:get', async (id) => {
-    try {
-        const data = await rest('GET', `store/${id}`);
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Got store item(${id})`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
-    }
+    const data = await api.rest.store.storeGet(Number(id)).promisify();
+    log(`Got store item(${id})`);
+    return { data };
 });
-driver.method('store:playcanvas:clone', async (id, name, license) => {
+driver.method('store:playcanvas:clone', async (id, name, license, folder) => {
     const denied = writeError('download store assets');
     if (denied) {
         return denied;
     }
-    try {
-        const data = await rest('POST', `store/${id}/clone`, {
-            scope: {
-                type: 'project',
-                id: config.project.id
-            },
-            name,
-            store: 'playcanvas',
-            targetFolderId: null,
-            license
-        });
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Cloned store item(${id})`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
-    }
+    const data = await clone('playcanvas', id, name, license, folder);
+    log(`Cloned store item(${id})`);
+    return { data };
 });
 
 // store - sketchfab
 driver.method('store:sketchfab:list', async (options: any = {}) => {
-    const params = ['restricted=0', 'type=models', 'downloadable=true'];
+    const params = new URLSearchParams({ restricted: '0', type: 'models', downloadable: 'true' });
     if (options.search) {
-        params.push(`q=${options.search}`);
+        params.set('q', options.search);
     }
     if (options.order) {
-        params.push(`sort_by=${options.order}`);
+        params.set('sort_by', options.order);
     }
     if (options.skip) {
-        params.push(`cursor=${options.skip}`);
+        params.set('cursor', options.skip);
     }
     if (options.limit) {
-        params.push(`count=${Math.min(options.limit ?? 0, 24)}`);
+        params.set('count', String(Math.min(options.limit, 24)));
     }
 
-    try {
-        const res = await fetch(`https://api.sketchfab.com/v3/search?${params.join('&')}`);
-        const data = await res.json();
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Searched Sketchfab: ${JSON.stringify(options)}`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
+    const res = await fetch(`https://api.sketchfab.com/v3/search?${params}`);
+    if (!res.ok) {
+        throw new Error(`Sketchfab search failed: ${res.status} ${res.statusText}.`);
     }
+    const data = await res.json();
+    log(`Searched Sketchfab: ${JSON.stringify(options)}`);
+    return { data };
 });
 driver.method('store:sketchfab:get', async (uid) => {
-    try {
-        const res = await fetch(`https://api.sketchfab.com/v3/models/${uid}`);
-        const data = await res.json();
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Got Sketchfab model(${uid})`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
+    const res = await fetch(`https://api.sketchfab.com/v3/models/${encodeURIComponent(uid)}`);
+    if (!res.ok) {
+        throw new Error(`Sketchfab model request failed: ${res.status} ${res.statusText}.`);
     }
+    const data = await res.json();
+    log(`Got Sketchfab model(${uid})`);
+    return { data };
 });
-driver.method('store:sketchfab:clone', async (uid, name, license) => {
+driver.method('store:sketchfab:clone', async (uid, name, license, folder) => {
     const denied = writeError('download store assets');
     if (denied) {
         return denied;
     }
-    try {
-        const data = await rest('POST', `store/${uid}/clone`, {
-            scope: {
-                type: 'project',
-                id: config.project.id
-            },
-            name,
-            store: 'sketchfab',
-            targetFolderId: null,
-            license
-        });
-        if (data.error) {
-            return { error: data.error };
-        }
-        log(`Cloned sketchfab item(${uid})`);
-        return { data };
-    } catch (e: any) {
-        return { error: e.message };
+    const data = await clone('sketchfab', uid, name, license, folder);
+    log(`Cloned sketchfab item(${uid})`);
+    return { data };
+});
+
+driver.method('store:myassets:list', async (options: any = {}) => {
+    const data = await api.rest.assets.assetsList({
+        search: options.search,
+        regex: !!options.search,
+        sort: options.sort,
+        order: options.order,
+        skip: options.skip,
+        limit: options.limit,
+        tags: options.tags
+    }).promisify();
+    return { data };
+});
+
+driver.method('store:myassets:clone', async (id, name, folder) => {
+    const denied = writeError('download My Assets');
+    if (denied) {
+        return denied;
     }
+    const data = await clone('myassets', id, name, '', folder);
+    return { data };
+});
+
+driver.method('store:licenses:list', async () => {
+    const data = await api.rest.store.storeLicenses().promisify();
+    return { data: (data as any).result || data };
 });

--- a/src/editor/driver/store.ts
+++ b/src/editor/driver/store.ts
@@ -3,7 +3,8 @@ import { config } from '@/editor/config';
 import { driver } from './driver';
 import { api, log, writeError } from './shared';
 
-type License = string | { author: string; authorUrl: string; license: string };
+type License =
+    string | { author: string; authorUrl: string; license: string } | { id: string; author: string; authorUrl: string };
 
 const clone = (store: string, id: string, name: string, license: License, folder?: number) =>
     api.rest.store
@@ -98,12 +99,20 @@ driver.method('store:myassets:list', async (options: any = {}) => {
     return { data };
 });
 
-driver.method('store:myassets:clone', async (id, name, folder) => {
+driver.method('store:myassets:clone', async (id, _name, folder) => {
     const denied = writeError('download My Assets');
     if (denied) {
         return denied;
     }
-    const data = await clone('myassets', id, name, '', folder);
+    const data = await api.rest.assets
+        .assetClone(String(id), {
+            scope: {
+                type: 'project',
+                id: Number(config.project.id)
+            },
+            targetFolderId: folder ?? null
+        })
+        .promisify();
     return { data };
 });
 

--- a/src/editor/driver/viewport.ts
+++ b/src/editor/driver/viewport.ts
@@ -100,10 +100,11 @@ driver.method('viewport:capture', () => {
 
         // convert to base64 WebP for smaller file size (falls back to PNG if unsupported)
         const dataUrl = dstCanvas.toDataURL('image/webp', 0.8);
-        const base64 = dataUrl.split(',')[1];
+        const [header, base64] = dataUrl.split(',');
+        const mimeType = header.match(/^data:([^;]+)/)?.[1] || 'image/png';
 
         log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
-        return { data: base64, meta: { mimeType: 'image/webp', width: dstWidth, height: dstHeight } };
+        return { data: base64, meta: { mimeType, width: dstWidth, height: dstHeight } };
     } catch (e: any) {
         return {
             error: `Failed to capture viewport: ${e.message}. Ensure a scene is loaded and the viewport is visible, then retry.`

--- a/src/editor/inspector/settings-panel.ts
+++ b/src/editor/inspector/settings-panel.ts
@@ -88,15 +88,18 @@ class SettingsPanel extends Container {
 
         this.buildDom(DOM(this));
 
-        editor.on('scene:raw', (data) => {
-            editor.emit('scene:name', data.name);
-            this._sceneName = data.name;
+        editor.on('scene:name', (name) => {
+            this._sceneName = name;
             const sceneNameField = this._sceneAttributes.getField('name');
 
             const suspend = this._suspendSceneNameEvt;
             this._suspendSceneNameEvt = true;
             sceneNameField.value = this._sceneName;
             this._suspendSceneNameEvt = suspend;
+        });
+
+        editor.on('scene:raw', (data) => {
+            editor.emit('scene:name', data.name);
         });
 
         editor.on('realtime:scene:op:name', (op) => {

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -105,6 +105,7 @@ class MCPConnection extends Events {
             // reconnect below; swallow it here so it isn't surfaced as unhandled
         };
         ws.onclose = (evt) => {
+            this._methods.get('files:transfer:clear')?.();
             // a deliberate disconnect() (FORCE) must never reconnect
             if (this._forceClosed || evt?.reason === 'FORCE') {
                 return;
@@ -123,6 +124,7 @@ class MCPConnection extends Events {
 
     disconnect() {
         this._forceClosed = true;
+        this._methods.get('files:transfer:clear')?.();
         if (this._connectTimeout) {
             clearTimeout(this._connectTimeout);
             this._connectTimeout = null;

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -16,11 +16,24 @@ mcp.method('launch:start', (options: any = {}) => {
     }
     const params = new URLSearchParams();
 
-    // debug=true makes the engine log warnings/errors to the console, which
-    // read_runtime_logs relies on
-    params.set('debug', 'true');
+    params.set('debug', String(options.debug ?? true));
     if (options.device) {
         params.set('device', options.device);
+    }
+    if (options.engineVersion) {
+        params.set('version', options.engineVersion);
+    }
+    if (options.profiler) {
+        params.set('profile', 'true');
+    }
+    if (options.concatenate) {
+        params.set('concatenateScripts', 'true');
+    }
+    if (options.bundles !== undefined) {
+        params.set('useBundles', String(options.bundles));
+    }
+    if (options.miniStats) {
+        params.set('ministats', 'true');
     }
 
     // pass the MCP port so the launch page can connect back as the runtime peer

--- a/src/editor/mcp/request.ts
+++ b/src/editor/mcp/request.ts
@@ -1,6 +1,14 @@
 type Result = { data?: unknown; error?: string; meta?: Record<string, unknown> };
 
-const message = (err: unknown) => (err instanceof Error ? err.message : String(err));
+const message = (err: any) => {
+    if (err instanceof Error || (typeof ErrorEvent !== 'undefined' && err instanceof ErrorEvent)) {
+        return err.message;
+    }
+    if (typeof err === 'string') {
+        return err;
+    }
+    return String(err?.message || err?.error || err?.response?.message || err?.response?.error || JSON.stringify(err));
+};
 
 const handleRequest = async (data: string, call: (name: string, ...args: unknown[]) => Result | Promise<Result>) => {
     let id: number | undefined;

--- a/src/workers/console.worker.ts
+++ b/src/workers/console.worker.ts
@@ -26,6 +26,7 @@ const workerServer = new WorkerServer(self);
 workerServer.on('init', async ({ projectId, branchId, legacyLogs }) => {
     const db = new Dexie('editor-console') as Dexie & { logs: Dexie.Table<Log, number> };
     db.version(1).stores({ logs: '++id' });
+    db.version(2).stores({ logs: '++id,[projectId+branchId]' });
 
     // get log count
     let count = await db.logs.count();
@@ -134,21 +135,32 @@ workerServer.on('init', async ({ projectId, branchId, legacyLogs }) => {
 
     workerServer.on('query', async (id: number, options: any = {}) => {
         await addPromise;
-        const logs = (await db.logs.toArray())
-            .concat(queue)
-            .filter((row) => row.projectId === projectId && row.branchId === branchId)
-            .filter((row) => !options.types?.length || options.types.includes(row.type))
-            .filter((row) => !options.search || row.msg.toLowerCase().includes(options.search.toLowerCase()))
-            .filter((row) => !options.since || row.ts >= options.since)
-            .reverse();
+        const stored = await db.logs.where('[projectId+branchId]').equals([projectId, branchId]).reverse().toArray();
+        const logs = queue.slice().reverse().concat(stored);
+        const search = options.search?.toLowerCase();
         const offset = options.offset || 0;
         const limit = options.limit || 100;
-        const data = logs.slice(offset, offset + limit);
+        const data = [];
+        let total = 0;
+        for (let i = 0; i < logs.length; i++) {
+            const row = logs[i];
+            if (
+                (options.types?.length && !options.types.includes(row.type)) ||
+                (search && !row.msg.toLowerCase().includes(search)) ||
+                (options.since && row.ts < options.since)
+            ) {
+                continue;
+            }
+            if (total >= offset && data.length < limit) {
+                data.push(row);
+            }
+            total++;
+        }
         workerServer.send(`query:${id}`, data, {
-            total: logs.length,
+            total,
             count: data.length,
-            hasMore: offset + data.length < logs.length,
-            nextCursor: offset + data.length < logs.length ? String(offset + data.length) : null
+            hasMore: offset + data.length < total,
+            nextCursor: offset + data.length < total ? String(offset + data.length) : null
         });
     });
 

--- a/src/workers/console.worker.ts
+++ b/src/workers/console.worker.ts
@@ -132,6 +132,26 @@ workerServer.on('init', async ({ projectId, branchId, legacyLogs }) => {
         });
     });
 
+    workerServer.on('query', async (id: number, options: any = {}) => {
+        await addPromise;
+        const logs = (await db.logs.toArray())
+            .concat(queue)
+            .filter((row) => row.projectId === projectId && row.branchId === branchId)
+            .filter((row) => !options.types?.length || options.types.includes(row.type))
+            .filter((row) => !options.search || row.msg.toLowerCase().includes(options.search.toLowerCase()))
+            .filter((row) => !options.since || row.ts >= options.since)
+            .reverse();
+        const offset = options.offset || 0;
+        const limit = options.limit || 100;
+        const data = logs.slice(offset, offset + limit);
+        workerServer.send(`query:${id}`, data, {
+            total: logs.length,
+            count: data.length,
+            hasMore: offset + data.length < logs.length,
+            nextCursor: offset + data.length < logs.length ? String(offset + data.length) : null
+        });
+    });
+
     // history blob generation
     let historyUrl = null;
     workerServer.on('history', async (projectName: string, branchName: string) => {

--- a/test/editor-api/api/test-assets.js
+++ b/test/editor-api/api/test-assets.js
@@ -544,7 +544,10 @@ ${className}.prototype.update = function(dt) {
         const folder = new api.Asset({ id: 10 });
         api.globals.assets.createMaterial({
             name: 'name',
-            folder: folder
+            folder: folder,
+            data: {
+                opacity: 0
+            }
         });
 
         expect(requests.length).to.equal(1);
@@ -557,8 +560,29 @@ ${className}.prototype.update = function(dt) {
         expect(data.get('parent')).to.equal('10');
         expect(data.get('preload')).to.equal('true');
         expect(data.get('data')).to.equal(JSON.stringify({
-            diffuse: [0, 0, 0]
+            diffuse: [0, 0, 0],
+            opacity: 0
         }));
+    });
+
+    it('serializes scene import pipeline options', function () {
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
+        api.globals.branchId = 'branch';
+        api.globals.projectId = 1;
+
+        new api.Rest().assets.assetCreate(
+            { type: 'scene', name: 'model.glb' },
+            { meshCompression: 'draco', useUniqueIndices: false }
+        );
+
+        expect(requests.length).to.equal(1);
+        const data = requests[0].requestBody;
+        expect(data.get('meshCompression')).to.equal('draco');
+        expect(data.get('useUniqueIndices')).to.equal('false');
     });
 
     it('creates shader asset', async function () {

--- a/test/editor-api/api/test-assets.js
+++ b/test/editor-api/api/test-assets.js
@@ -10,6 +10,7 @@ describe('Assets API tests', function () {
         api.globals.messenger = null;
         api.globals.history = null;
         api.globals.assets = new api.Assets();
+        api.globals.apiUrl = '';
         assets = api.globals.assets;
         sandbox = sinon.createSandbox();
     });
@@ -583,6 +584,28 @@ ${className}.prototype.update = function(dt) {
         const data = requests[0].requestBody;
         expect(data.get('meshCompression')).to.equal('draco');
         expect(data.get('useUniqueIndices')).to.equal('false');
+    });
+
+    it('clones a user asset through the assets route', function () {
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
+        api.globals.apiUrl = '/api';
+
+        new api.Rest().assets.assetClone('9', {
+            scope: { type: 'project', id: 1 },
+            targetFolderId: 10
+        });
+
+        expect(requests.length).to.equal(1);
+        expect(requests[0].method).to.equal('POST');
+        expect(requests[0].url).to.equal('/api/assets/9/clone');
+        expect(JSON.parse(requests[0].requestBody)).to.deep.equal({
+            scope: { type: 'project', id: 1 },
+            targetFolderId: 10
+        });
     });
 
     it('creates shader asset', async function () {

--- a/test/editor-api/api/test-entities.js
+++ b/test/editor-api/api/test-entities.js
@@ -599,19 +599,43 @@ describe('api.Entities tests', function () {
         expect(parent2.children).to.deep.equal([child, child2]);
     });
 
-    it('reparent child to one of its children is not allowed', function () {
+    it('reparent rejects invalid hierarchy targets before mutation', function () {
         const root = api.globals.entities.create();
         const parent = api.globals.entities.create({ parent: root });
         const child = api.globals.entities.create({ parent: parent });
+        const sibling = api.globals.entities.create({ parent: root });
 
-        api.globals.entities.reparent([{
+        expect(() => api.globals.entities.reparent([{
             entity: parent,
             parent: child
-        }]);
+        }])).to.throw('An entity cannot be parented to itself or its descendant.');
+        expect(() => api.globals.entities.reparent([{
+            entity: parent,
+            parent
+        }])).to.throw('An entity cannot be parented to itself or its descendant.');
+        expect(() => api.globals.entities.reparent([{
+            entity: root,
+            parent
+        }])).to.throw('The root entity cannot be reparented.');
+        expect(() => api.globals.entities.reparent([{
+            entity: child,
+            parent: root,
+            index: -1
+        }])).to.throw('Invalid child index: -1.');
+        expect(() => api.globals.entities.reparent([{
+            entity: child,
+            parent: root,
+            index: 10
+        }])).to.throw('Invalid child index: 10.');
+        expect(() => api.globals.entities.reparent([
+            { entity: parent, parent: sibling },
+            { entity: sibling, parent }
+        ])).to.throw('An entity cannot be parented to itself or its descendant.');
 
         expect(child.children).to.deep.equal([]);
         expect(parent.parent).to.equal(root);
         expect(parent.children).to.deep.equal([child]);
+        expect(sibling.parent).to.equal(root);
     });
 
     it('undo / redo reparent', async function () {

--- a/test/editor-api/api/test-entity.js
+++ b/test/editor-api/api/test-entity.js
@@ -240,6 +240,12 @@ describe('api.Entity tests', function () {
         expect(e.get('components.testcomponent.entityRef')).to.equal(e.get('resource_id'));
     });
 
+    it('addComponent rejects unsupported components', function () {
+        api.globals.schema = new api.Schema(schema);
+        const e = api.globals.entities.create();
+        expect(() => e.addComponent('ligth')).to.throw('Unsupported component: ligth');
+    });
+
     it('removeComponent removes component', function () {
         api.globals.schema = new api.Schema(schema);
         const e = api.globals.entities.create();

--- a/test/editor-api/api/test-schema.js
+++ b/test/editor-api/api/test-schema.js
@@ -8,4 +8,41 @@ describe('api.Schema tests', function () {
         const fields = api.globals.schema.components.getFieldsOfType('testcomponent', 'entity');
         expect(fields).to.deep.equal(['entityRef', 'entityArrayRef', 'nestedEntityRef.*.entity']);
     });
+
+    it('components.resolvePath resolves fixed fields and open maps', function () {
+        api.globals.schema = new api.Schema(schema);
+        expect(api.globals.schema.components.resolvePath('testcomponent', 'entityRef')).to.include({
+            default: null,
+            hasDefault: true,
+            open: false
+        });
+        expect(api.globals.schema.components.resolvePath('testcomponent', 'nestedEntityRef.item.entity')).to.include({
+            hasDefault: false,
+            open: true
+        });
+        expect(api.globals.schema.components.resolvePath('script', 'scripts.rotate.attributes.speed')).to.include({
+            open: true
+        });
+        expect(api.globals.schema.components.resolvePath('testcomponent', 'missing')).to.equal(null);
+    });
+
+    it('assets.resolvePath resolves fixed fields, arrays and open maps', function () {
+        api.globals.schema = new api.Schema(schema);
+        expect(api.globals.schema.assets.resolvePath('material', 'diffuse')).to.deep.include({
+            default: [0, 0, 0],
+            hasDefault: true,
+            open: false
+        });
+        expect(api.globals.schema.assets.resolvePath('model', 'mapping.0.material')).to.include({
+            hasDefault: false,
+            open: false
+        });
+        expect(api.globals.schema.assets.resolvePath('test', 'nestedAssetRef.item.asset')).to.include({
+            default: null,
+            hasDefault: true,
+            open: true
+        });
+        expect(api.globals.schema.assets.resolvePath('model', 'mapping.nope.material')).to.equal(null);
+        expect(api.globals.schema.assets.resolvePath('material', 'missing')).to.equal(null);
+    });
 });

--- a/test/editor-api/lib/schema.js
+++ b/test/editor-api/lib/schema.js
@@ -75,6 +75,10 @@ window.schema = {
         diffuse: {
             $type: ["number"],
             $default: [0, 0, 0]
+        },
+        opacity: {
+            $type: "number",
+            $default: 1
         }
     },
     modelData: {

--- a/test/editor/animstategraph/events-data.test.ts
+++ b/test/editor/animstategraph/events-data.test.ts
@@ -28,13 +28,31 @@ describe('remapAnimStateAssets', () => {
                     'Layer:B': { asset: 2 }
                 },
                 [
-                    { key: 'Layer:A', next: 'Layer:B' },
-                    { key: 'Layer:B', next: 'Layer:C' }
+                    { key: 'Layer:A', next: 'Layer:B', drop: true },
+                    { key: 'Layer:B', next: 'Layer:C', drop: false }
                 ]
             )
         ).to.deep.equal({
             'Layer:B': { asset: 1 },
             'Layer:C': { asset: 2 }
+        });
+    });
+
+    it('remaps swapped keys without losing values', () => {
+        expect(
+            remapAnimStateAssets(
+                {
+                    'Layer:A': { asset: 1 },
+                    'Layer:B': { asset: 2 }
+                },
+                [
+                    { key: 'Layer:A', next: 'Layer:B', drop: true },
+                    { key: 'Layer:B', next: 'Layer:A', drop: false }
+                ]
+            )
+        ).to.deep.equal({
+            'Layer:A': { asset: 2 },
+            'Layer:B': { asset: 1 }
         });
     });
 });

--- a/test/editor/animstategraph/events-data.test.ts
+++ b/test/editor/animstategraph/events-data.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { remapAnimStateAssets } from '../../../src/editor/animstategraph/data';
 import { modifyAnimationEvents } from '../../../src/editor/animstategraph/events-data';
 
 describe('modifyAnimationEvents', () => {
@@ -16,43 +15,5 @@ describe('modifyAnimationEvents', () => {
         expect(() => modifyAnimationEvents({}, [{ kind: 'event.add', name: 'late', time: 1.01 }])).to.throw(
             'Event time must be between 0 and 1.'
         );
-    });
-});
-
-describe('remapAnimStateAssets', () => {
-    it('remaps chained keys without overwriting source values', () => {
-        expect(
-            remapAnimStateAssets(
-                {
-                    'Layer:A': { asset: 1 },
-                    'Layer:B': { asset: 2 }
-                },
-                [
-                    { key: 'Layer:A', next: 'Layer:B', drop: true },
-                    { key: 'Layer:B', next: 'Layer:C', drop: false }
-                ]
-            )
-        ).to.deep.equal({
-            'Layer:B': { asset: 1 },
-            'Layer:C': { asset: 2 }
-        });
-    });
-
-    it('remaps swapped keys without losing values', () => {
-        expect(
-            remapAnimStateAssets(
-                {
-                    'Layer:A': { asset: 1 },
-                    'Layer:B': { asset: 2 }
-                },
-                [
-                    { key: 'Layer:A', next: 'Layer:B', drop: true },
-                    { key: 'Layer:B', next: 'Layer:A', drop: false }
-                ]
-            )
-        ).to.deep.equal({
-            'Layer:A': { asset: 2 },
-            'Layer:B': { asset: 1 }
-        });
     });
 });

--- a/test/editor/animstategraph/events-data.test.ts
+++ b/test/editor/animstategraph/events-data.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { remapAnimStateAssets } from '../../../src/editor/animstategraph/data';
 import { modifyAnimationEvents } from '../../../src/editor/animstategraph/events-data';
 
 describe('modifyAnimationEvents', () => {
@@ -15,5 +16,25 @@ describe('modifyAnimationEvents', () => {
         expect(() => modifyAnimationEvents({}, [{ kind: 'event.add', name: 'late', time: 1.01 }])).to.throw(
             'Event time must be between 0 and 1.'
         );
+    });
+});
+
+describe('remapAnimStateAssets', () => {
+    it('remaps chained keys without overwriting source values', () => {
+        expect(
+            remapAnimStateAssets(
+                {
+                    'Layer:A': { asset: 1 },
+                    'Layer:B': { asset: 2 }
+                },
+                [
+                    { key: 'Layer:A', next: 'Layer:B' },
+                    { key: 'Layer:B', next: 'Layer:C' }
+                ]
+            )
+        ).to.deep.equal({
+            'Layer:B': { asset: 1 },
+            'Layer:C': { asset: 2 }
+        });
     });
 });


### PR DESCRIPTION
### What's Changed

- Complete safe entity, settings, asset, processing, build, store, log, and launch operations for MCP.
- Add schema-aware path validation, exact mutation results, and bounded chunked asset transfer.
- Preserve the existing Caller contract and add editor-side regression coverage only to the Editor API suite.
- Paired MCP server PR: https://github.com/playcanvas/editor-mcp-server/pull/99

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

### Manual smoke test

1. Connect the paired MCP server to an Editor project, then query an entity, asset, and scene setting; each call should return the exact current data.
2. Modify and unset valid component and scene paths, then use Editor undo and redo; the UI should reflect every change while invalid paths and hierarchy edits leave state unchanged.
3. Upload and download an asset larger than 20 MiB; the transfer should complete without truncation and should not overwrite an existing destination file.
4. Run an asset processing operation, read Editor logs, and launch with explicit runtime options; each operation should settle with its final result.