### PR TITLE
chore(deps): guard against unavailable patch updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "monaco-themes": "0.4.8",
                 "ot-text": "github:playcanvas/ot-text",
                 "playcanvas": "2.21.2",
-                "postcss": "8.5.24",
+                "postcss": "8.5.23",
                 "prettier": "3.9.4",
                 "rollup": "4.59.0",
                 "rollup-plugin-polyfill-node": "0.13.0",
@@ -9424,9 +9424,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.24",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
         "playcanvas": "2.21.2",
-        "postcss": "8.5.24",
+        "postcss": "8.5.23",
         "prettier": "3.9.4",
         "rollup": "4.59.0",
         "rollup-plugin-polyfill-node": "0.13.0",

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,10 @@
             "schedule": ["on monday at 10:00am"]
         },
         {
+            "matchUpdateTypes": ["patch"],
+            "minimumReleaseAge": "1 day"
+        },
+        {
             "matchManagers": ["npm", "dockerfile"],
             "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
             "groupName": "playwright",


### PR DESCRIPTION
### What's Changed

- Pin PostCSS to 8.5.23, the latest 8.5.x available from Snap's internal registry.
- Wait one day before Renovate proposes patch updates.

### Manual smoke test

1. Trigger Renovate while an npm patch release is less than 24 hours old; confirm no update PR includes it.
2. Trigger Renovate after the release is at least 24 hours old; confirm it becomes eligible for the scheduled npm update group.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
