### PR TITLE
feat: add Antigravity IDE external editor support

### DIFF
--- a/src/code-editor/assets/assets.ts
+++ b/src/code-editor/assets/assets.ts
@@ -198,7 +198,7 @@ editor.once('load', () => {
     editor.method('assets:getByVirtualPath', (path: string) => assetToVirtualPath.get(path));
 
     // get asset ide path
-    editor.method('assets:idePath', (ide: 'cursor' | 'vscode', asset?: Observer) => {
+    editor.method('assets:idePath', (ide: 'cursor' | 'vscode' | 'antigravity-ide', asset?: Observer) => {
         const assetPath = asset ? `/asset/${asset.get('id')}` : '';
         return `${ide}://playcanvas.playcanvas/project/${config.project.id}${assetPath}`;
     });

--- a/src/editor/assets/assets-context-menu.ts
+++ b/src/editor/assets/assets-context-menu.ts
@@ -583,6 +583,15 @@ editor.once('load', () => {
     });
     menu.append(menuItemEditCursor);
 
+    const menuItemEditAntigravity = new MenuItem({
+        text: `${writeLabel} in Antigravity IDE`,
+        icon: ICONS.EDIT,
+        onSelect: () => {
+            editor.call('assets:edit', currentAsset, 'antigravity-ide');
+        }
+    });
+    menu.append(menuItemEditAntigravity);
+
     // duplicate
     const menuItemDuplicate = new MenuItem({
         text: 'Duplicate',
@@ -738,6 +747,7 @@ editor.once('load', () => {
                 menuItemEditWeb.hidden = true;
                 menuItemEditVSCode.hidden = true;
                 menuItemEditCursor.hidden = true;
+                menuItemEditAntigravity.hidden = true;
                 if (editor.call('selector:type') === 'asset') {
                     const items = editor.call('selector:items');
                     menuItemDuplicate.hidden = items.length > 1 && items.indexOf(currentAsset) !== -1;
@@ -759,15 +769,18 @@ editor.once('load', () => {
                     menuItemEditWeb.hidden = editHidden;
                     menuItemEditVSCode.hidden = editHidden;
                     menuItemEditCursor.hidden = editHidden;
+                    menuItemEditAntigravity.hidden = editHidden;
                 } else {
                     menuItemEditWeb.hidden = false;
                     menuItemEditVSCode.hidden = false;
                     menuItemEditCursor.hidden = false;
+                    menuItemEditAntigravity.hidden = false;
                 }
             } else {
                 menuItemEditWeb.hidden = true;
                 menuItemEditVSCode.hidden = true;
                 menuItemEditCursor.hidden = true;
+                menuItemEditAntigravity.hidden = true;
             }
 
             // create atlas
@@ -951,6 +964,7 @@ editor.once('load', () => {
             menuItemEditWeb.hidden = true;
             menuItemEditVSCode.hidden = true;
             menuItemEditCursor.hidden = true;
+            menuItemEditAntigravity.hidden = true;
             menuItemDelete.hidden = true;
             menuItemReferences.hidden = true;
             menuItemReplace.hidden = true;

--- a/src/editor/assets/assets.ts
+++ b/src/editor/assets/assets.ts
@@ -124,7 +124,7 @@ editor.once('load', () => {
     });
 
     // get asset ide path
-    editor.method('assets:idePath', (ide: 'cursor' | 'vscode', asset?: AssetObserver) => {
+    editor.method('assets:idePath', (ide: 'cursor' | 'vscode' | 'antigravity-ide', asset?: AssetObserver) => {
         const assetPath = asset ? `/asset/${asset.get('id')}` : '';
         return `${ide}://playcanvas.playcanvas/project/${config.project.id}${assetPath}`;
     });

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -417,6 +417,11 @@ class AssetInspector extends Container {
                     text: `${writeLabel} in Cursor`,
                     icon: 'E130',
                     onSelect: () => editor.call('assets:edit', this._assets[0], 'cursor')
+                },
+                {
+                    text: `${writeLabel} in Antigravity IDE`,
+                    icon: 'E130',
+                    onSelect: () => editor.call('assets:edit', this._assets[0], 'antigravity-ide')
                 }
             ]
         });

--- a/src/editor/inspector/settings-panels/editor.ts
+++ b/src/editor/inspector/settings-panels/editor.ts
@@ -277,6 +277,10 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
                 {
                     v: 'cursor',
                     t: 'Cursor'
+                },
+                {
+                    v: 'antigravity-ide',
+                    t: 'Antigravity IDE'
                 }
             ]
         }

--- a/src/editor/toolbar/toolbar-code-editor.ts
+++ b/src/editor/toolbar/toolbar-code-editor.ts
@@ -25,7 +25,7 @@ editor.once('load', () => {
         (asset?: Observer, options?: Record<string, unknown>, popup?: boolean, ideOverride?: string) => {
             // open the code editor external editor
             const ide = ideOverride || projectUserSettings.get('editor.codeEditor');
-            if (ide === 'vscode' || ide === 'cursor') {
+            if (ide === 'vscode' || ide === 'cursor' || ide === 'antigravity-ide') {
                 if (asset) {
                     window.open(editor.call('assets:idePath', ide, asset));
                     return;

--- a/src/launch/assets/assets.ts
+++ b/src/launch/assets/assets.ts
@@ -86,7 +86,7 @@ editor.once('load', () => {
     });
 
     // get asset ide path
-    editor.method('assets:idePath', (ide: 'cursor' | 'vscode', asset) => {
+    editor.method('assets:idePath', (ide: 'cursor' | 'vscode' | 'antigravity-ide', asset) => {
         return `${ide}://playcanvas.playcanvas/project/${config.project.id}/asset/${asset.get('id')}`;
     });
 });

--- a/src/launch/viewport/viewport-error-console.ts
+++ b/src/launch/viewport/viewport-error-console.ts
@@ -115,7 +115,8 @@ editor.once('load', () => {
                     assetId = parseInt(match[1], 10);
                     switch (ide) {
                         case 'vscode':
-                        case 'cursor': {
+                        case 'cursor':
+                        case 'antigravity-ide': {
                             const asset = editor.call('assets:get', assetId);
                             target = `${ide}:${config.project.id}`;
                             codeEditorUrl = editor.call('assets:idePath', ide, asset);
@@ -157,7 +158,7 @@ editor.once('load', () => {
             if (assetId) {
                 const link = document.getElementById(`error-${errorCount}`);
                 link.addEventListener('click', (e: MouseEvent) => {
-                    if (ide === 'vscode' || ide === 'cursor') {
+                    if (ide === 'vscode' || ide === 'cursor' || ide === 'antigravity-ide') {
                         window.open(codeEditorUrl + query, target);
                         return;
                     }


### PR DESCRIPTION
 ### What's Changed

  - Added **Antigravity IDE** (`antigravity-ide:`) as an external code editor option alongside VS Code and Cursor.
  - Added `Antigravity IDE` option to the Code Editor setting dropdown in user settings (`editor.codeEditor`).
  - Updated `assets:idePath` handlers to construct `antigravity-ide://` protocol URLs for script assets.
  - Added "Edit/View in Antigravity IDE" options to asset context menus and inspector dropdowns.
  - Updated launch error console and toolbar editor dispatchers to handle `antigravity-ide`.

  ### Checks

  - [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

  ### Screenshots:
    
<img width="323" height="1388" alt="image" src="https://github.com/user-attachments/assets/b852a209-5fda-4d08-99ab-738098b2db3e" />
