### PR TITLE
fix(code-editor): switch tabs when a document was loaded twice

### DIFF
--- a/src/code-editor/documents/documents-load.ts
+++ b/src/code-editor/documents/documents-load.ts
@@ -50,6 +50,13 @@ editor.once('load', () => {
     // Loads the editable document that corresponds to the specified asset id
     const loadDocument = function (asset: Observer, importSubModules = true) {
         const id = asset.get('id').toString();
+
+        // already loading or loaded - re-subscribing an already loaded sharedb doc does not
+        // re-emit 'load', so a second entry would stay stuck loading and never focus
+        if (documentsIndex[id]) {
+            return;
+        }
+
         const uniqueId = asset.get('uniqueId').toString();
         const connection = editor.call('realtime:connection');
         const doc = connection.get('documents', uniqueId);
@@ -78,8 +85,8 @@ editor.once('load', () => {
                 return;
             }
 
-            // check if closed by the user
-            if (!documentsIndex[id]) {
+            // check if closed by the user or superseded by a newer entry
+            if (documentsIndex[id] !== entry) {
                 return;
             }
 


### PR DESCRIPTION
Fixes #2173

## Symptom

Clicking a script tab moves the focus highlight but Monaco keeps showing the previous file, and from then on that file can never be opened again for the rest of the session. Nothing appears in the console.

In the reporter's video the `cue-mesh.mjs` tab carries the focused underline while the editor still shows `custom.mjs`. When the other tab happens to be the temporary one, closing it blanks the editor instead, so you get a focused tab over an empty pane.

## Cause

When an ESM script's document loads, `documents-load.ts` walks its imports and loads them too so Monaco can resolve the dependency. That walk called `loadDocument` for every dependency unconditionally, including dependencies that were already open.

ShareDB only emits `load` when it first ingests a snapshot: `Doc.prototype.ingestSnapshot` returns early when `this.type` is already set, and `Connection.prototype.get` hands back the cached `Doc` rather than a fresh one. So the second `loadDocument` call replaced the index entry with a new one whose `isLoading` flag was never cleared.

`select:asset` only emits `documents:focus` when loading has finished, so the focus event never fired for that asset and `monaco/document.ts` never called `setModel`. The tab panel focuses the tab from its own `select:asset` handler regardless, which is why the UI looks like the click worked. Nothing was logged either, since the "Requested to focus document that has no view yet" warning sits downstream of the event that was missing.

Since only `documents:close` clears the index entry, the file stays unfocusable until its tab is closed — which is why it can look intermittent.

## Repro

Two `.mjs` scripts where one imports the other, e.g. a `custom.mjs` Script class that does `import { createMesh } from './cue-mesh.mjs'`.

1. Double-click `cue-mesh.mjs` in the Files panel. Double-click rather than single-click, so the tab is permanent and survives the next step.
2. Double-click `custom.mjs`. Its document loads, walks its imports, and calls `loadDocument` for `cue-mesh.mjs`, which is already open. That is the moment the dependency gets wedged.
3. Click the `cue-mesh.mjs` tab. The focus underline moves to it, the editor keeps showing `custom.mjs`.

Closing the `cue-mesh.mjs` tab and reopening it clears the state, since that is the only thing that removes the index entry.

The order matters: the dependency has to be open *before* the importer's document loads. Opening the importer first and the dependency second works fine, because at that point the dependency is loaded by the import walk itself rather than re-loaded.

## Fix

Bail out of `loadDocument` when the document is already in the index. Every caller routes through it — the `select:asset` path, the dependency walk, and `load:asset` from `asset:update-dependencies` — so one guard covers them all. This also removes the duplicate `error` and `load` listeners and the discarded `isDirty` state that the overwrite caused, and drops a redundant subscribe round-trip.

The load handler's staleness check changes from "the index holds something for this id" to "the index still holds *this* entry", so a handler left over from a closed document cannot write to the entry that replaced it.

The guard is safe because `documents:close` is the only thing that deletes from `documentsIndex`, and it disposes the matching `viewIndex` entry in `monaco/document.ts`, so the two indexes stay in sync — an id absent from the index genuinely needs loading. Reconnection re-subscribes existing docs through `realtime:authenticated`, which does not go through `loadDocument`.

## Testing

ESLint clean on the changed file, `tsc` reports nothing new there, and the 176 unit tests pass. No unit test added: `documents-load.ts` exports nothing and is driven by the global `editor` caller, and the suite currently only covers exported pure functions.

**Not yet verified in a running editor.** The analysis is static, against the ShareDB client source and the attached video, so the repro above is worth a manual pass before merge. The existing `test-suite` code-editor check only opens the code editor and asserts no console errors without opening a file, so CI does not cover this path.

## Follow-up, not in this PR

`monaco/sharedb.ts` attaches `doc.on('op')` and `doc.on('load')` in its `documents:load` handler but its `documents:close` handler only deletes the index entry, and ShareDB's `destroy` is deferred until its unsubscribe round-trip completes. Reopening a file inside that window resets `_wantsDestroy`, so `_destroyDoc` bails and the doc survives in the connection cache carrying listeners that point at a disposed Monaco model. That is a second route to the same stuck-tab symptom plus a possible throw on the next remote op, and fixing it means changing that module's teardown.
