### PR TITLE
chore(deps): bump playcanvas to 2.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "monaco-editor": "0.47.0",
                 "monaco-themes": "0.4.8",
                 "ot-text": "github:playcanvas/ot-text",
-                "playcanvas": "2.21.2",
+                "playcanvas": "2.21.3",
                 "postcss": "8.5.23",
                 "prettier": "3.9.4",
                 "rollup": "4.59.0",
@@ -9401,9 +9401,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.21.2",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.21.2.tgz",
-            "integrity": "sha512-8g7ny23jP2+SbnKmgCfphcI75nUDS49b29Ha4nEj/XgyulOvzutdUGCuabHIj9rHkx6KT9mlObNyJtvKWhogsg==",
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.21.3.tgz",
+            "integrity": "sha512-+AKl0yeNUBo9JSjMRNi2Sz24KhWDhBVMtvhonbeRnKD6FGhNK0O76zvqOu3zgXZxUEzF54h4QGpruhNUkKvsUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.21.2",
+        "playcanvas": "2.21.3",
         "postcss": "8.5.23",
         "prettier": "3.9.4",
         "rollup": "4.59.0",


### PR DESCRIPTION
### What's Changed

- Bump the PlayCanvas engine from 2.21.2 to 2.21.3.

### Manual smoke test

1. Open an existing project and scene in the Editor.
2. Confirm the scene renders in the viewport and launches without engine errors.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)