### PR TITLE
fix(code-editor): do not reload a document sharedb is still destroying

### DIFF
--- a/src/code-editor/documents/documents-load.ts
+++ b/src/code-editor/documents/documents-load.ts
@@ -43,6 +43,10 @@ editor.once('load', () => {
     // becomes available for example
     const queuedLoad = {};
 
+    // docs that sharedb is still tearing down, holding any load
+    // request that arrived during that - see 'documents:close'
+    const destroying = {};
+
     // the last document id the
     // user requested to focus
     let lastFocusedId = null;
@@ -54,6 +58,14 @@ editor.once('load', () => {
         // already loading or loaded - re-subscribing an already loaded sharedb doc does not
         // re-emit 'load', so a second entry would stay stuck loading and never focus
         if (documentsIndex[id]) {
+            return;
+        }
+
+        // sharedb destroys a doc asynchronously, so loading it again now would be handed the
+        // old doc back instead of a fresh one. wait for the teardown to finish
+        if (destroying[id]) {
+            destroying[id].asset = asset;
+            destroying[id].importSubModules = importSubModules;
             return;
         }
 
@@ -181,13 +193,33 @@ editor.once('load', () => {
     editor.on('documents:close', (id: string) => {
         const entry = documentsIndex[id];
         if (entry) {
-            entry.doc.unsubscribe();
-            entry.doc.destroy();
             delete documentsIndex[id];
+
+            // sharedb defers the destroy until the unsubscribe completes, and hands the doc
+            // back to anything that asks for it in the meantime, so gate reloads until it is
+            // really gone
+            const pending: { asset?: Observer; importSubModules?: boolean } = {};
+            destroying[id] = pending;
+
+            entry.doc.unsubscribe();
+            entry.doc.destroy((err: unknown) => {
+                delete destroying[id];
+
+                if (err) {
+                    log.error(err);
+                }
+
+                if (pending.asset) {
+                    loadDocument(pending.asset, pending.importSubModules);
+                }
+            });
 
             // send close message to update whoisonline for document
             const connection = editor.call('realtime:connection');
             connection.socket.send(`close:document:${entry.uniqueId}`);
+        } else if (destroying[id]) {
+            // closed again before the teardown finished - drop the queued reload
+            delete destroying[id].asset;
         }
 
         // stop any queued load events

--- a/src/code-editor/monaco/sharedb.ts
+++ b/src/code-editor/monaco/sharedb.ts
@@ -418,40 +418,43 @@ editor.once('load', () => {
             forceConcatenate: false, // if true then the last two ops will be concatenated
             lastChangedLine: null,
             changedLine: null,
-            ignoreLocalChanges: false // do not send ops to sharedb while true
+            ignoreLocalChanges: false, // do not send ops to sharedb while true
+
+            // mark document as dirty on every op
+            onDocOp: (ops, local) => {
+                if (!local) {
+                    entry.context._onOp(ops);
+                }
+
+                if (!docEntry.isDirty) {
+                    docEntry.isDirty = true;
+                    editor.emit('documents:dirty', docEntry.id, true);
+                }
+
+                if (local && !docEntry.hasLocalChanges) {
+                    docEntry.hasLocalChanges = true;
+                    editor.emit('documents:dirtyLocal', docEntry.id, true);
+                }
+            },
+
+            // resync monaco after a rollback+fetch cycle
+            onDocLoad: () => {
+                if (!entry.doc.type) {
+                    return;
+                }
+
+                entry.ignoreLocalChanges = true;
+                entry.view.setValue(entry.doc.data || '');
+                entry.ignoreLocalChanges = false;
+
+                // stale undo/redo references pre-rollback state
+                entry.undo.length = 0;
+                entry.redo.length = 0;
+            }
         };
 
-        // mark document as dirty on every op
-        doc.on('op', (ops, local) => {
-            if (!local) {
-                entry.context._onOp(ops);
-            }
-
-            if (!docEntry.isDirty) {
-                docEntry.isDirty = true;
-                editor.emit('documents:dirty', docEntry.id, true);
-            }
-
-            if (local && !docEntry.hasLocalChanges) {
-                docEntry.hasLocalChanges = true;
-                editor.emit('documents:dirtyLocal', docEntry.id, true);
-            }
-        });
-
-        // resync monaco after a rollback+fetch cycle
-        doc.on('load', () => {
-            if (!entry.doc.type) {
-                return;
-            }
-
-            entry.ignoreLocalChanges = true;
-            entry.view.setValue(entry.doc.data || '');
-            entry.ignoreLocalChanges = false;
-
-            // stale undo/redo references pre-rollback state
-            entry.undo.length = 0;
-            entry.redo.length = 0;
-        });
+        doc.on('op', entry.onDocOp);
+        doc.on('load', entry.onDocLoad);
 
         // add to index
         documentIndex[asset.get('id')] = entry;
@@ -530,6 +533,14 @@ editor.once('load', () => {
     editor.on('documents:close', (id: string) => {
         if (focusedDocument === documentIndex[id]) {
             focusedDocument = null;
+        }
+
+        // detach from the doc - it can outlive this close, and these handlers write into
+        // a monaco model that is disposed on close
+        const entry = documentIndex[id];
+        if (entry) {
+            entry.doc.removeListener('op', entry.onDocOp);
+            entry.doc.removeListener('load', entry.onDocLoad);
         }
 
         delete documentIndex[id];


### PR DESCRIPTION
Follow-up to #2181, which fixed the deterministic half of #2173. This closes the timing-dependent half, the one flagged as out of scope there.

Stacked on `main` rather than on the previous branch, since #2181 is already merged.

## Cause

`documents:close` calls `doc.unsubscribe()` then `doc.destroy()`. ShareDB defers the destroy through `whenNothingPending` until the unsubscribe round-trip returns. Reopening the same file inside that window goes through `Connection#get`, which resets `_wantsDestroy` to false and hands back the cached doc, so the eventual `_destroyDoc` bails on `if (!doc._wantsDestroy) return` and the doc survives in the connection cache.

Three failures follow from that surviving doc.

**Stuck tab.** It already holds data, and ShareDB only emits `load` on first ingest, so the reopened document sits in the index with `isLoading` true and its tab can never be focused. Same symptom as #2173, different route.

**Silent desync.** The deferred destroy callback then sees `wantSubscribe` true again after the reopen and issues a second `unsubscribe` before bailing out of `_destroyDoc`. The reopened document is left cached but unsubscribed, so remote edits stop arriving with nothing logged.

**`Model is disposed!`** `monaco/sharedb.ts` attaches `doc.on('op')` and `doc.on('load')` in its `documents:load` handler and never detaches them, while `monaco/document.ts` disposes the Monaco model on close. ShareDB does not remove listeners on destroy either — `_destroyDoc` only emits `destroy`. So the stale handlers drive `applyEdits` / `setValue` on a disposed model, which throws from `TextModel._assertNotDisposed`.

## Fix

Gate reloads on the teardown instead of racing it. `documents-load.ts` tracks the docs ShareDB is destroying, parks a load request that arrives for one, and runs it from the destroy callback once the doc is really gone. A close arriving while a reload is parked drops it, so closing a tab you just reopened doesn't leave an orphan document. Reopening always gets a fresh doc, so none of the three failures can occur.

The tab still appears immediately with its loading progress while the teardown finishes, because the tab panel keys that off `documents:get` returning nothing. The added wait is bounded by the unsubscribe round-trip, and only in the reopen-during-teardown case; a fresh open already needs a subscribe round-trip before it can show content.

Separately, `monaco/sharedb.ts` now detaches its `op` and `load` handlers when a document closes, mirroring where they're attached. The handlers move into the entry so `documents:close` can remove them; their bodies are unchanged.

## Residual, deliberately not handled

If `doc.destroy()` calls back with an error the unsubscribe failed, `_destroyDoc` never runs and the doc is still resurrected. The parked reload then runs against it and that document stays stuck loading, as it does today. The listener detach above is what keeps that path from also throwing, so the failure mode is a file that won't open rather than an exception into a disposed model. Handling it properly means driving the load path for a doc that already holds data, which is a bigger change and wants a repro first.

If the socket never returns, the destroy callback never fires and a parked reload never runs. That only applies while realtime is down, when the editor already blocks document loading behind `errors:hasRealtime`.

## Testing

ESLint clean on both files. `tsc` reports 19 errors in `monaco/sharedb.ts` and 0 in `documents/documents-load.ts`, identical to the counts on `main` before this change, so nothing new. The 176 unit tests pass.

**Not verified in a running editor**, same caveat as #2181: this comes from reading the ShareDB and Monaco sources. A repro needs a close and reopen of the same file within one unsubscribe round-trip, which is easiest to force by throttling the websocket or by adding a temporary delay before the reopen. Worth confirming before merge, and worth checking that ordinary tab churn — preview tabs, `Navigate` cycling, fuzzy-search jumps — still opens files normally, since every close now routes through the new gate.
