### PR TITLE
fix: replace deprecated Entity#setGuid/#getGuid with Entity#guid

### DIFF
--- a/src/editor/driver/viewport.ts
+++ b/src/editor/driver/viewport.ts
@@ -26,7 +26,7 @@ const viewportState = () => {
     const grid = editor.call('settings:projectUser');
     const user = editor.call('settings:user');
     return {
-        cameraId: camera.__editorName || camera.getGuid(),
+        cameraId: camera.__editorName || camera.guid,
         position: camera.getPosition().toArray(),
         rotation: camera.getEulerAngles().toArray(),
         projection: camera.camera.projection === PROJECTION_ORTHOGRAPHIC ? 'orthographic' : 'perspective',

--- a/src/editor/entities/entities-icons.ts
+++ b/src/editor/entities/entities-icons.ts
@@ -156,7 +156,7 @@ editor.once('load', () => {
                 !this._link.entity._enabledInHierarchy ||
                 this._link.entity.__noIcon ||
                 scale === 0 ||
-                selectedIds[this._link.entity.getGuid()]
+                selectedIds[this._link.entity.guid]
             ) {
                 if (this.entity) {
                     this.entityDelete();

--- a/src/editor/entities/entities-pick.ts
+++ b/src/editor/entities/entities-pick.ts
@@ -10,7 +10,7 @@ editor.once('load', () => {
             }
         }
 
-        return editor.call('entities:get', targetNode.getGuid()) || null;
+        return editor.call('entities:get', targetNode.guid) || null;
     };
 
     editor.on('viewport:pick:clear', () => {

--- a/src/editor/viewport-controls/viewport-cameras.ts
+++ b/src/editor/viewport-controls/viewport-cameras.ts
@@ -146,7 +146,7 @@ editor.once('viewport:load', (app) => {
     editor.on('permissions:writeState', refreshOptions);
 
     editor.on('camera:add', (entity) => {
-        const guid = entity.getGuid();
+        const guid = entity.guid;
 
         viewportCamera.optionTitles[guid] = entity.name;
         viewportCamera.cameras[guid] = entity;
@@ -176,7 +176,7 @@ editor.once('viewport:load', (app) => {
     });
 
     editor.on('camera:remove', (entity) => {
-        const guid = entity.getGuid();
+        const guid = entity.guid;
 
         delete viewportCamera.optionTitles[guid];
         refreshOptions();
@@ -189,7 +189,7 @@ editor.once('viewport:load', (app) => {
 
     // Update camera selected title and active button
     editor.on('camera:change', (entity) => {
-        const guid = entity.getGuid();
+        const guid = entity.guid;
 
         viewportCamera.active = guid;
         clearRadioButtons();

--- a/src/editor/viewport/camera/camera-history.ts
+++ b/src/editor/viewport/camera/camera-history.ts
@@ -14,7 +14,7 @@ editor.once('load', () => {
             editor.call('camera:history:stop');
         }
 
-        const obj = editor.call('entities:get', entity.getGuid());
+        const obj = editor.call('entities:get', entity.guid);
         if (!obj) {
             return;
         }
@@ -45,7 +45,7 @@ editor.once('load', () => {
             }
         }
 
-        const obj = editor.call('entities:get', camera.getGuid());
+        const obj = editor.call('entities:get', camera.guid);
         if (!obj) {
             camera = null;
             return;

--- a/src/editor/viewport/camera/camera-userdata.ts
+++ b/src/editor/viewport/camera/camera-userdata.ts
@@ -32,7 +32,7 @@ editor.once('camera:load', () => {
                 }
             }
         } else if (!camera.__editorCamera) {
-            const obj = editor.call('entities:get', camera.getGuid());
+            const obj = editor.call('entities:get', camera.guid);
             if (!obj) {
                 return;
             }

--- a/src/editor/viewport/camera/camera.ts
+++ b/src/editor/viewport/camera/camera.ts
@@ -113,7 +113,7 @@ editor.once('load', () => {
                     });
                 };
 
-                const e = editor.call('entities:get', entity.getGuid());
+                const e = editor.call('entities:get', entity.guid);
                 if (e) {
                     evtLayersInsert = e.on('components.camera.layers:insert', fixLayers);
                     evtLayersRemove = e.on('components.camera.layers:remove', fixLayers);
@@ -151,11 +151,11 @@ editor.once('load', () => {
         });
 
         editor.method('camera:add', (entity: Entity) => {
-            if (camerasIndex[entity.getGuid()]) {
+            if (camerasIndex[entity.guid]) {
                 return;
             }
 
-            camerasIndex[entity.getGuid()] = entity;
+            camerasIndex[entity.guid] = entity;
 
             if (entity.camera) {
                 entity.camera.enabled = false;
@@ -166,11 +166,11 @@ editor.once('load', () => {
         });
 
         editor.method('camera:remove', (entity: Entity) => {
-            if (!camerasIndex[entity.getGuid()]) {
+            if (!camerasIndex[entity.guid]) {
                 return;
             }
 
-            delete camerasIndex[entity.getGuid()];
+            delete camerasIndex[entity.guid];
 
             if (entity === currentCamera) {
                 editor.call('camera:set');

--- a/src/editor/viewport/gizmo/gizmo-collision.ts
+++ b/src/editor/viewport/gizmo/gizmo-collision.ts
@@ -162,7 +162,7 @@ editor.once('load', () => {
                 this.type = type;
 
                 if (!this.color) {
-                    const guid = this._link.entity.getGuid();
+                    const guid = this._link.entity.guid;
                     let hash = 0;
                     for (const char of guid) {
                         hash += char.charCodeAt(0);

--- a/src/editor/viewport/gizmo/gizmo-zone.ts
+++ b/src/editor/viewport/gizmo/gizmo-zone.ts
@@ -321,7 +321,7 @@ editor.once('load', () => {
 
                     if (!this.color && this._link.entity) {
                         let hash = 0;
-                        const string = this._link.entity.getGuid();
+                        const string = this._link.entity.guid;
                         for (let i = 0; i < string.length; i++) {
                             hash += string.charCodeAt(i);
                         }

--- a/src/editor/viewport/viewport-drop-material.ts
+++ b/src/editor/viewport/viewport-drop-material.ts
@@ -115,7 +115,7 @@ editor.once('load', () => {
             node = node._getEntity();
         }
 
-        if (!node || !editor.call('entities:get', node.getGuid())) {
+        if (!node || !editor.call('entities:get', node.guid)) {
             onHover(null, null);
             return;
         }
@@ -159,7 +159,7 @@ editor.once('load', () => {
                 return;
             }
 
-            let entity = editor.call('entities:get', hoverEntity.getGuid());
+            let entity = editor.call('entities:get', hoverEntity.guid);
             if (!entity) {
                 return;
             }

--- a/src/editor/viewport/viewport-entities-create.ts
+++ b/src/editor/viewport/viewport-entities-create.ts
@@ -33,7 +33,7 @@ editor.once('load', () => {
         entitiesIndex[obj.get('resource_id')] = entity;
 
         entity.name = obj.get('name');
-        entity.setGuid(obj.get('resource_id'));
+        entity.guid = obj.get('resource_id');
         entity.setLocalPosition(obj.get('position.0'), obj.get('position.1'), obj.get('position.2'));
         entity.setLocalEulerAngles(obj.get('rotation.0'), obj.get('rotation.1'), obj.get('rotation.2'));
         entity.setLocalScale(obj.get('scale.0'), obj.get('scale.1'), obj.get('scale.2'));
@@ -50,10 +50,10 @@ editor.once('load', () => {
         // try to insert the node at the right index
         for (let i = 0, len = parent._children.length; i < len; i++) {
             const child = parent._children[i];
-            if (child instanceof Entity && childIndex[child.getGuid()]) {
+            if (child instanceof Entity && childIndex[child.guid]) {
                 // if our index is less than this child's index
                 // then put the item here
-                if (index < childIndex[child.getGuid()].index) {
+                if (index < childIndex[child.guid].index) {
                     parent.insertChild(node, i);
                     return;
                 }

--- a/src/editor/viewport/viewport-entities-elements.ts
+++ b/src/editor/viewport/viewport-entities-elements.ts
@@ -297,7 +297,7 @@ editor.once('load', () => {
                     // excluding a layout child from the layout
 
                     if (value === true && valueOld === false) {
-                        editor.call('entities:layout:storeLayout', [entity.entity.getGuid()]);
+                        editor.call('entities:layout:storeLayout', [entity.entity.guid]);
                     }
                 } else if (/^components.scrollbar.orientation/.test(path)) {
                     // switching the orientation of a scrollbar - we need to update the anchoring

--- a/src/editor/viewport/viewport-entities-observer-binding.ts
+++ b/src/editor/viewport/viewport-entities-observer-binding.ts
@@ -76,7 +76,7 @@ editor.once('load', () => {
                 // persist the positions and sizes of elements if they were previously
                 // under control of a layout group but have now been reparented
                 if (oldParent && oldParent.layoutgroup) {
-                    editor.call('entities:layout:storeLayout', [childEntity.entity.getGuid()]);
+                    editor.call('entities:layout:storeLayout', [childEntity.entity.guid]);
                 }
             }
         };

--- a/src/editor/viewport/viewport-pick.ts
+++ b/src/editor/viewport/viewport-pick.ts
@@ -156,7 +156,7 @@ editor.once('load', () => {
                     continue;
                 }
 
-                const guid = entity.getGuid();
+                const guid = entity.guid;
                 if (!seenGuids.has(guid)) {
                     seenGuids.add(guid);
                     entities.push(entity);

--- a/src/editor/viewport/viewport-tooltips.ts
+++ b/src/editor/viewport/viewport-tooltips.ts
@@ -44,7 +44,7 @@ editor.once('load', () => {
                 name = `${node.name} &#8594; ${picked.node.name}`;
             } else {
                 // normal entity
-                if (editor.call('entities:get', node.getGuid())) {
+                if (editor.call('entities:get', node.guid)) {
                     name = node.name;
                 }
             }

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -181,7 +181,7 @@ const entityRuntimeState = (e: any) => {
     const s = e.getLocalScale();
     const state: Record<string, any> = {
         name: e.name,
-        guid: e.getGuid(),
+        guid: e.guid,
         enabled: e.enabled,
         position: [round(p.x), round(p.y), round(p.z)],
         localPosition: [round(lp.x), round(lp.y), round(lp.z)],

--- a/src/launch/viewport/viewport-binding-entities.ts
+++ b/src/launch/viewport/viewport-binding-entities.ts
@@ -22,7 +22,7 @@ editor.once('load', () => {
     const createEntity = function (obj: Observer) {
         const entity = new pc.Entity(obj.get('name'));
 
-        entity.setGuid(obj.get('resource_id'));
+        entity.guid = obj.get('resource_id');
         entity.setLocalPosition(obj.get('position.0'), obj.get('position.1'), obj.get('position.2'));
         entity.setLocalEulerAngles(obj.get('rotation.0'), obj.get('rotation.1'), obj.get('rotation.2'));
         entity.setLocalScale(obj.get('scale.0'), obj.get('scale.1'), obj.get('scale.2'));


### PR DESCRIPTION
## Summary

Replaces all remaining uses of the deprecated `Entity#setGuid` (2 call sites) and `Entity#getGuid` (25 call sites) with the `Entity#guid` property, which the engine designates as the replacement:

https://github.com/playcanvas/engine/blob/main/src/framework/entity.js (`Debug.deprecated('Entity#setGuid is deprecated. Use Entity#guid instead.')`)

This removes the deprecation warning reported in the launch page viewport (fired from `viewport-binding-entities.ts`) and the equivalent warnings anywhere else the debug engine build runs, and future-proofs the Editor against eventual removal of the deprecated shims.

## Changes

- `entity.setGuid(x)` -> `entity.guid = x` (launch + editor viewport entity creation)
- `entity.getGuid()` -> `entity.guid` (25 sites across viewport, gizmos, cameras, picking, tooltips, MCP runtime)

Pure mechanical one-token replacements; 17 files, 27 lines.

## Verification

- `tsc`: no new errors — none of the repo's pre-existing type errors involve any changed line (both accessors are declared on the same class in the published engine types, so the swap is type-identical)
- `eslint` on all 17 changed files: 0 errors (32 pre-existing warnings at untouched lines)
- Diff reviewed hunk-by-hunk: every change is the intended one-token replacement

Fixes #2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)