### PR TITLE
fix: remove obsolete lightmap component properties

### DIFF
--- a/src/editor/entities/entities-migrations.ts
+++ b/src/editor/entities/entities-migrations.ts
@@ -12,6 +12,9 @@ import {
 
 import { formatter as f } from '@/common/utils';
 
+const LIGHTMAP_COMPONENTS = ['model', 'render'];
+const LEGACY_LIGHTMAP_PROPERTIES = ['castShadowsLightMap', 'lightMapped', 'lightMapSizeMultiplier'];
+
 editor.once('load', () => {
     /**
      * @param entity - The entity to migrate
@@ -27,6 +30,15 @@ editor.once('load', () => {
             }
 
             // components
+
+            for (const component of LIGHTMAP_COMPONENTS) {
+                for (const property of LEGACY_LIGHTMAP_PROPERTIES) {
+                    const path = `components.${component}.${property}`;
+                    if (entity.has(path)) {
+                        entity.unset(path);
+                    }
+                }
+            }
 
             // camera
             if (entity.has('components.camera')) {


### PR DESCRIPTION
Fixes #2172

### What’s Changed

- Remove stale `castShadowsLightMap`, `lightMapped`, and `lightMapSizeMultiplier` keys from model and render component data when scenes load.
- Preserve the valid lowercase properties while realtime sync persists the cleanup.

### Manual smoke test

1. Open a project containing the obsolete model or render component fields in the Editor.
2. Wait for realtime to connect, then reload the Editor or Launch page.
3. Confirm the three `addComponent: ignoring unknown option` warnings no longer appear and the lightmapping settings are unchanged.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)