### PR TITLE
fix(fonts): msdf atlas settings, and give the font ownership of mirror preload

### DIFF
--- a/src/common/referenced-font-handler.ts
+++ b/src/common/referenced-font-handler.ts
@@ -124,6 +124,8 @@ class ReferencedFontHandler extends FontHandler {
                 // the stock font handler forces on its atlas: srgb corrupts the median distance
                 // reconstruction (broken corners/thin strokes), and mipmaps bleed glyphs together at small
                 // sizes, both of which read as "the font looks wrong" with no obvious cause.
+                // a no-op for generated pages, which carry MSDF_ATLAS_DATA already; this is here for an
+                // atlas the user repointed at a texture of their own.
                 textures.forEach((t: any) => {
                     if (t) {
                         t.srgb = false;

--- a/src/editor/assets/assets-font-import.ts
+++ b/src/editor/assets/assets-font-import.ts
@@ -17,6 +17,14 @@ type FontDataV3 = {
 // how long to wait for a created asset to arrive over realtime before giving up
 const ASSET_ADD_TIMEOUT = 30000;
 
+// an msdf atlas is a distance field, not colour: mipmaps and srgb both corrupt the median. set at
+// create so the texture is built right — flipping mipmaps later re-creates it on webgpu
+const MSDF_ATLAS_DATA = {
+    mipmaps: false,
+    srgb: false,
+    minfilter: 'linear'
+};
+
 const DEFAULT_CHARS = (() => {
     let s = '';
     for (let i = 0x20; i <= 0x7e; i++) {
@@ -100,9 +108,8 @@ editor.once('load', () => {
                   filename: `${base}.json`,
                   source_asset_id: `${sourceId}`,
                   parent,
-                  // not preloaded: the font's own load resolves and loads this, so it arrives either
-                  // way. preloading it alongside the atlas pages would only pull the fetch earlier
-                  preload: false
+                  // matches the font, which is created preloaded; watchFont keeps them in step after
+                  preload: true
               });
 
         const ids = font?.get('data.textureAssets') || [];
@@ -121,7 +128,14 @@ editor.once('load', () => {
                 const name = i === 0 ? `${base}.png` : `${base}${i}.png`;
                 const file = new Blob([bytes as BlobPart], { type: 'image/png' });
                 return asset
-                    ? updateFile(asset, file, asset.get('name'), true).then(() => asset.get('id'))
+                    ? updateFile(asset, file, asset.get('name'), true).then(() => {
+                          // this page may be a texture the user repointed the picker at, carrying its
+                          // own colour settings. it holds the atlas now, so it gets the atlas settings
+                          Object.entries(MSDF_ATLAS_DATA).forEach(([key, value]) => {
+                              asset.set(`data.${key}`, value);
+                          });
+                          return asset.get('id');
+                      })
                     : createAsset({
                           name,
                           type: 'texture',
@@ -130,7 +144,9 @@ editor.once('load', () => {
                           source_asset_id: `${sourceId}`,
                           parent,
                           noConvert: true,
-                          preload: true
+                          // matches the font, which is created preloaded; watchFont keeps them in step
+                          preload: true,
+                          data: MSDF_ATLAS_DATA
                       });
             })
         );
@@ -205,14 +221,31 @@ editor.once('load', () => {
             return;
         }
 
+        const mirrorIds = () =>
+            [asset.get('data.jsonAsset'), ...(asset.get('data.textureAssets') || [])].filter(Boolean);
+
         let watches: any[] = [];
         const sync = () => {
             watches.forEach((h) => h.off());
-            watches = [asset.get('data.jsonAsset'), ...(asset.get('data.textureAssets') || [])]
-                .filter(Boolean)
-                .map((ref: number) => app.assets.on(`load:${ref}`, () => reloadFont(asset)));
+            watches = mirrorIds().map((ref: number) => app.assets.on(`load:${ref}`, () => reloadFont(asset)));
         };
         sync();
+
+        // the font decides whether its descriptor and atlas are preloaded, so its flag is written
+        // through to them. their own is not user-editable, and a stale value would either waste a
+        // boot download or under-report what the loading bar is waiting on. writes only on a real
+        // difference, so this is a no-op once they agree and self-heals a repoint or a merge
+        const syncPreload = () => {
+            const preload = asset.get('preload');
+            mirrorIds().forEach((ref: number) => {
+                const mirror = editor.call('assets:get', ref);
+                if (mirror && mirror.get('preload') !== preload) {
+                    mirror.set('preload', preload);
+                }
+            });
+        };
+        syncPreload();
+        const preloadEvent = asset.on('preload:set', syncPreload);
 
         // the texture list is edited as an array, so element writes, length changes and reordering all
         // matter (chars[].map indexes into page order). the observer has no mid-path wildcard, so listen
@@ -223,6 +256,7 @@ editor.once('load', () => {
                     return;
                 }
                 sync();
+                syncPreload();
                 reloadFont(asset);
             })
         );
@@ -230,6 +264,7 @@ editor.once('load', () => {
         watched.set(id, () => {
             watches.forEach((h) => h.off());
             events.forEach((e) => e.unbind());
+            preloadEvent.unbind();
         });
     };
 
@@ -296,6 +331,19 @@ editor.once('load', () => {
         importFont(file, folder).catch((err) => {
             editor.call('status:error', `Font import failed: ${err?.message ?? err}`);
         });
+    });
+
+    // is this asset serving purely as a font's descriptor/atlas right now? keyed off live references
+    // rather than source_asset_id, so clearing a picker hands the asset back: an unreferenced page is
+    // no longer a mirror. a page shared with e.g. a material also fails, since that use is its own
+    editor.method('fonts:isMirror', (asset: any) => {
+        const type = asset?.get('type');
+        if (type !== 'json' && type !== 'texture') {
+            return false;
+        }
+        const refs = editor.call('assets:used:index')[asset.get('id')]?.ref;
+        const referers = refs ? Object.keys(refs) : [];
+        return referers.length > 0 && referers.every((id) => editor.call('assets:get', id)?.get('type') === 'font');
     });
 
     // generate references for old fonts or refresh them for referenced fonts

--- a/src/editor/inspector/asset.ts
+++ b/src/editor/inspector/asset.ts
@@ -636,6 +636,19 @@ class AssetInspector extends Container {
         this._btnOpenInViewer.hidden = !allModel && !allTexture;
     }
 
+    // a font loads its descriptor and atlas itself, so their own preload does nothing — the font's
+    // flag is the only one that decides, as it was when a font was a single asset. shown but disabled,
+    // and it comes back as soon as the asset stops being a font's mirror
+    _updatePreloadField() {
+        const field = this._attributesInspector.getField('preload');
+        if (!field) {
+            return;
+        }
+        const isMirror = !!this._assets?.length && this._assets.every((a) => editor.call('fonts:isMirror', a));
+        field.enabled = !isMirror;
+        field.parent.class[isMirror ? 'add' : 'remove']('pcui-disabled');
+    }
+
     _updateDownloadButton() {
         let disabled = false;
         let hidden = false;
@@ -812,6 +825,9 @@ class AssetInspector extends Container {
 
         // Determine the open in viewer button state
         this._updateOpenInViewerButton();
+
+        // Determine whether preload is the font's to decide rather than this asset's
+        this._updatePreloadField();
 
         if (assets[0].get('type') === 'cubemap') {
             this._updateDownloadButton.bind(this)();


### PR DESCRIPTION
Follow-up to #2190. Two problems with the json/texture assets a client-imported font references.

## The atlas was created with colour-texture settings

An atlas page was created as a plain texture asset with no `data` of its own, so it inherited the defaults for colour data: `mipmaps: true`, `srgb: true`, `minfilter: linear_mip_linear`. All three are wrong for a distance field. Mip levels box-average the r/g/b channels and `median(average) != average(median)`, so minified text samples a corrupted median; sRGB gamma corrupts it the same way. This is the same reasoning as playcanvas/engine#8997.

`ReferencedFontHandler` already forced the right values on the loaded texture, so output was correct — but it was correcting rather than preventing. The texture was built with an 11-level mip chain and an sRGB format and then changed, and on WebGPU changing `mipmaps` re-creates the texture, because the mip count is baked into the immutable descriptor (playcanvas/engine#9003). The asset data also misreported what the font actually uses, so the inspector showed settings that had no effect and a user toggling them changed nothing.

Pages are now created with `mipmaps: false, srgb: false, minfilter: linear`. The handler keeps forcing them, now as a no-op for generated pages and a safety net for an atlas repointed at a texture of the user's own.

## The font did not own its mirrors' preload

A legacy font was a single asset with a single Preload checkbox, and it governed the descriptor and atlas because those were files inside it. Unpacking them into real assets split that into three independent checkboxes, two of which a user has no way to reason about: the font's own load resolves and loads both mirrors, so their flags only ever agreed with the font by luck. Unticking the font while a page stayed ticked left the atlas downloading at boot for a font nobody preloaded, with no feedback.

The font's preload is now written through to the descriptor and every atlas page, on change and on repoint, and their own field is disabled in the inspector while they serve it. It writes only on a real difference, so it is a no-op once they agree and self-heals a repoint or a merge.

Ownership is keyed on **live references** rather than on how the asset was created, so it ends when the link does:

- clear a picker, and the asset gets its field back
- a page also used by something else, a material map say, keeps its field, because that use has its own reason to preload

The field is disabled rather than hidden so the inherited value stays visible.

## Verification

Driven against a local backend with the editor served locally.

Atlas settings, on WebGL2 and WebGPU: the atlas reports `mipLevelCount: 1` with zero `mipmaps` transitions and a single `recreateImpl` (the constructor's own), where before it needed one re-create for the mip count and another for the format switch. No engine warnings.

| Action | font / json / atlas | mirror field |
| --- | --- | --- |
| Fresh import | true / true / true | disabled |
| Untick the font | false / false / false | disabled |
| Re-tick | true / true / true | disabled |
| Clear the json reference | json keeps its value | enabled |
| Untick font while unlinked | json untouched | enabled |
| Atlas also used by a material | — | enabled |

Legacy conversion: a server-pipeline font set to `preload: false` converts to mirrors that are also `preload: false`, with the atlas settings applied, 95 glyphs, and `numLevels: 1` at runtime. `meta.chars` preserved.

Also confirmed the timing assumption behind all of this: the descriptor and atlas requests start 0.2 ms apart, and the font's own placeholder file is never fetched, so nothing serialises behind it.

A matching backend change, so that a texture uploaded with `noConvert` still gets thumbnails generated, ships separately.