### PR TITLE
fix: tolerate unknown components when loading the hierarchy

### DIFF
--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -44,9 +44,6 @@ class ComponentSchema {
      * ```
      */
     getDefaultData(component: string) {
-        if (!Object.hasOwn(this._schema, component)) {
-            throw new Error(`Unsupported component: ${component}`);
-        }
         const result: Record<string, any> = {};
         for (const fieldName in this._schema[component]) {
             if (fieldName.startsWith('$')) {

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -323,8 +323,10 @@ driver.method('entities:components:add', (id, components) => {
         return { error: `Entity ${id} already has components: ${existing.join(', ')}.` };
     }
     const names = Object.keys(components);
-    for (let i = 0; i < names.length; i++) {
-        api.schema.components.getDefaultData(names[i]);
+    const valid = api.schema.components.list();
+    const invalid = names.filter(name => !valid.includes(name));
+    if (invalid.length) {
+        return { error: `Unsupported component(s): ${invalid.join(', ')}. Valid components: ${valid.join(', ')}.` };
     }
     for (let i = 0; i < names.length; i++) {
         entity.addComponent(names[i], components[names[i]]);

--- a/src/editor/driver/entity.ts
+++ b/src/editor/driver/entity.ts
@@ -324,7 +324,7 @@ driver.method('entities:components:add', (id, components) => {
     }
     const names = Object.keys(components);
     const valid = api.schema.components.list();
-    const invalid = names.filter(name => !valid.includes(name));
+    const invalid = names.filter((name) => !valid.includes(name));
     if (invalid.length) {
         return { error: `Unsupported component(s): ${invalid.join(', ')}. Valid components: ${valid.join(', ')}.` };
     }

--- a/test/editor-api/api/test-entity.js
+++ b/test/editor-api/api/test-entity.js
@@ -240,10 +240,11 @@ describe('api.Entity tests', function () {
         expect(e.get('components.testcomponent.entityRef')).to.equal(e.get('resource_id'));
     });
 
-    it('addComponent rejects unsupported components', function () {
+    it('addComponent tolerates unsupported components (legacy data loads without throwing)', function () {
         api.globals.schema = new api.Schema(schema);
         const e = api.globals.entities.create();
-        expect(() => e.addComponent('ligth')).to.throw('Unsupported component: ligth');
+        e.addComponent('pack', { legacy: true });
+        expect(e.get('components.pack')).to.deep.equal({ legacy: true });
     });
 
     it('removeComponent removes component', function () {


### PR DESCRIPTION
## Problem

Loading a scene throws `Error: Unsupported component: pack` and aborts the entire hierarchy load:

```
at ComponentSchema.getDefaultData (components.ts)
at Entity.addComponent (entity.ts)
at new Entity (entity.ts)
at Entities.serverAdd (entities.ts)
at ... scene:raw
```

## Root cause

A recent change added a `throw` to `ComponentSchema.getDefaultData` so the MCP driver could reject invalid component names. But `getDefaultData` is also on the scene-load path:

```
scene:raw → serverAdd → new Entity → addComponent → getDefaultData
```

Before that change, an unknown/legacy component silently resolved to `{}` and loaded fine. `pack` is a legacy component still present in real project data, so the throw now aborts the whole hierarchy load on the first entity that carries one.

## Fix

- **`schema/components.ts`** — remove the throw, restoring the tolerant getter (unknown component → `{}`, so `addComponent` stores the existing data as-is). This is what lets the hierarchy load again.
- **`driver/entity.ts`** — move component-name validation to the MCP `entities:components:add` boundary, checking against `schema.components.list()` and returning a proper `{ error }` (matching the surrounding driver convention) instead of relying on the throw. Invalid names supplied via MCP are still rejected — with a clean message rather than an uncaught exception.
- **`test/editor-api/api/test-entity.js`** — update the `addComponent` test to assert tolerance of unknown/legacy components.

## Verification

- Changed files: zero new type/lint errors.
- Focused logic check: unknown component returns `{}` without throwing (load tolerant); the driver still rejects invalid names and accepts valid ones.