### PR TITLE
Consume versioned JSON-Schema editor catalog

### DIFF
--- a/src/editor-api/entities/copy.ts
+++ b/src/editor-api/entities/copy.ts
@@ -1,8 +1,8 @@
 import type { Entity } from '../entity';
 import { globals as api } from '../globals';
+import { utils } from '../utils';
 
 let ASSET_PATHS: string[] = null;
-const REGEX_CONTAINS_STAR = /\.\*\./;
 
 /**
  * Stores asset paths in the assets dictionary by converting the array of
@@ -79,40 +79,10 @@ function gatherDependencies(entity: Entity, data: Record<string, any>) {
     // and store their path + name
     for (let i = 0; i < ASSET_PATHS.length; i++) {
         const path = ASSET_PATHS[i];
-        // handle paths that contain a '*' as a wildcard
-        if (REGEX_CONTAINS_STAR.test(path)) {
-            const parts = path.split('.*.');
-            if (!entity.has(parts[0])) {
-                continue;
-            }
-
-            const obj = entity.get(parts[0]);
-            if (!obj) {
-                continue;
-            }
-
-            for (const key in obj) {
-                const fullKey = `${parts[0]}.${key}.${parts[1]}`;
-                if (!entity.has(fullKey)) {
-                    continue;
-                }
-
-                const assets = entity.get(fullKey);
-                if (!assets) {
-                    continue;
-                }
-
-                storeAssetPaths(assets, data.assets);
-            }
-        } else if (entity.has(path)) {
-            // handle path without '*'
+        utils.expandPath(entity, path, (entity, path) => {
             const assets = entity.get(path);
-            if (!assets) {
-                continue;
-            }
-
-            storeAssetPaths(assets, data.assets);
-        }
+            if (assets) storeAssetPaths(assets, data.assets);
+        });
     }
 
     // gather script attributes

--- a/src/editor-api/entities/paste.ts
+++ b/src/editor-api/entities/paste.ts
@@ -4,10 +4,10 @@ import type { EventHandle } from '@playcanvas/observer';
 import type { Entity } from '../entity';
 import { globals as api } from '../globals';
 import { Guid } from '../guid';
+import { utils } from '../utils';
 
 const USE_BACKEND_LIMIT = 500;
 const TIME_WAIT_ENTITIES = 5000;
-const REGEX_CONTAINS_STAR = /\.\*\./;
 
 let ASSET_PATHS: any[];
 let evtMessenger: EventHandle;
@@ -103,42 +103,9 @@ function mapValue(value: string, mapping: Record<string, any>, sameProject: bool
 }
 
 function remapField(entity: Entity, path: string, mapping: Record<string, any>, sameProject: boolean) {
-    if (REGEX_CONTAINS_STAR.test(path)) {
-        const parts = path.split('.*.');
-        if (!entity.has(parts[0])) {
-            return;
-        }
-
-        const obj = entity.get(parts[0]);
-        if (!obj) {
-            return;
-        }
-
-        for (const key in obj) {
-            const fullKey = `${parts[0]}.${key}.${parts[1]}`;
-            if (!entity.has(fullKey)) {
-                continue;
-            }
-
-            const value = entity.get(fullKey);
-            if (!value) {
-                continue;
-            }
-
-            if (value instanceof Array) {
-                for (let j = 0; j < value.length; j++) {
-                    value[j] = mapValue(value[j], mapping, sameProject);
-                }
-                entity.set(fullKey, value);
-            } else {
-                entity.set(fullKey, mapValue(value, mapping, sameProject));
-            }
-        }
-    } else if (entity.has(path)) {
+    utils.expandPath(entity, path, (entity, path) => {
         const value = entity.get(path);
-        if (!value) {
-            return;
-        }
+        if (!value) return;
 
         if (value instanceof Array) {
             for (let j = 0; j < value.length; j++) {
@@ -148,7 +115,7 @@ function remapField(entity: Entity, path: string, mapping: Record<string, any>, 
         } else {
             entity.set(path, mapValue(value, mapping, sameProject));
         }
-    }
+    });
 }
 
 function remapScriptAttribute(

--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -91,12 +91,18 @@ type Sentry =
           enabled: false;
       };
 
-type ModelSchema = {
-    scene: object;
-    settings: object;
-    asset: object;
-    [key: string]: object;
+type EditorSchemaCatalog = {
+    version: 0;
+    documents: {
+        asset: Record<string, unknown>;
+        scene: Record<string, unknown>;
+        settings: Record<string, unknown>;
+    };
+    assetData: Record<string, Record<string, unknown>>;
+    [key: string]: unknown;
 };
+
+type ModelSchema = EditorSchemaCatalog;
 
 type Url = {
     api: string;

--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -92,7 +92,7 @@ type Sentry =
       };
 
 type EditorSchemaCatalog = {
-    version: 0;
+    version: 1;
     documents: {
         asset: Record<string, unknown>;
         scene: Record<string, unknown>;

--- a/src/editor-api/schema.ts
+++ b/src/editor-api/schema.ts
@@ -41,7 +41,7 @@ class Schema {
             throw new Error('Invalid Editor schema payload');
         }
 
-        if (schema.version !== 0 || !isObject(schema.documents) || !isObject(schema.assetData)) {
+        if (schema.version !== 1 || !isObject(schema.documents) || !isObject(schema.assetData)) {
             throw new Error(`Unsupported Editor schema version: ${String(schema.version)}`);
         }
 
@@ -106,7 +106,8 @@ class Schema {
 
     getMapValue(field: unknown) {
         if (!isObject(field)) return null;
-        if (isObject(field.additionalProperties)) return field.additionalProperties;
+        const value = jsonValue(field);
+        if (isObject(value) && isObject(value.additionalProperties)) return value.additionalProperties;
         return null;
     }
 

--- a/src/editor-api/schema.ts
+++ b/src/editor-api/schema.ts
@@ -3,11 +3,27 @@ import { ComponentSchema } from './schema/components';
 import { SceneSchema } from './schema/scene';
 import { SettingsSchema } from './schema/settings';
 
+type Field = Record<string, unknown>;
+
+const isObject = (value: unknown): value is Field => {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+};
+
+const jsonValue = (field: unknown) => {
+    let value = field;
+    while (isObject(value) && Array.isArray(value.anyOf)) {
+        const next = value.anyOf.find((item) => isObject(item) && item.type !== 'null');
+        if (!next) break;
+        value = next;
+    }
+    return value;
+};
+
 /**
  * Provides methods to access the Editor schema.
  */
 class Schema {
-    private _schema: any;
+    private _schema: Field;
 
     private _assetsSchema: AssetsSchema;
 
@@ -20,7 +36,15 @@ class Schema {
     /**
      * Creates new instance of API
      */
-    constructor(schema: any) {
+    constructor(schema: Field) {
+        if (!isObject(schema)) {
+            throw new Error('Invalid Editor schema payload');
+        }
+
+        if (schema.version !== 0 || !isObject(schema.documents) || !isObject(schema.assetData)) {
+            throw new Error(`Unsupported Editor schema version: ${String(schema.version)}`);
+        }
+
         this._schema = schema;
         this._assetsSchema = new AssetsSchema(this);
         this._componentSchema = new ComponentSchema(this);
@@ -29,38 +53,120 @@ class Schema {
     }
 
     /**
-     * Gets the schema
+     * Gets the raw schema payload.
      */
     get schema() {
         return this._schema;
     }
 
     /**
-     * Gets the assets schema
+     * Gets the assets schema.
      */
     get assets() {
         return this._assetsSchema;
     }
 
     /**
-     * Gets the component schema
+     * Gets the component schema.
      */
     get components() {
         return this._componentSchema;
     }
 
     /**
-     * Gets the scene schema
+     * Gets the scene schema.
      */
     get scene() {
         return this._sceneSchema;
     }
 
     /**
-     * Gets the settings schema
+     * Gets the settings schema.
      */
     get settings() {
         return this._settingsSchema;
+    }
+
+    getDocument(name: 'asset' | 'scene' | 'settings') {
+        return (this._schema.documents as Field)[name] as Field;
+    }
+
+    getAssetData(type: string) {
+        return (this._schema.assetData as Field)[type.toLowerCase()] as Field | undefined;
+    }
+
+    getComponents() {
+        return this.resolvePath(this.getDocument('scene'), 'entities.*.components', false)?.field as Field;
+    }
+
+    getFields(field: unknown) {
+        if (!isObject(field)) return {};
+        return isObject(field.properties) ? field.properties : {};
+    }
+
+    getMapValue(field: unknown) {
+        if (!isObject(field)) return null;
+        if (isObject(field.additionalProperties)) return field.additionalProperties;
+        return null;
+    }
+
+    getArrayItem(field: unknown) {
+        if (!isObject(field)) return null;
+        const value = jsonValue(field);
+        return isObject(value) && value.type === 'array' ? value.items : null;
+    }
+
+    getDefault(field: unknown) {
+        if (!isObject(field)) return { value: undefined, hasDefault: false };
+        const hasDefault = Object.hasOwn(field, 'default');
+        return { value: hasDefault ? field.default : undefined, hasDefault };
+    }
+
+    getScope(field: unknown) {
+        if (!isObject(field)) return undefined;
+        return field['x-scope'] as string | undefined;
+    }
+
+    getAssetTypes() {
+        const asset = this.getDocument('asset');
+        const type = (asset.properties as Field)?.type;
+        return ((type as Field)?.enum as string[]) || [];
+    }
+
+    resolvePath(root: unknown, path: string | readonly (string | number)[], strictArrays = true) {
+        const parts = typeof path === 'string' ? path.split('.') : path;
+        let field = root;
+        let open = false;
+
+        for (const part of parts) {
+            if (part === '' || !isObject(field)) return null;
+
+            field = jsonValue(field);
+            if (!isObject(field)) return null;
+
+            if (field['x-open-map'] === true || isObject(field.additionalProperties)) {
+                open = true;
+                if (!isObject(field.additionalProperties)) {
+                    return { field: null, default: undefined, hasDefault: false, open };
+                }
+                field = field.additionalProperties;
+            } else if (field.type === 'array') {
+                if (strictArrays && (!Number.isInteger(Number(part)) || Number(part) < 0)) return null;
+                if (!isObject(field.items)) return null;
+                field = field.items;
+            } else if (isObject(field.properties) && Object.hasOwn(field.properties, part)) {
+                field = field.properties[part];
+                continue;
+            } else if (!field.type && !field.properties && !field.items && !field.anyOf) {
+                open = true;
+                return { field: null, default: undefined, hasDefault: false, open };
+            } else {
+                return null;
+            }
+        }
+
+        const result = this.getDefault(field);
+        return { field, default: result.value, hasDefault: result.hasDefault, open };
     }
 
     /**
@@ -68,38 +174,40 @@ class Schema {
      *
      * @category Internal
      */
-    getType(field: any, fixedLength = 0): string {
-        if (typeof field === 'string') {
-            if (field === 'map' || field === 'mixed') {
-                field = 'object';
+    getType(field: unknown): string {
+        const value = jsonValue(field);
+        if (!isObject(value)) return 'object';
+        if (isObject(field) && typeof field['x-editor-type'] === 'string') return field['x-editor-type'];
+        if (typeof value['x-editor-type'] === 'string') return value['x-editor-type'];
+        if (value.type === 'array' && isObject(value.items)) {
+            if (
+                value.items.type === 'number' &&
+                value.minItems === value.maxItems &&
+                Number(value.minItems) >= 2 &&
+                Number(value.minItems) <= 4
+            ) {
+                return `vec${value.minItems}`;
             }
-
-            return field.toLowerCase();
+            return `array:${this.getType(value.items)}`;
         }
+        return typeof value.type === 'string' ? value.type : 'object';
+    }
 
-        if (field.$editorType) {
-            return field.$editorType;
-        }
+    getTypeForPath(root: unknown, path: string, strictArrays = true) {
+        const result = this.resolvePath(root, path, strictArrays);
+        return result?.field ? this.getType(result.field) : null;
+    }
 
-        if (Array.isArray(field)) {
-            if (field[0] === 'number' && fixedLength) {
-                if (fixedLength === 2) {
-                    return 'vec2';
-                } else if (fixedLength === 3) {
-                    return 'vec3';
-                } else if (fixedLength === 4) {
-                    return 'vec4';
-                }
-            }
+    getMergeMethodForPath(root: unknown, path: string, strictArrays = true) {
+        const field = this.resolvePath(root, path, strictArrays)?.field;
+        if (!isObject(field)) return undefined;
+        return field['x-merge-method'] as string | undefined;
+    }
 
-            return `array:${this.getType(field[0])}`;
-        }
-
-        if (field.$type) {
-            return this.getType(field.$type, field.$length);
-        }
-
-        return 'object';
+    getScopeForPath(root: unknown, path: string, strictArrays = true) {
+        const field = this.resolvePath(root, path, strictArrays)?.field;
+        if (!isObject(field)) return undefined;
+        return field['x-scope'] as string | undefined;
     }
 }
 

--- a/src/editor-api/schema/assets.ts
+++ b/src/editor-api/schema/assets.ts
@@ -19,6 +19,9 @@ class AssetsSchema {
 
     /**
      * Gets default data for asset type.
+     *
+     * @param type - The asset type
+     * @returns The default data
      */
     getDefaultData(type: string) {
         const schema = this._schemaApi.getAssetData(type);
@@ -44,6 +47,14 @@ class AssetsSchema {
 
     /**
      * Gets a list of fields of a particular type for an asset type.
+     *
+     * @param assetType - The type of the asset.
+     * @param type - The desired type
+     * @returns A list of fields
+     * @example
+     * ```javascript
+     * const materialAssetPaths = editor.schema.assets.getFieldsOfType('material', 'asset');
+     * ```
      */
     getFieldsOfType(assetType: string, type: string) {
         const result: string[] = [];

--- a/src/editor-api/schema/assets.ts
+++ b/src/editor-api/schema/assets.ts
@@ -1,13 +1,13 @@
 import type { Schema } from '../schema';
 import { utils } from '../utils';
 
+type Field = Record<string, unknown>;
+
 /**
- * Provides methods to access the Assets schema
+ * Provides methods to access the Assets schema.
  */
 class AssetsSchema {
     private _schemaApi: Schema;
-
-    private _schema: any;
 
     /**
      * @category Internal
@@ -15,115 +15,61 @@ class AssetsSchema {
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = this._schemaApi.schema;
     }
 
     /**
-     * Gets default data for asset type
-     *
-     * @param type - The asset type
-     * @returns The default data
+     * Gets default data for asset type.
      */
     getDefaultData(type: string) {
-        const field = `${type}Data`;
+        const schema = this._schemaApi.getAssetData(type);
+        if (!schema) return null;
 
-        if (!field || !this._schema[field]) {
-            return null;
+        const result: Record<string, unknown> = {};
+        for (const [key, block] of Object.entries(this._schemaApi.getFields(schema))) {
+            const value = this._schemaApi.getDefault(block);
+            if (value.hasDefault) result[key] = utils.deepCopy(value.value);
         }
-
-        const result: Record<string, any> = {};
-
-        const schema = this._schema[field];
-        for (const key in schema) {
-            if (key.startsWith('$')) {
-                continue;
-            }
-            const block = schema[key];
-            if (Object.prototype.hasOwnProperty.call(block, '$default')) {
-                result[key] = utils.deepCopy(block.$default);
-            }
-        }
-
         return result;
     }
 
     resolvePath(type: string, path: string) {
-        let field = this._schema[`${type}Data`];
-        let open = false;
-
-        if (!field) {
-            return null;
+        const schema = this._schemaApi.getAssetData(type);
+        const result = schema ? this._schemaApi.resolvePath(schema, path) : null;
+        // copy the default so callers never mutate the shared catalog value
+        if (result?.hasDefault) {
+            result.default = typeof result.default === 'function' ? result.default() : utils.deepCopy(result.default);
         }
-        for (const part of path.split('.')) {
-            if (!part) {
-                return null;
-            }
-            if (field.$type === 'map' || field.$type === 'mixed') {
-                open = true;
-                if (!field.$of) {
-                    return { field: null, default: undefined, hasDefault: false, open };
-                }
-                field = field.$of;
-            } else if (Array.isArray(field.$type)) {
-                if (!Number.isInteger(Number(part)) || Number(part) < 0) {
-                    return null;
-                }
-                field = field.$type[0];
-            } else if (Object.hasOwn(field, part)) {
-                field = field[part];
-                continue;
-            } else {
-                return null;
-            }
-        }
-
-        const hasDefault = Object.hasOwn(field, '$default');
-        return { field, default: hasDefault ? utils.deepCopy(field.$default) : undefined, hasDefault, open };
+        return result;
     }
 
     /**
-     * Gets a list of fields of a particular type for an asset type
-     *
-     * @param assetType - The type of the asset.
-     * @param type - The desired type
-     * @returns A list of fields
-     * @example
-     * ```javascript
-     * const materialAssetPaths = editor.schema.assets.getFieldsOfType('material', 'asset');
-     * ```
+     * Gets a list of fields of a particular type for an asset type.
      */
     getFieldsOfType(assetType: string, type: string) {
         const result: string[] = [];
 
-        const recurse = (schemaField: Record<string, any>, path: string, prefix = '') => {
-            if (!schemaField) {
-                return;
-            }
-
-            if (schemaField.$editorType === type || schemaField.$editorType === `array:${type}`) {
-                result.push(prefix + path);
-                return;
-            }
-
-            for (const field in schemaField) {
-                if (field.startsWith('$')) {
+        const recurse = (schema: Field, path: string, prefix = '') => {
+            for (const [name, field] of Object.entries(this._schemaApi.getFields(schema))) {
+                const current = (path ? `${path}.` : '') + name;
+                const fieldType = this._schemaApi.getType(field);
+                if (fieldType === type || fieldType === `array:${type}`) {
+                    result.push(prefix + current);
                     continue;
                 }
 
-                const p = (path ? `${path}.` : '') + field;
-                const fieldType = this._schemaApi.getType(schemaField[field]);
-                if (fieldType === type || fieldType === `array:${type}`) {
-                    result.push(prefix + p);
-                } else if (fieldType === 'object' && schemaField[field].$of) {
-                    recurse(schemaField[field].$of, `${p}.*`, prefix);
-                } else if (fieldType === 'array:object' && Array.isArray(schemaField[field].$type)) {
-                    recurse(schemaField[field].$type[0], `${p}.*`, prefix);
+                const map = this._schemaApi.getMapValue(field);
+                if (fieldType === 'object' && map) {
+                    recurse(map as Field, `${current}.*`, prefix);
+                    continue;
                 }
+
+                const item = this._schemaApi.getArrayItem(field);
+                if (fieldType === 'array:object' && item) recurse(item as Field, `${current}.*`, prefix);
             }
         };
 
-        recurse(this._schema[`${assetType}Data`], '', 'data.');
-
+        const schema = this._schemaApi.getAssetData(assetType);
+        if (schema) recurse(schema, '', 'data.');
         return result;
     }
 }

--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -15,6 +15,7 @@ class ComponentSchema {
      * Creates new instance of API.
      *
      * @category Internal
+     * @param schema - The schema API
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
@@ -29,6 +30,13 @@ class ComponentSchema {
 
     /**
      * Gets default data for a component.
+     *
+     * @param component - The component name
+     * @returns The default data
+     * @example
+     * ```javascript
+     * const modelData = editor.schema.components.getDefaultData('model');
+     * ```
      */
     getDefaultData(component: string) {
         const result: Record<string, unknown> = {};
@@ -52,6 +60,14 @@ class ComponentSchema {
 
     /**
      * Gets a list of fields of a particular type for a component.
+     *
+     * @param component - The component name
+     * @param type - The desired type
+     * @returns A list of fields
+     * @example
+     * ```javascript
+     * const buttonEntityFields = editor.schema.components.getFieldsOfType('button', 'entity');
+     * ```
      */
     getFieldsOfType(component: string, type: string) {
         const result: string[] = [];
@@ -76,6 +92,8 @@ class ComponentSchema {
 
     /**
      * Gets a list of all the available components.
+     *
+     * @returns The components
      */
     list() {
         const result = Object.keys(this._schemaApi.getFields(this._schema)).sort();

--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -1,164 +1,86 @@
 import type { Schema } from '../schema';
 import { utils } from '../utils';
 
+type Field = Record<string, unknown>;
+
 /**
- * Provides methods to access the components schema
+ * Provides methods to access the components schema.
  */
 class ComponentSchema {
     private _schemaApi: Schema;
 
-    private _schema: any;
+    private _schema: Field;
 
     /**
-     * Creates new instance of API
+     * Creates new instance of API.
      *
      * @category Internal
-     * @param schema - The schema API
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = this._schemaApi.schema.scene.entities.$of.components;
+        this._schema = schema.getComponents();
     }
 
-    _resolveLazyDefaults(defaults: Record<string, any>) {
-        // Any functions in the default property set are used to provide
-        // lazy resolution, to handle cases where the values are not known
-        // at startup time.
-        Object.keys(defaults).forEach((key: string) => {
-            const value = defaults[key];
-
-            if (typeof value === 'function') {
-                defaults[key] = value();
-            }
-        });
+    _resolveLazyDefaults(defaults: Record<string, unknown>) {
+        for (const [key, value] of Object.entries(defaults)) {
+            if (typeof value === 'function') defaults[key] = value();
+        }
     }
 
     /**
-     * Gets default data for a component
-     *
-     * @param component - The component name
-     * @returns The default data
-     * @example
-     * ```javascript
-     * const modelData = editor.schema.components.getDefaultData('model');
-     * ```
+     * Gets default data for a component.
      */
     getDefaultData(component: string) {
-        const result: Record<string, any> = {};
-        for (const fieldName in this._schema[component]) {
-            if (fieldName.startsWith('$')) {
-                continue;
-            }
-            const field = this._schema[component][fieldName];
-            if (Object.prototype.hasOwnProperty.call(field, '$default')) {
-                result[fieldName] = utils.deepCopy(field.$default);
-            }
+        const result: Record<string, unknown> = {};
+        const schema = this._schemaApi.getFields(this._schema)[component];
+        for (const [name, field] of Object.entries(this._schemaApi.getFields(schema))) {
+            const value = this._schemaApi.getDefault(field);
+            if (value.hasDefault) result[name] = utils.deepCopy(value.value);
         }
-
         this._resolveLazyDefaults(result);
-
         return result;
     }
 
     resolvePath(component: string, path: string) {
-        let field = this._schema[component];
-        let open = false;
-
-        if (!field) {
-            return null;
+        const schema = this._schemaApi.getFields(this._schema)[component];
+        const result = schema ? this._schemaApi.resolvePath(schema, path) : null;
+        if (result?.hasDefault) {
+            result.default = typeof result.default === 'function' ? result.default() : utils.deepCopy(result.default);
         }
-        for (const part of path.split('.')) {
-            if (!part) {
-                return null;
-            }
-            if (field.$type === 'map' || field.$type === 'mixed') {
-                open = true;
-                if (!field.$of) {
-                    return { field: null, default: undefined, hasDefault: false, open };
-                }
-                field = field.$of;
-            } else if (Array.isArray(field.$type)) {
-                if (!Number.isInteger(Number(part)) || Number(part) < 0) {
-                    return null;
-                }
-                field = field.$type[0];
-            } else if (Object.hasOwn(field, part)) {
-                field = field[part];
-                continue;
-            } else {
-                return null;
-            }
-        }
-
-        const hasDefault = Object.hasOwn(field, '$default');
-        const value = hasDefault ? field.$default : undefined;
-        return {
-            field,
-            default: hasDefault ? (typeof value === 'function' ? value() : utils.deepCopy(value)) : undefined,
-            hasDefault,
-            open
-        };
-    }
-
-    /**
-     * Gets a list of fields of a particular type for a component
-     *
-     * @param componentName - The component name
-     * @param type - The desired type
-     * @returns A list of fields
-     * @example
-     * ```javascript
-     * const buttonEntityFields = editor.schema.components.getFieldsOfType('button', 'entity');
-     * ```
-     */
-    getFieldsOfType(componentName: string, type: string) {
-        const result: string[] = [];
-
-        const recurse = (schemaField: Record<string, any>, path: string) => {
-            if (!schemaField) {
-                return;
-            }
-
-            if (schemaField.$editorType === type || schemaField.$editorType === `array:${type}`) {
-                result.push(path);
-                return;
-            }
-
-            for (const field in schemaField) {
-                if (field.startsWith('$')) {
-                    continue;
-                }
-
-                const p = (path ? `${path}.` : '') + field;
-                const fieldType = this._schemaApi.getType(schemaField[field]);
-                if (fieldType === type || fieldType === `array:${type}`) {
-                    result.push(p);
-                } else if (fieldType === 'object' && schemaField[field].$of) {
-                    recurse(schemaField[field].$of, `${p}.*`);
-                }
-            }
-        };
-
-        recurse(this._schema[componentName], '');
-
         return result;
     }
 
     /**
-     * Gets a list of all the available components
-     *
-     * @returns The components
+     * Gets a list of fields of a particular type for a component.
+     */
+    getFieldsOfType(component: string, type: string) {
+        const result: string[] = [];
+
+        const recurse = (schema: Field, path: string) => {
+            for (const [name, field] of Object.entries(this._schemaApi.getFields(schema))) {
+                const current = (path ? `${path}.` : '') + name;
+                const fieldType = this._schemaApi.getType(field);
+                if (fieldType === type || fieldType === `array:${type}`) {
+                    result.push(current);
+                    continue;
+                }
+                const map = this._schemaApi.getMapValue(field);
+                if (fieldType === 'object' && map) recurse(map as Field, `${current}.*`);
+            }
+        };
+
+        const schema = this._schemaApi.getFields(this._schema)[component];
+        if (schema) recurse(schema as Field, '');
+        return result;
+    }
+
+    /**
+     * Gets a list of all the available components.
      */
     list() {
-        const result = Object.keys(this._schema);
-        result.sort();
-
-        // filter out zone (which is not really supported)
-        const idx = result.indexOf('zone');
-        if (idx !== -1) {
-            result.splice(idx, 1);
-        }
-
+        const result = Object.keys(this._schemaApi.getFields(this._schema)).sort();
+        const index = result.indexOf('zone');
+        if (index !== -1) result.splice(index, 1);
         return result;
     }
 }

--- a/src/editor-api/schema/components.ts
+++ b/src/editor-api/schema/components.ts
@@ -81,7 +81,14 @@ class ComponentSchema {
                     continue;
                 }
                 const map = this._schemaApi.getMapValue(field);
-                if (fieldType === 'object' && map) recurse(map as Field, `${current}.*`);
+                if (fieldType === 'object' && map) {
+                    const mapType = this._schemaApi.getType(map);
+                    if (mapType === type || mapType === `array:${type}`) {
+                        result.push(`${current}.*`);
+                    } else {
+                        recurse(map as Field, `${current}.*`);
+                    }
+                }
             }
         };
 

--- a/src/editor-api/schema/scene.ts
+++ b/src/editor-api/schema/scene.ts
@@ -1,72 +1,45 @@
 import type { Schema } from '../schema';
 import { utils } from '../utils';
 
+type Field = Record<string, unknown>;
+
 /**
- * Provides methods to access the render schema
+ * Provides methods to access the scene schema.
  */
 class SceneSchema {
     private _schemaApi: Schema;
 
-    private _schema: any;
+    private _schema: Field;
 
-    /**
-     * Creates new instance of API
-     *
-     * @category Internal
-     * @param schema - The schema API
-     */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = this._schemaApi.schema.scene;
+        this._schema = schema.getDocument('scene');
     }
 
-    _getDefaultData(obj: Record<string, any>) {
-        const result: Record<string, any> = {};
-        for (const key in obj) {
-            if (key.startsWith('$')) {
+    _getDefaultData(schema: Field) {
+        const result: Record<string, unknown> = {};
+        for (const [key, field] of Object.entries(this._schemaApi.getFields(schema))) {
+            const value = this._schemaApi.getDefault(field);
+            if (value.hasDefault) {
+                result[key] = utils.deepCopy(value.value);
                 continue;
             }
-            if (!(obj[key] instanceof Object)) {
-                continue;
-            }
-
-            if (Object.prototype.hasOwnProperty.call(obj[key], '$default')) {
-                result[key] = utils.deepCopy(obj[key].$default);
-                continue;
-            } else {
-                const subDefaults = this._getDefaultData(obj[key]);
-                if (Object.keys(subDefaults).length) {
-                    result[key] = subDefaults;
-                }
-            }
+            const nested = this._getDefaultData(field as Field);
+            if (Object.keys(nested).length) result[key] = nested;
         }
         return result;
     }
 
-    /**
-     * Get the default physics scene settings for the project
-     *
-     * @returns The default physics scene settings
-     * @example
-     * ```javascript
-     * const scenePhysicsSettings = editor.schema.scene.getDefaultPhysicsSettings();
-     * ```
-     */
     getDefaultPhysicsSettings() {
-        return this._getDefaultData(this._schema.settings.physics);
+        const settings = this._schemaApi.getFields(this._schema).settings;
+        const physics = this._schemaApi.getFields(settings).physics;
+        return this._getDefaultData(physics as Field);
     }
 
-    /**
-     * Get the default render scene settings for the project
-     *
-     * @returns The default physics scene settings
-     * @example
-     * ```javascript
-     * const sceneRenderSettings = editor.schema.scene.getDefaultRenderSettings();
-     * ```
-     */
     getDefaultRenderSettings() {
-        return this._getDefaultData(this._schema.settings.render);
+        const settings = this._schemaApi.getFields(this._schema).settings;
+        const render = this._schemaApi.getFields(settings).render;
+        return this._getDefaultData(render as Field);
     }
 }
 

--- a/src/editor-api/schema/scene.ts
+++ b/src/editor-api/schema/scene.ts
@@ -11,6 +11,12 @@ class SceneSchema {
 
     private _schema: Field;
 
+    /**
+     * Creates new instance of API.
+     *
+     * @category Internal
+     * @param schema - The schema API
+     */
     constructor(schema: Schema) {
         this._schemaApi = schema;
         this._schema = schema.getDocument('scene');
@@ -30,12 +36,30 @@ class SceneSchema {
         return result;
     }
 
+    /**
+     * Get the default physics scene settings for the project.
+     *
+     * @returns The default physics scene settings
+     * @example
+     * ```javascript
+     * const scenePhysicsSettings = editor.schema.scene.getDefaultPhysicsSettings();
+     * ```
+     */
     getDefaultPhysicsSettings() {
         const settings = this._schemaApi.getFields(this._schema).settings;
         const physics = this._schemaApi.getFields(settings).physics;
         return this._getDefaultData(physics as Field);
     }
 
+    /**
+     * Get the default render scene settings for the project.
+     *
+     * @returns The default render scene settings
+     * @example
+     * ```javascript
+     * const sceneRenderSettings = editor.schema.scene.getDefaultRenderSettings();
+     * ```
+     */
     getDefaultRenderSettings() {
         const settings = this._schemaApi.getFields(this._schema).settings;
         const render = this._schemaApi.getFields(settings).render;

--- a/src/editor-api/schema/settings.ts
+++ b/src/editor-api/schema/settings.ts
@@ -1,85 +1,43 @@
 import type { Schema } from '../schema';
 import { utils } from '../utils';
 
+type Field = Record<string, unknown>;
+
 /**
- * Provides methods to access the settings schema
+ * Provides methods to access the settings schema.
  */
 class SettingsSchema {
     private _schemaApi: Schema;
 
-    private _schema: any;
+    private _schema: Field;
 
-    /**
-     * Creates new instance of API
-     *
-     * @category Internal
-     * @param schema - The schema API
-     */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = this._schemaApi.schema.settings;
+        this._schema = schema.getDocument('settings');
     }
 
-    _getDefaultData(obj: Record<string, any>, scope: string) {
-        const result: Record<string, any> = {};
-        for (const key in obj) {
-            if (key.startsWith('$')) {
+    _getDefaultData(schema: Field, scope: string) {
+        const result: Record<string, unknown> = {};
+        for (const [key, field] of Object.entries(this._schemaApi.getFields(schema))) {
+            const value = this._schemaApi.getDefault(field);
+            if (value.hasDefault) {
+                if (this._schemaApi.getScope(field) === scope) result[key] = utils.deepCopy(value.value);
                 continue;
             }
-            if (!(obj[key] instanceof Object)) {
-                continue;
-            }
-
-            if (Object.prototype.hasOwnProperty.call(obj[key], '$default')) {
-                if (obj[key].$scope === scope) {
-                    result[key] = utils.deepCopy(obj[key].$default);
-                }
-                continue;
-            } else {
-                const subDefaults = this._getDefaultData(obj[key], scope);
-                if (Object.keys(subDefaults).length) {
-                    result[key] = subDefaults;
-                }
-            }
+            const nested = this._getDefaultData(field as Field, scope);
+            if (Object.keys(nested).length) result[key] = nested;
         }
         return result;
     }
 
-    /**
-     * Get the default settings for the project
-     *
-     * @returns The default settings for the project
-     * @example
-     * ```javascript
-     * const projectSettings = editor.schema.settings.getDefaultProjectSettings();
-     * ```
-     */
     getDefaultProjectSettings() {
         return this._getDefaultData(this._schema, 'project');
     }
 
-    /**
-     * Get the default settings for the user
-     *
-     * @returns The default settings for the user
-     * @example
-     * ```javascript
-     * const userSettings = editor.schema.settings.getDefaultUserSettings();
-     * ```
-     */
     getDefaultUserSettings() {
         return this._getDefaultData(this._schema, 'user');
     }
 
-    /**
-     * Get the default settings for the user in the project
-     *
-     * @returns The default settings for the user in the project
-     * @example
-     * ```javascript
-     * const projectUserSettings = editor.schema.settings.getDefaultProjectUserSettings();
-     * ```
-     */
     getDefaultProjectUserSettings() {
         return this._getDefaultData(this._schema, 'projectUser');
     }

--- a/src/editor-api/schema/settings.ts
+++ b/src/editor-api/schema/settings.ts
@@ -11,6 +11,12 @@ class SettingsSchema {
 
     private _schema: Field;
 
+    /**
+     * Creates new instance of API.
+     *
+     * @category Internal
+     * @param schema - The schema API
+     */
     constructor(schema: Schema) {
         this._schemaApi = schema;
         this._schema = schema.getDocument('settings');
@@ -30,14 +36,41 @@ class SettingsSchema {
         return result;
     }
 
+    /**
+     * Get the default settings for the project.
+     *
+     * @returns The default settings for the project
+     * @example
+     * ```javascript
+     * const projectSettings = editor.schema.settings.getDefaultProjectSettings();
+     * ```
+     */
     getDefaultProjectSettings() {
         return this._getDefaultData(this._schema, 'project');
     }
 
+    /**
+     * Get the default settings for the user.
+     *
+     * @returns The default settings for the user
+     * @example
+     * ```javascript
+     * const userSettings = editor.schema.settings.getDefaultUserSettings();
+     * ```
+     */
     getDefaultUserSettings() {
         return this._getDefaultData(this._schema, 'user');
     }
 
+    /**
+     * Get the default settings for the user in the project.
+     *
+     * @returns The default settings for the user in the project
+     * @example
+     * ```javascript
+     * const projectUserSettings = editor.schema.settings.getDefaultProjectUserSettings();
+     * ```
+     */
     getDefaultProjectUserSettings() {
         return this._getDefaultData(this._schema, 'projectUser');
     }

--- a/src/editor/assets/assets-preview-font-watch.ts
+++ b/src/editor/assets/assets-preview-font-watch.ts
@@ -123,6 +123,8 @@ editor.once('load', () => {
                 watch.engineAsset = asset;
                 loadFont(watch, asset);
             }
+        } else if (args.autoLoad) {
+            app.assets.get(watch.asset.get('id'))?.ready(args.callback);
         }
 
         return watch.ind;

--- a/src/editor/entities/entities-components-menu.ts
+++ b/src/editor/entities/entities-components-menu.ts
@@ -34,12 +34,8 @@ editor.once('load', () => {
         return selection;
     };
 
-    const makeAddComponentMenuItem = function (
-        key: string,
-        components: Record<string, { $title: string }>,
-        logos: Record<string, string>
-    ) {
-        let title = components[key].$title;
+    const makeAddComponentMenuItem = function (key: string, logos: Record<string, string>) {
+        let title = editor.call('components:title', key);
         if (title === 'Model' || title === 'Animation') {
             title += ' (legacy)';
         }
@@ -91,16 +87,15 @@ editor.once('load', () => {
         };
 
         // fill menu with available components
-        const components = editor.call('components:schema');
         const list = editor.call('components:list');
 
         for (let i = 0; i < list.length; i++) {
             const key = list[i];
             const submenu = getSubMenu(key);
             if (submenu) {
-                items[submenu].items.push(makeAddComponentMenuItem(key, components, COMPONENT_LOGOS));
+                items[submenu].items.push(makeAddComponentMenuItem(key, COMPONENT_LOGOS));
             } else {
-                items[key] = makeAddComponentMenuItem(key, components, COMPONENT_LOGOS);
+                items[key] = makeAddComponentMenuItem(key, COMPONENT_LOGOS);
             }
         }
 

--- a/src/editor/inspector/entity.ts
+++ b/src/editor/inspector/entity.ts
@@ -406,7 +406,6 @@ class EntityInspector extends Container {
     // add component menu
     _createAddComponentMenu() {
         let menu = null;
-        const componentsSchema = editor.call('components:schema');
         const components = editor.call('components:list');
 
         // Create empty menu with sub-menus
@@ -460,7 +459,7 @@ class EntityInspector extends Container {
         const hiddenComponents = new Set(['audiosource']);
 
         components.forEach((component) => {
-            let title = componentsSchema[component].$title;
+            let title = editor.call('components:title', component);
             if (title === 'Model' || title === 'Animation') {
                 title += ' (legacy)';
             }
@@ -530,7 +529,7 @@ class EntityInspector extends Container {
 
                 const submenu = getSubMenu(component);
                 if (submenu) {
-                    let title = componentsSchema[component].$title;
+                    let title = editor.call('components:title', component);
                     if (title === 'Model' || title === 'Animation') {
                         title += ' (legacy)';
                     }

--- a/src/editor/schema/schema-anim-state-graph.ts
+++ b/src/editor/schema/schema-anim-state-graph.ts
@@ -1,6 +1,8 @@
 import { deepCopy } from '@/common/utils';
 
 editor.once('load', () => {
+    const schema = editor.api.globals.schema;
+
     /**
      * Returns a JSON object that contains all of the default anim state graph data.
      *
@@ -9,19 +11,13 @@ editor.once('load', () => {
      */
     editor.method('schema:animstategraph:getDefaultData', (existingData?: object) => {
         const result = {};
-        const schema = config.schema.animstategraphData;
+        const defaults = schema.assets.getDefaultData('animstategraph') || {};
 
-        for (const key in schema) {
-            if (key.startsWith('$')) {
-                continue;
-            }
+        for (const key in schema.getFields(schema.getAssetData('animstategraph'))) {
             if (existingData && existingData[key] !== undefined) {
                 result[key] = existingData[key];
-            } else {
-                const field = schema[key];
-                if (Object.prototype.hasOwnProperty.call(field, '$default')) {
-                    result[key] = deepCopy(field.$default);
-                }
+            } else if (Object.hasOwn(defaults, key)) {
+                result[key] = deepCopy(defaults[key]);
             }
         }
 

--- a/src/editor/schema/schema-asset.ts
+++ b/src/editor/schema/schema-asset.ts
@@ -1,4 +1,6 @@
 editor.once('load', () => {
+    const schema = editor.api.globals.schema;
+
     /**
      * Gets the type of a path in the asset schema
      *
@@ -6,7 +8,7 @@ editor.once('load', () => {
      * @returns The type
      */
     editor.method('schema:asset:getType', (path: string): string => {
-        return editor.call('schema:getTypeForPath', config.schema.asset, path);
+        return editor.call('schema:getTypeForPath', schema.getDocument('asset'), path);
     });
 
     /**
@@ -17,11 +19,11 @@ editor.once('load', () => {
      * @returns The type
      */
     editor.method('schema:asset:getDataType', (assetType: string, path: string): string => {
-        const schema = config.schema[`${assetType}Data`];
-        if (schema) {
+        const data = schema.getAssetData(assetType);
+        if (data) {
             // strip data.
             path = path.substring(5);
-            return editor.call('schema:getTypeForPath', schema, path);
+            return editor.call('schema:getTypeForPath', data, path);
         }
 
         return editor.call('schema:asset:getType', path);
@@ -33,7 +35,6 @@ editor.once('load', () => {
      * @returns Array of asset type names
      */
     editor.method('schema:assets:list', (): string[] => {
-        const assetSchema = config.schema.asset as { type: { $enum: string[] } };
-        return assetSchema.type.$enum;
+        return schema.getAssetTypes();
     });
 });

--- a/src/editor/schema/schema-components.ts
+++ b/src/editor/schema/schema-components.ts
@@ -3,176 +3,138 @@ import { Color, Curve, CurveSet, Quat, Vec2, Vec3, Vec4 } from 'playcanvas';
 
 import { deepCopy } from '@/common/utils';
 
+type CurveValue = { keys: number[]; type: number };
+
 editor.once('load', () => {
-    const projectSettings = editor.call('settings:project');
+    const api = editor.api.globals.schema;
+    const schema = api.getFields(api.getComponents());
+    const settings = editor.call('settings:project');
+    const titles: Record<string, string> = {};
 
-    const schema = config.schema.scene.entities.$of.components;
-
-    let componentName;
-
-    // make titles for each component
-    for (componentName in schema) {
-        if (componentName.startsWith('$')) {
-            continue;
-        }
-
-        let title;
-        switch (componentName) {
+    for (const name of Object.keys(schema)) {
+        switch (name) {
             case 'audiosource':
-                title = 'Audio Source';
+                titles[name] = 'Audio Source';
                 break;
             case 'audiolistener':
-                title = 'Audio Listener';
+                titles[name] = 'Audio Listener';
                 break;
             case 'particlesystem':
-                title = 'Particle System';
+                titles[name] = 'Particle System';
                 break;
             case 'rigidbody':
-                title = 'Rigid Body';
+                titles[name] = 'Rigid Body';
                 break;
             case 'scrollview':
-                title = 'Scroll View';
+                titles[name] = 'Scroll View';
                 break;
             case 'layoutgroup':
-                title = 'Layout Group';
+                titles[name] = 'Layout Group';
                 break;
             case 'layoutchild':
-                title = 'Layout Child';
+                titles[name] = 'Layout Child';
                 break;
             case 'gsplat':
-                title = 'Gaussian Splat';
+                titles[name] = 'Gaussian Splat';
                 break;
             default:
-                title = componentName[0].toUpperCase() + componentName.substring(1);
+                titles[name] = name[0].toUpperCase() + name.substring(1);
                 break;
         }
-
-        schema[componentName].$title = title;
     }
 
-    // some property defaults should be dynamic so
-    // patch them in
     if (schema.screen) {
-        // default resolution to project resolution for screen components
-        schema.screen.resolution.$default = function () {
-            return [projectSettings.get('width'), projectSettings.get('height')];
-        };
-        schema.screen.referenceResolution.$default = function () {
-            return [projectSettings.get('width'), projectSettings.get('height')];
-        };
+        const fields = api.getFields(schema.screen);
+        (fields.resolution as Record<string, unknown>).default = () => [settings.get('width'), settings.get('height')];
+        (fields.referenceResolution as Record<string, unknown>).default = () => [
+            settings.get('width'),
+            settings.get('height')
+        ];
     }
 
     if (schema.element) {
-        schema.element.fontAsset.$default = function () {
-            // Reuse the last selected font, if it still exists in the library
-            const lastSelectedFontId = editor.call('settings:projectUser').get('editor.lastSelectedFontId');
-            const lastSelectedFontStillExists =
-                lastSelectedFontId !== -1 && !!editor.call('assets:get', lastSelectedFontId);
+        const fields = api.getFields(schema.element);
+        (fields.fontAsset as Record<string, unknown>).default = () => {
+            const id = editor.call('settings:projectUser').get('editor.lastSelectedFontId');
+            if (id !== -1 && editor.call('assets:get', id)) return id;
 
-            if (lastSelectedFontStillExists) {
-                return lastSelectedFontId;
-            }
-
-            // Otherwise, select the first available font in the library
-            const firstAvailableFont = editor.call('assets:findOne', (asset: Observer) => {
-                return !asset.get('source') && asset.get('type') === 'font';
+            const asset = editor.call('assets:findOne', (item: Observer) => {
+                return !item.get('source') && item.get('type') === 'font';
             });
-
-            return firstAvailableFont ? parseInt(firstAvailableFont[1].get('id'), 10) : null;
+            return asset ? parseInt(asset[1].get('id'), 10) : null;
         };
     }
 
-    // Paths in components that represent assets.
-    // Does not include asset script attributes.
-    const assetPaths = [];
-    const gatherAssetPathsRecursively = function (schemaField: Record<string, unknown>, path: string) {
-        if (schemaField.$editorType === 'asset' || schemaField.$editorType === 'array:asset') {
-            // this is for cases like components.model.mapping
+    const assetPaths: string[] = [];
+    const gather = (root: unknown, path: string) => {
+        const type = api.getType(root);
+        if (type === 'asset' || type === 'array:asset') {
             assetPaths.push(path);
             return;
         }
 
-        for (const fieldName in schemaField) {
-            if (fieldName.startsWith('$')) {
+        for (const [name, field] of Object.entries(api.getFields(root))) {
+            const current = `${path}.${name}`;
+            const fieldType = api.getType(field);
+            if (fieldType === 'asset' || fieldType === 'array:asset') {
+                assetPaths.push(current);
                 continue;
             }
-
-            const field = schemaField[fieldName];
-            const type = editor.call('schema:getType', field);
-            if (type === 'asset' || type === 'array:asset') {
-                assetPaths.push(`${path}.${fieldName}`);
-            } else if (type === 'object' && field.$of) {
-                gatherAssetPathsRecursively(field.$of, `${path}.${fieldName}.*`);
-            }
+            const map = api.getMapValue(field);
+            if (fieldType === 'object' && map) gather(map, `${current}.*`);
         }
     };
 
-    for (componentName in schema) {
-        gatherAssetPathsRecursively(schema[componentName], `components.${componentName}`);
+    for (const [name, field] of Object.entries(schema)) {
+        gather(field, `components.${name}`);
     }
 
-    editor.method('components:assetPaths', () => {
-        return assetPaths;
-    });
+    editor.method('components:assetPaths', () => assetPaths);
 
-    if (editor.call('settings:project').get('useLegacyScripts')) {
-        schema.script.scripts.$default = [];
-        delete schema.script.order;
+    const legacy = settings.get('useLegacyScripts');
+    if (legacy) {
+        const fields = api.getFields(schema.script);
+        (fields.scripts as Record<string, unknown>).default = [];
+        delete fields.order;
     }
 
-    // Order components alphabetically
-    const components = Object.keys(schema);
-
-    let list = components.sort((a, b) => {
-        if (a < b) {
-            return -1;
-        }
-        if (a > b) {
-            return 1;
-        }
-        return 0;
-    });
-
+    let list = Object.keys(schema).sort();
     list = list.filter((item) => !item.startsWith('$'));
 
     editor.method('components:convertValue', (component: string, property: string, value: unknown) => {
         let result = value;
+        const field = api.getFields(schema[component])[property];
 
-        if (value) {
-            const data = schema[component];
-            if (data && data[property]) {
-                const type = editor.call('schema:getType', data[property]);
-                switch (type) {
-                    case 'rgb':
-                        result = new Color(value[0], value[1], value[2]);
-                        break;
-                    case 'rgba':
-                        result = new Color(value[0], value[1], value[2], value[3]);
-                        break;
-                    case 'vec2':
-                        result = new Vec2(value[0], value[1]);
-                        break;
-                    case 'vec3':
-                        result = new Vec3(value[0], value[1], value[2]);
-                        break;
-                    case 'vec4':
-                        result = new Vec4(value[0], value[1], value[2], value[3]);
-                        break;
-                    case 'curveset':
-                        result = new CurveSet(value.keys);
-                        result.type = value.type;
-                        break;
-                    case 'curve':
-                        result = new Curve(value.keys);
-                        result.type = value.type;
-                        break;
-                    case 'entity':
-                        result = value; // Entity fields should just be a string guid
-                        break;
-                }
+        if (value && field) {
+            switch (api.getType(field)) {
+                case 'rgb':
+                    result = new Color(value[0], value[1], value[2]);
+                    break;
+                case 'rgba':
+                    result = new Color(value[0], value[1], value[2], value[3]);
+                    break;
+                case 'vec2':
+                    result = new Vec2(value[0], value[1]);
+                    break;
+                case 'vec3':
+                    result = new Vec3(value[0], value[1], value[2]);
+                    break;
+                case 'vec4':
+                    result = new Vec4(value[0], value[1], value[2], value[3]);
+                    break;
+                case 'curveset':
+                    result = new CurveSet((value as CurveValue).keys);
+                    (result as CurveSet).type = (value as CurveValue).type;
+                    break;
+                case 'curve':
+                    result = new Curve((value as CurveValue).keys);
+                    (result as Curve).type = (value as CurveValue).type;
+                    break;
+                case 'entity':
+                    result = value;
+                    break;
             }
 
-            // Collision component's angularOffset is stored as euler angles but runtime needs Quat
             if (
                 component === 'collision' &&
                 property === 'angularOffset' &&
@@ -183,72 +145,41 @@ editor.once('load', () => {
             }
         }
 
-        // for batchGroupId convert null to -1 for runtime
-        if (result === null && property === 'batchGroupId') {
-            result = -1;
-        }
-
+        if (result === null && property === 'batchGroupId') result = -1;
         return result;
     });
 
     editor.method('components:list', () => {
-        const result = list.slice(0);
-        let idx;
-
-        // filter out zone (which is not really supported)
+        const result = list.slice();
         if (!editor.call('users:hasFlag', 'hasZoneComponent')) {
-            idx = result.indexOf('zone');
-            if (idx !== -1) {
-                result.splice(idx, 1);
-            }
+            const index = result.indexOf('zone');
+            if (index !== -1) result.splice(index, 1);
         }
-
         return result;
     });
 
-    editor.method('components:schema', () => {
-        return schema;
-    });
+    editor.method('components:schema', () => schema);
+    editor.method('components:title', (component: string) => titles[component]);
 
     editor.method('components:getDefault', (component: string) => {
-        const result = {};
-        for (const fieldName in schema[component]) {
-            if (fieldName.startsWith('$')) {
-                continue;
-            }
-            const field = schema[component][fieldName];
-            if (Object.prototype.hasOwnProperty.call(field, '$default')) {
-                result[fieldName] = deepCopy(field.$default);
-            }
+        const result: Record<string, unknown> = {};
+        for (const [name, field] of Object.entries(api.getFields(schema[component]))) {
+            if (legacy && component === 'script' && name === 'order') continue;
+            const value = api.getDefault(field);
+            if (value.hasDefault) result[name] = deepCopy(value.value);
         }
 
-        resolveLazyDefaults(result);
-
+        for (const [name, value] of Object.entries(result)) {
+            if (typeof value === 'function') result[name] = value();
+        }
         return result;
     });
 
-    function resolveLazyDefaults(defaults: Record<string, unknown>) {
-        // Any functions in the default property set are used to provide
-        // lazy resolution, to handle cases where the values are not known
-        // at startup time.
-        Object.keys(defaults).forEach((key: string) => {
-            const value = defaults[key];
-
-            if (typeof value === 'function') {
-                defaults[key] = value();
-            }
-        });
-    }
-
     editor.method('components:getFieldsOfType', (component, type) => {
-        const matchingFields = [];
-
-        for (const field in schema[component]) {
-            if (schema[component][field].$editorType === type) {
-                matchingFields.push(field);
-            }
+        const result = [];
+        for (const [name, field] of Object.entries(api.getFields(schema[component]))) {
+            if (api.getType(field) === type) result.push(name);
         }
-
-        return matchingFields;
+        return result;
     });
 });

--- a/src/editor/schema/schema-material.ts
+++ b/src/editor/schema/schema-material.ts
@@ -1,6 +1,8 @@
 import { deepCopy } from '@/common/utils';
 
 editor.once('load', () => {
+    const schema = editor.api.globals.schema;
+
     /**
      * Returns a JSON object that contains all of the default material data.
      *
@@ -9,19 +11,13 @@ editor.once('load', () => {
      */
     editor.method('schema:material:getDefaultData', (existingData?: object) => {
         const result = {};
-        const schema = config.schema.materialData;
+        const defaults = schema.assets.getDefaultData('material') || {};
 
-        for (const key in schema) {
-            if (key.startsWith('$')) {
-                continue;
-            }
+        for (const key in schema.getFields(schema.getAssetData('material'))) {
             if (existingData && existingData[key] !== undefined) {
                 result[key] = existingData[key];
-            } else {
-                const field = schema[key];
-                if (Object.prototype.hasOwnProperty.call(field, '$default')) {
-                    result[key] = deepCopy(field.$default);
-                }
+            } else if (Object.hasOwn(defaults, key)) {
+                result[key] = deepCopy(defaults[key]);
             }
         }
 
@@ -35,13 +31,8 @@ editor.once('load', () => {
      * @returns The default value or undefined
      */
     editor.method('schema:material:getDefaultValueForField', (fieldName: string): unknown => {
-        const field = config.schema.materialData[fieldName];
-
-        if (field && Object.prototype.hasOwnProperty.call(field, '$default')) {
-            return deepCopy(field.$default);
-        }
-
-        return undefined;
+        const field = schema.assets.resolvePath('material', fieldName);
+        return field?.hasDefault ? deepCopy(field.default) : undefined;
     });
 
     /**
@@ -51,6 +42,11 @@ editor.once('load', () => {
      * @returns The type of the field
      */
     editor.method('schema:material:getType', (fieldName: string): string => {
-        return editor.call('schema:getTypeForPath', config.schema.materialData, fieldName);
+        const resolved = schema.assets.resolvePath('material', fieldName);
+        if (!resolved?.field) {
+            console.warn(`Unknown type for ${fieldName}`);
+            return 'string';
+        }
+        return schema.getType(resolved.field);
     });
 });

--- a/src/editor/schema/schema-scene.ts
+++ b/src/editor/schema/schema-scene.ts
@@ -1,4 +1,6 @@
 editor.once('load', () => {
+    const schema = editor.api.globals.schema;
+
     /**
      * Gets the type of a path in the scene schema
      *
@@ -6,6 +8,6 @@ editor.once('load', () => {
      * @returns The type
      */
     editor.method('schema:scene:getType', (path: string): string => {
-        return editor.call('schema:getTypeForPath', config.schema.scene, path);
+        return editor.call('schema:getTypeForPath', schema.getDocument('scene'), path);
     });
 });

--- a/src/editor/schema/schema-settings.ts
+++ b/src/editor/schema/schema-settings.ts
@@ -1,4 +1,6 @@
 editor.once('load', () => {
+    const schema = editor.api.globals.schema;
+
     /**
      * Gets the type of a path in the settings schema
      *
@@ -6,6 +8,6 @@ editor.once('load', () => {
      * @returns The type
      */
     editor.method('schema:settings:getType', (path: string): string => {
-        return editor.call('schema:getTypeForPath', config.schema.settings, path);
+        return editor.call('schema:getTypeForPath', schema.getDocument('settings'), path);
     });
 });

--- a/src/editor/schema/schema.ts
+++ b/src/editor/schema/schema.ts
@@ -1,121 +1,17 @@
 editor.once('load', () => {
-    /**
-     * Gets the schema object that corresponds to the specified dot separated
-     * path from the specified schema object.
-     *
-     * @param path - The path separated by dots
-     * @param schema - The schema object
-     * @returns The sub schema
-     */
-    const pathToSchema = function (path: string | number, schema: object): object | null {
-        if (typeof path === 'string') {
-            path = path.split('.');
-        }
-
-        if (typeof path === 'number') {
-            path = [path];
-        }
-
-        let result = schema;
-        for (let i = 0, len = path.length; i < len; i++) {
-            const p = path[i];
-            if (result.$type === 'map' && result.$of) {
-                result = result.$of;
-            } else if (result[p] || (result.$type && result.$type[p])) {
-                result = result[p] || result.$type[p];
-            } else if ((!isNaN(parseInt(p, 10)) && Array.isArray(result)) || Array.isArray(result.$type)) {
-                result = Array.isArray(result) ? result[0] : result.$type[0];
-            } else {
-                return null;
-            }
-        }
-
-        return result;
-    };
-
-    /**
-     * Converts the specified schema object to a type recursively.
-     *
-     * @param schema - The schema object or field of a parent schema object.
-     * @param fixedLength - Whether the specified schema field has a fixed length if it's an array type.
-     * @returns The type
-     */
-    const schemaToType = function (schema: object | string | unknown[], fixedLength?: number): string {
-        if (typeof schema === 'string') {
-            if (schema === 'map' || schema === 'mixed') {
-                schema = 'object';
-            }
-
-            return schema.toLowerCase();
-        }
-
-        if (schema.$editorType) {
-            return schema.$editorType;
-        }
-
-        if (Array.isArray(schema)) {
-            if (schema[0] === 'number' && fixedLength) {
-                if (fixedLength === 2) {
-                    return 'vec2';
-                }
-                if (fixedLength === 3) {
-                    return 'vec3';
-                }
-                if (fixedLength === 4) {
-                    return 'vec4';
-                }
-            }
-
-            return `array:${schemaToType(schema[0])}`;
-        }
-
-        if (schema.$type) {
-            return schemaToType(schema.$type, schema.$length);
-        }
-
-        return 'object';
-    };
-
-    /**
-     * Gets the type of the specified schema object,
-     *
-     * @param schemaField - A field of the schema
-     * @param fixedLength - Whether this field has a fixed length if it's an array type
-     * @returns The type
-     */
-    editor.method('schema:getType', (schemaField: object, fixedLength?: number): string => {
-        return schemaToType(schemaField, fixedLength);
+    editor.method('schema:getType', (field: object) => {
+        return editor.api.globals.schema.getType(field);
     });
 
-    /**
-     * Gets the type of the specified path from the specified schema
-     *
-     * @param schema - The schema object
-     * @param path - A path separated by dots
-     * @returns The type
-     */
-    editor.method('schema:getTypeForPath', (schema: object, path: string): string => {
-        const subSchema = pathToSchema(path, schema);
-        let type = subSchema && schemaToType(subSchema);
+    editor.method('schema:getTypeForPath', (schema: object, path: string) => {
+        const type = editor.api.globals.schema.getTypeForPath(schema, path, false);
+        if (type) return type;
 
-        if (!type) {
-            console.warn(`Unknown type for ${path}`);
-            type = 'string';
-        }
-
-        return type;
+        console.warn(`Unknown type for ${path}`);
+        return 'string';
     });
 
-    /**
-     * Gets the merge method for the specified path from the specified schema
-     *
-     * @param schema - The schema object
-     * @param path - A path separated by dots
-     * @returns The merge method for the path, or undefined
-     */
-    editor.method('schema:getMergeMethodForPath', (schema: object, path: string): string | undefined => {
-        const h = pathToSchema(path, schema);
-
-        return h && (h as { $mergeMethod?: string }).$mergeMethod;
+    editor.method('schema:getMergeMethodForPath', (schema: object, path: string) => {
+        return editor.api.globals.schema.getMergeMethodForPath(schema, path, false);
     });
 });

--- a/src/editor/storage/clipboard-context-menu.ts
+++ b/src/editor/storage/clipboard-context-menu.ts
@@ -3,9 +3,6 @@ import { Color } from 'playcanvas';
 
 const colorA = new Color();
 
-// list of asset types
-const assetTypes = config.schema.asset.type.$enum;
-
 // supported types for a context menu
 const types = new Set([
     'boolean',
@@ -31,12 +28,6 @@ const types = new Set([
     'assets',
     'array:asset'
 ]);
-
-// add support for specific asset types
-for (const type of assetTypes) {
-    types.add(`asset:${type}`);
-    types.add(`array:asset:${type}`);
-}
 
 // converts string to vector (2-4 components)
 // these formats supported:
@@ -586,93 +577,99 @@ const convertTypes = new Map<string, (n: unknown, o: unknown) => unknown>([
     ]
 ]);
 
-// additional assets conversions
-for (const type of assetTypes) {
-    convertTypes.set(`asset:${type}-asset`, (n: unknown, o: unknown) => {
-        return n;
-    });
+const addAssetTypes = () => {
+    for (const type of editor.api.globals.schema.getAssetTypes()) {
+        types.add(`asset:${type}`);
+        types.add(`array:asset:${type}`);
 
-    convertTypes.set(`asset-asset:${type}`, (n: unknown, o: unknown) => {
-        if (!n) {
-            return null;
-        }
-
-        const assetType = editor.call('assets:get', n)?.get('type');
-        if (!assetType) {
-            return o;
-        }
-
-        if (assetType === type) {
+        convertTypes.set(`asset:${type}-asset`, (n: unknown, o: unknown) => {
             return n;
-        }
+        });
 
-        return o;
-    });
-
-    convertTypes.set(`asset-array:asset:${type}`, (n: unknown, o: unknown) => {
-        if (!n) {
-            return [];
-        }
-
-        if (Array.isArray(n)) {
-            const items = [];
-            for (let i = 0; i < n.length; i++) {
-                const id = n[i];
-                const assetType = editor.call('assets:get', id)?.get('type');
-
-                if (!assetType) {
-                    continue;
-                }
-
-                if (assetType === type) {
-                    items.push(id);
-                }
+        convertTypes.set(`asset-asset:${type}`, (n: unknown, o: unknown) => {
+            if (!n) {
+                return null;
             }
 
-            if (items.length) {
-                return items;
-            }
-
-            return o;
-        } else if (n) {
             const assetType = editor.call('assets:get', n)?.get('type');
-
             if (!assetType) {
                 return o;
             }
 
             if (assetType === type) {
-                return [n];
+                return n;
             }
-        }
 
-        return o;
-    });
+            return o;
+        });
 
-    convertTypes.set(`array:asset:${type}-array:asset`, (n: unknown, o: unknown) => {
-        return n;
-    });
+        convertTypes.set(`asset-array:asset:${type}`, (n: unknown, o: unknown) => {
+            if (!n) {
+                return [];
+            }
 
-    convertTypes.set(`number-asset:${type}`, (n: unknown, o: unknown) => {
-        if (!n) {
+            if (Array.isArray(n)) {
+                const items = [];
+                for (let i = 0; i < n.length; i++) {
+                    const id = n[i];
+                    const assetType = editor.call('assets:get', id)?.get('type');
+
+                    if (!assetType) {
+                        continue;
+                    }
+
+                    if (assetType === type) {
+                        items.push(id);
+                    }
+                }
+
+                if (items.length) {
+                    return items;
+                }
+
+                return o;
+            } else if (n) {
+                const assetType = editor.call('assets:get', n)?.get('type');
+
+                if (!assetType) {
+                    return o;
+                }
+
+                if (assetType === type) {
+                    return [n];
+                }
+            }
+
             return o;
-        }
-        const asset = editor.call('assets:get', n);
-        if (!asset) {
-            return o;
-        }
-        if (asset.get('type') !== type) {
-            return o;
-        }
-        return n;
-    });
-}
+        });
+
+        convertTypes.set(`array:asset:${type}-array:asset`, (n: unknown, o: unknown) => {
+            return n;
+        });
+
+        convertTypes.set(`number-asset:${type}`, (n: unknown, o: unknown) => {
+            if (!n) {
+                return o;
+            }
+            const asset = editor.call('assets:get', n);
+            if (!asset) {
+                return o;
+            }
+            if (asset.get('type') !== type) {
+                return o;
+            }
+            return n;
+        });
+    }
+};
 
 editor.method('clipboard:types', () => {
     return types;
 });
 
 editor.once('load', () => {
+    addAssetTypes();
+
     const root = editor.call('layout.root');
     const hasWriteAccess = () => editor.call('permissions:write');
 

--- a/src/editor/templates/template-utils.ts
+++ b/src/editor/templates/template-utils.ts
@@ -259,7 +259,7 @@ editor.once('load', () => {
 
             const s = TemplateUtils.pathToStr(path);
 
-            const m = editor.call('schema:getMergeMethodForPath', config.schema.scene, s);
+            const m = editor.call('schema:getMergeMethodForPath', editor.api.globals.schema.getDocument('scene'), s);
 
             return m === method;
         },

--- a/src/editor/templates/templates-override-panel.ts
+++ b/src/editor/templates/templates-override-panel.ts
@@ -717,7 +717,11 @@ class TemplateOverridesView extends Container {
                 }
             } else if (pathParts.length === 5) {
                 attributeName = pathParts[4];
-                type = editor.call('schema:getTypeForPath', config.schema.scene, `entities.$.${override.path}`);
+                type = editor.call(
+                    'schema:getTypeForPath',
+                    editor.api.globals.schema.getDocument('scene'),
+                    `entities.$.${override.path}`
+                );
             }
 
             if (attributeName) {
@@ -772,7 +776,11 @@ class TemplateOverridesView extends Container {
                 result.overrideGroups[soundSlotName].missingInSrc = true;
             }
         } else {
-            const type = editor.call('schema:getTypeForPath', config.schema.scene, `entities.$.${override.path}`);
+            const type = editor.call(
+                'schema:getTypeForPath',
+                editor.api.globals.schema.getDocument('scene'),
+                `entities.$.${override.path}`
+            );
             const field = this._prettifyName(pathParts[4]);
             result.overrideGroups[soundSlotName].properties.push(...this._createGridLine(field, type, override, false));
         }
@@ -821,7 +829,11 @@ class TemplateOverridesView extends Container {
                 result.overrideGroups[clipName].missingInSrc = true;
             }
         } else {
-            const type = editor.call('schema:getTypeForPath', config.schema.scene, `entities.$.${override.path}`);
+            const type = editor.call(
+                'schema:getTypeForPath',
+                editor.api.globals.schema.getDocument('scene'),
+                `entities.$.${override.path}`
+            );
             const field = this._prettifyName(pathParts[4]);
             result.overrideGroups[clipName].properties.push(...this._createGridLine(field, type, override, false));
         }
@@ -1030,7 +1042,11 @@ class TemplateOverridesView extends Container {
                     type = 'string';
                 } else {
                     field = parts[0];
-                    type = editor.call('schema:getTypeForPath', config.schema.scene, `entities.$.${parts[0]}`);
+                    type = editor.call(
+                        'schema:getTypeForPath',
+                        editor.api.globals.schema.getDocument('scene'),
+                        `entities.$.${parts[0]}`
+                    );
                 }
 
                 fields.properties.push(...this._createGridLine(this._prettifyName(field), type, override, false));
@@ -1060,7 +1076,7 @@ class TemplateOverridesView extends Container {
                         } else {
                             type = editor.call(
                                 'schema:getTypeForPath',
-                                config.schema.scene,
+                                editor.api.globals.schema.getDocument('scene'),
                                 `entities.$.components.${parts[1]}.${parts[2]}`
                             );
                             field = parts[2];

--- a/test/editor-api/api/test-assets.js
+++ b/test/editor-api/api/test-assets.js
@@ -562,7 +562,9 @@ ${className}.prototype.update = function(dt) {
         expect(data.get('preload')).to.equal('true');
         expect(data.get('data')).to.equal(JSON.stringify({
             diffuse: [0, 0, 0],
-            opacity: 0
+            opacity: 0,
+            useLighting: false,
+            blendType: 0
         }));
     });
 

--- a/test/editor-api/api/test-assets.js
+++ b/test/editor-api/api/test-assets.js
@@ -60,6 +60,22 @@ ${className}.prototype.update = function(dt) {
         expect(assets.getUnique(2)).to.equal(asset);
     });
 
+    it('replace updates model material mappings', function () {
+        api.globals.schema = new api.Schema(schema);
+        api.globals.entities = new api.Entities();
+        const root = api.globals.entities.create();
+        const entity = api.globals.entities.create({ parent: root });
+        entity.addComponent('model', { mapping: { 0: 1 } });
+
+        const oldAsset = new api.Asset({ type: 'material', id: 1 });
+        const newAsset = new api.Asset({ type: 'material', id: 2 });
+        assets.add(oldAsset);
+        assets.add(newAsset);
+        oldAsset.replace(newAsset, { history: false });
+
+        expect(entity.get('components.model.mapping.0')).to.equal(2);
+    });
+
     it('add does not add duplicate asset', function () {
         const asset = new api.Asset({ type: 'material', id: 1 });
         assets.add(asset);

--- a/test/editor-api/api/test-entities.js
+++ b/test/editor-api/api/test-entities.js
@@ -1377,6 +1377,29 @@ describe('api.Entities tests', function () {
         }));
     });
 
+    it('copy and cross-project paste preserve model material mappings', async function () {
+        prepareCopyTest();
+
+        const source = new api.Asset({ id: 1, type: 'material', path: [], name: 'mat' });
+        api.globals.assets.add(source);
+        const root = api.globals.entities.create();
+        const e = api.globals.entities.create({ parent: root });
+        e.addComponent('model', { mapping: { 0: source.get('id') } });
+
+        api.globals.entities.copyToClipboard([e]);
+        expect(api.globals.clipboard.value.assets).to.deep.equal({
+            1: { path: ['mat'], type: 'material' }
+        });
+
+        api.globals.projectId = 2;
+        api.globals.assets.remove(source);
+        const target = new api.Asset({ id: 2, type: 'material', path: [], name: 'mat' });
+        api.globals.assets.add(target);
+
+        const pasted = await api.globals.entities.pasteFromClipboard(root);
+        expect(pasted[0].get('components.model.mapping.0')).to.equal(target.get('id'));
+    });
+
     it('copy picks up assets from script attributes', function () {
         prepareCopyTest();
 

--- a/test/editor-api/api/test-entity.js
+++ b/test/editor-api/api/test-entity.js
@@ -231,6 +231,25 @@ describe('api.Entity tests', function () {
         expect(e.has('components.testcomponent.entityRef')).to.equal(true);
     });
 
+    it('addComponent resolves runtime and legacy defaults', function () {
+        api.globals.schema = new api.Schema(structuredClone(schema));
+        const components = api.globals.schema.getFields(api.globals.schema.getComponents());
+        const fields = api.globals.schema.getFields(components.testcomponent);
+        fields.count.default = () => 7;
+        const scripts = api.globals.schema.getFields(components.script);
+        scripts.scripts.default = [];
+        delete scripts.order;
+
+        const e = api.globals.entities.create();
+        e.addComponent('testcomponent');
+        expect(e.get('components.testcomponent.count')).to.equal(7);
+        expect(api.globals.schema.components.resolvePath('testcomponent', 'count').default).to.equal(7);
+
+        const legacy = api.globals.entities.create();
+        legacy.addComponent('script');
+        expect(legacy.get('components.script')).to.deep.equal({ enabled: true, scripts: [] });
+    });
+
     it('addComponent accepts partial data', function () {
         api.globals.schema = new api.Schema(schema);
         const e = api.globals.entities.create();

--- a/test/editor-api/api/test-schema.js
+++ b/test/editor-api/api/test-schema.js
@@ -12,6 +12,7 @@ describe('api.Schema tests', function () {
         withSchema(() => {
             const fields = api.globals.schema.components.getFieldsOfType('testcomponent', 'entity');
             expect(fields).to.deep.equal(['entityRef', 'entityArrayRef', 'nestedEntityRef.*.entity']);
+            expect(api.globals.schema.components.getFieldsOfType('model', 'asset')).to.deep.equal(['mapping.*']);
         });
     });
 
@@ -109,7 +110,7 @@ describe('api.Schema tests', function () {
         withSchema(() => {
             const vec2 = { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 };
             expect(api.globals.schema.getType(vec2)).to.equal('vec2');
-            expect(api.globals.schema.components.list()).to.deep.equal(['script', 'testcomponent']);
+            expect(api.globals.schema.components.list()).to.deep.equal(['model', 'script', 'testcomponent']);
             expect(api.globals.schema.assets.getFieldsOfType('test', 'asset')).to.deep.equal([
                 'data.assetRef',
                 'data.assetArrayRef',
@@ -121,7 +122,7 @@ describe('api.Schema tests', function () {
         });
     });
 
-    it('preserves the loose legacy Caller path separately from typed resolution', function () {
+    it('preserves the loose caller path separately from typed resolution', function () {
         withSchema(() => {
             const model = api.globals.schema.getAssetData('model');
             expect(api.globals.schema.getTypeForPath(model, 'mapping.anyKey.material', false)).to.equal('asset');
@@ -135,6 +136,9 @@ describe('api.Schema tests', function () {
         );
         expect(() => new api.Schema({ version: 2, documents: {}, assetData: {} })).to.throw(
             'Unsupported Editor schema version: 2'
+        );
+        expect(() => new api.Schema({ version: 0, documents: {}, assetData: {} })).to.throw(
+            'Unsupported Editor schema version: 0'
         );
         expect(() => new api.Schema({ version: 1 })).to.throw('Unsupported Editor schema version: 1');
     });

--- a/test/editor-api/api/test-schema.js
+++ b/test/editor-api/api/test-schema.js
@@ -3,46 +3,139 @@ describe('api.Schema tests', function () {
         api.globals.schema = null;
     });
 
-    it('components.getFieldsOfType returns fields', function () {
+    const withSchema = (callback) => {
         api.globals.schema = new api.Schema(schema);
-        const fields = api.globals.schema.components.getFieldsOfType('testcomponent', 'entity');
-        expect(fields).to.deep.equal(['entityRef', 'entityArrayRef', 'nestedEntityRef.*.entity']);
+        callback();
+    };
+
+    it('components.getFieldsOfType returns fields', function () {
+        withSchema(() => {
+            const fields = api.globals.schema.components.getFieldsOfType('testcomponent', 'entity');
+            expect(fields).to.deep.equal(['entityRef', 'entityArrayRef', 'nestedEntityRef.*.entity']);
+        });
     });
 
     it('components.resolvePath resolves fixed fields and open maps', function () {
-        api.globals.schema = new api.Schema(schema);
-        expect(api.globals.schema.components.resolvePath('testcomponent', 'entityRef')).to.include({
-            default: null,
-            hasDefault: true,
-            open: false
+        withSchema(() => {
+            expect(api.globals.schema.components.resolvePath('testcomponent', 'entityRef')).to.include({
+                default: null,
+                hasDefault: true,
+                open: false
+            });
+            expect(api.globals.schema.components.resolvePath('testcomponent', 'nestedEntityRef.item.entity')).to.include({
+                hasDefault: false,
+                open: true
+            });
+            expect(api.globals.schema.components.resolvePath('script', 'scripts.rotate.attributes.speed')).to.include({
+                open: true
+            });
+            expect(api.globals.schema.components.resolvePath('testcomponent', 'missing')).to.equal(null);
         });
-        expect(api.globals.schema.components.resolvePath('testcomponent', 'nestedEntityRef.item.entity')).to.include({
-            hasDefault: false,
-            open: true
-        });
-        expect(api.globals.schema.components.resolvePath('script', 'scripts.rotate.attributes.speed')).to.include({
-            open: true
-        });
-        expect(api.globals.schema.components.resolvePath('testcomponent', 'missing')).to.equal(null);
     });
 
     it('assets.resolvePath resolves fixed fields, arrays and open maps', function () {
-        api.globals.schema = new api.Schema(schema);
-        expect(api.globals.schema.assets.resolvePath('material', 'diffuse')).to.deep.include({
-            default: [0, 0, 0],
-            hasDefault: true,
-            open: false
+        withSchema(() => {
+            expect(api.globals.schema.assets.resolvePath('material', 'diffuse')).to.deep.include({
+                default: [0, 0, 0],
+                hasDefault: true,
+                open: false
+            });
+            expect(api.globals.schema.assets.resolvePath('model', 'mapping.0.material')).to.include({
+                hasDefault: false,
+                open: false
+            });
+            expect(api.globals.schema.assets.resolvePath('test', 'nestedAssetRef.item.asset')).to.include({
+                default: null,
+                hasDefault: true,
+                open: true
+            });
+            expect(api.globals.schema.assets.resolvePath('model', 'mapping.nope.material')).to.equal(null);
+            expect(api.globals.schema.assets.resolvePath('material', 'missing')).to.equal(null);
         });
-        expect(api.globals.schema.assets.resolvePath('model', 'mapping.0.material')).to.include({
-            hasDefault: false,
-            open: false
+    });
+
+    it('resolves open maps without value schemas and keeps typed arrays numeric-only', function () {
+        withSchema(() => {
+            expect(api.globals.schema.assets.resolvePath('font', 'kerning.anyKey')).to.deep.equal({
+                field: null,
+                default: undefined,
+                hasDefault: false,
+                open: true
+            });
+            expect(api.globals.schema.assets.resolvePath('model', 'mapping.anyKey.material')).to.equal(null);
+            expect(api.globals.schema.assets.resolvePath('model', 'mapping.-1.material')).to.equal(null);
         });
-        expect(api.globals.schema.assets.resolvePath('test', 'nestedAssetRef.item.asset')).to.include({
-            default: null,
-            hasDefault: true,
-            open: true
+    });
+
+    it('preserves falsey and nested defaults', function () {
+        withSchema(() => {
+            expect(api.globals.schema.assets.getDefaultData('material')).to.deep.equal({
+                diffuse: [0, 0, 0],
+                opacity: 1,
+                useLighting: false,
+                blendType: 0
+            });
+            expect(api.globals.schema.assets.getDefaultData('animstategraph')).to.deep.equal({ testData: 0 });
+            expect(api.globals.schema.assets.getDefaultData('missing')).to.equal(null);
+            expect(api.globals.schema.components.getDefaultData('testcomponent')).to.deep.equal({
+                enabled: false,
+                count: 0,
+                vector: [0, 0, 0],
+                nestedDefault: { enabled: false, count: 0 },
+                entityRef: null,
+                entityArrayRef: [],
+                assetRef: null,
+                assetArrayRef: []
+            });
         });
-        expect(api.globals.schema.assets.resolvePath('model', 'mapping.nope.material')).to.equal(null);
-        expect(api.globals.schema.assets.resolvePath('material', 'missing')).to.equal(null);
+    });
+
+    it('preserves scene and scoped settings defaults', function () {
+        withSchema(() => {
+            expect(api.globals.schema.scene.getDefaultPhysicsSettings()).to.deep.equal({
+                gravity: [0, -9.8, 0],
+                enabled: false
+            });
+            expect(api.globals.schema.scene.getDefaultRenderSettings()).to.deep.equal({ fog: 'none', exposure: 0 });
+            expect(api.globals.schema.settings.getDefaultProjectSettings()).to.deep.equal({ projectFlag: false });
+            expect(api.globals.schema.settings.getDefaultUserSettings()).to.deep.equal({ userCount: 0 });
+            expect(api.globals.schema.settings.getDefaultProjectUserSettings()).to.deep.equal({
+                nested: { projectUserValue: '' }
+            });
+        });
+    });
+
+    it('preserves types, metadata, lists and reference paths', function () {
+        withSchema(() => {
+            const vec2 = { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 };
+            expect(api.globals.schema.getType(vec2)).to.equal('vec2');
+            expect(api.globals.schema.components.list()).to.deep.equal(['script', 'testcomponent']);
+            expect(api.globals.schema.assets.getFieldsOfType('test', 'asset')).to.deep.equal([
+                'data.assetRef',
+                'data.assetArrayRef',
+                'data.nestedAssetRef.*.asset'
+            ]);
+            expect(api.globals.schema.getAssetTypes()).to.deep.equal(['material', 'model', 'font', 'test']);
+            const field = api.globals.schema.assets.resolvePath('model', 'mapping').field;
+            expect(field['x-merge-method']).to.equal('stop_and_report_conflict');
+        });
+    });
+
+    it('preserves the loose legacy Caller path separately from typed resolution', function () {
+        withSchema(() => {
+            const model = api.globals.schema.getAssetData('model');
+            expect(api.globals.schema.getTypeForPath(model, 'mapping.anyKey.material', false)).to.equal('asset');
+            expect(api.globals.schema.assets.resolvePath('model', 'mapping.anyKey.material')).to.equal(null);
+        });
+    });
+
+    it('rejects unsupported versioned payloads', function () {
+        expect(() => new api.Schema({ documents: {}, assetData: {} })).to.throw(
+            'Unsupported Editor schema version: undefined'
+        );
+        expect(() => new api.Schema({ version: 2, documents: {}, assetData: {} })).to.throw(
+            'Unsupported Editor schema version: 2'
+        );
+        expect(() => new api.Schema({ version: 1 })).to.throw('Unsupported Editor schema version: 1');
     });
 });

--- a/test/editor-api/lib/schema.js
+++ b/test/editor-api/lib/schema.js
@@ -1,116 +1,120 @@
-// test schema
+const object = (properties, data = {}) => ({
+    type: 'object',
+    properties,
+    additionalProperties: false,
+    ...data
+});
+
+const array = (items, data = {}) => ({ type: 'array', items, ...data });
+
+const map = (additionalProperties, data = {}) => ({
+    type: 'object',
+    additionalProperties,
+    'x-open-map': true,
+    ...data
+});
+
+const nullable = (field, data = {}) => ({
+    anyOf: [field, { type: 'null' }],
+    ...data
+});
+
+const entity = object({
+    components: object({
+        testcomponent: object({
+            enabled: { type: 'boolean', default: false },
+            count: { type: 'number', default: 0 },
+            vector: array({ type: 'number' }, { minItems: 3, maxItems: 3, default: [0, 0, 0] }),
+            nestedDefault: object(
+                { enabled: { type: 'boolean' }, count: { type: 'number' } },
+                { default: { enabled: false, count: 0 } }
+            ),
+            entityRef: nullable(
+                { type: 'string' },
+                { default: null, 'x-editor-type': 'entity' }
+            ),
+            entityArrayRef: { type: 'string', default: [], 'x-editor-type': 'array:entity' },
+            nestedEntityRef: map(
+                object({
+                    entity: { type: 'string', 'x-editor-type': 'entity' }
+                })
+            ),
+            assetRef: nullable(
+                { type: 'number' },
+                { default: null, 'x-editor-type': 'asset' }
+            ),
+            assetArrayRef: { type: 'string', default: [], 'x-editor-type': 'array:asset' },
+            nestedAssetRef: map(
+                object({
+                    asset: { type: 'number', default: null, 'x-editor-type': 'asset' }
+                })
+            )
+        }),
+        script: object({
+            enabled: { type: 'boolean', default: true },
+            order: array({ type: 'string' }, { default: [] }),
+            scripts: map({}, { default: {} })
+        }),
+        zone: object({ enabled: { type: 'boolean', default: true } })
+    })
+});
+
 window.schema = {
-    scene: {
-        entities: {
-            $of: {
-                components: {
-                    testcomponent: {
-                        entityRef: {
-                            $type: 'string',
-                            $editorType: 'entity',
-                            $allowNull: true,
-                            $default: null
-                        },
-                        entityArrayRef: {
-                            $type: 'string',
-                            $editorType: 'array:entity',
-                            $default: []
-                        },
-                        nestedEntityRef: {
-                            $type: 'map',
-                            $of: {
-                                entity: {
-                                    $type: 'string',
-                                    $editorType: 'entity'
-                                }
-                            }
-                        },
-                        assetRef: {
-                            $type: 'number',
-                            $editorType: 'asset',
-                            $allowNull: true,
-                            $default: null
-                        },
-                        assetArrayRef: {
-                            $type: '[number]',
-                            $editorType: 'array:asset',
-                            $default: []
-                        },
-                        nestedAssetRef: {
-                            $type: 'map',
-                            $of: {
-                                asset: {
-                                    $type: 'number',
-                                    $editorType: 'asset',
-                                    $default: null
-                                }
-                            }
-                        }
-                    },
-                    script: {
-                        enabled: {
-                            $type: 'boolean',
-                            $default: true
-                        },
-                        order: {
-                            $type: ['string'],
-                            $default: []
-                        },
-                        scripts: {
-                            $type: 'map',
-                            $default: {}
-                        }
-                    }
-                }
-            }
-        }
+    version: 0,
+    documents: {
+        scene: object({
+            settings: object({
+                physics: object({
+                    gravity: array(
+                        { type: 'number' },
+                        { minItems: 3, maxItems: 3, default: [0, -9.8, 0] }
+                    ),
+                    enabled: { type: 'boolean', default: false }
+                }),
+                render: object({
+                    fog: { type: 'string', default: 'none' },
+                    exposure: { type: 'number', default: 0 }
+                })
+            }),
+            entities: map(entity)
+        }),
+        settings: object({
+            projectFlag: { type: 'boolean', default: false, 'x-scope': 'project' },
+            userCount: { type: 'number', default: 0, 'x-scope': 'user' },
+            nested: object({
+                projectUserValue: { type: 'string', default: '', 'x-scope': 'projectUser' }
+            })
+        }),
+        asset: object({
+            type: { type: 'string', enum: ['material', 'model', 'font', 'test'] }
+        })
     },
-    animstategraphData: {
-        testData: {
-            $type: 'number',
-            $default: 0
-        }
-    },
-    materialData: {
-        diffuse: {
-            $type: ["number"],
-            $default: [0, 0, 0]
-        },
-        opacity: {
-            $type: "number",
-            $default: 1
-        }
-    },
-    modelData: {
-        mapping: {
-            $type: [{
-                material: {
-                    $type: 'number',
-                    $editorType: 'asset'
-                }
-            }]
-        }
-    },
-    testData: {
-        assetRef: {
-            $type: 'number',
-            $editorType: 'asset',
-            $default: null
-        },
-        assetArrayRef: {
-            $type: ['number'],
-            $editorType: 'array:asset',
-            $default: []
-        },
-        nestedAssetRef: {
-            $type: 'map',
-            $of: {
-                asset: {
-                    $type: 'number',
-                    $editorType: 'asset',
-                    $default: null
-                }
-            }
-        }
+    assetData: {
+        animstategraph: object({ testData: { type: 'number', default: 0 } }),
+        material: object({
+            diffuse: array({ type: 'number' }, { default: [0, 0, 0] }),
+            opacity: { type: 'number', default: 1 },
+            useLighting: { type: 'boolean', default: false },
+            blendType: { type: 'number', default: 0 }
+        }),
+        model: object({
+            mapping: array(
+                object({ material: { type: 'number', 'x-editor-type': 'asset' } }),
+                { 'x-merge-method': 'stop_and_report_conflict' }
+            )
+        }),
+        font: object({ kerning: map(false) }),
+        test: object({
+            assetRef: { type: 'number', default: null, 'x-editor-type': 'asset' },
+            assetArrayRef: array(
+                { type: 'number', 'x-editor-type': 'asset' },
+                { default: [], 'x-editor-type': 'array:asset' }
+            ),
+            nestedAssetRef: map(
+                object({
+                    asset: { type: 'number', default: null, 'x-editor-type': 'asset' }
+                })
+            )
+        })
     }
 };

--- a/test/editor-api/lib/schema.js
+++ b/test/editor-api/lib/schema.js
@@ -21,6 +21,9 @@ const nullable = (field, data = {}) => ({
 
 const entity = object({
     components: object({
+        model: object({
+            mapping: nullable(map(nullable({ type: 'number' }, { 'x-editor-type': 'asset' })))
+        }),
         testcomponent: object({
             enabled: { type: 'boolean', default: false },
             count: { type: 'number', default: 0 },
@@ -60,7 +63,7 @@ const entity = object({
 });
 
 window.schema = {
-    version: 0,
+    version: 1,
     documents: {
         scene: object({
             settings: object({


### PR DESCRIPTION
## Summary

Updates the schema API to consume a **versioned (`version: 1`) JSON-Schema catalog** for asset / scene / settings / component schemas, replacing the previous `$`-prefixed schema shape. Schema nodes now use standard JSON-Schema keywords (`type`, `properties`, `items`, `additionalProperties`, `enum`, `default`, `minItems`/`maxItems`, `anyOf` for nullability) plus `x-editor-type` / `x-merge-method` / `x-scope` / `x-open-map` extensions.

## Changes

- **`editor-api/schema*`** — read the JSON-Schema catalog shape (type, default, enum, exact length, nullability via `anyOf`) and map metadata to the `x-*` extension keys. `Schema` now fail-fasts on a non-`version: 1` payload.
- **Inspector, components menu, templates override panel, clipboard** — updated to the new node shape.
- **Fix — `AssetsSchema.resolvePath`** now returns a deep copy of a field's `default` instead of a live reference into the shared catalog. Previously a consumer that mutated the returned default (e.g. on an unset→set edit) could corrupt the schema default for the rest of the session. This matches the existing behaviour of `ComponentSchema.resolvePath`.
- **Fix — `schema:material:getType`** falls back to `'string'` (with a warning) for an unresolved path instead of returning `null`, restoring the prior `getTypeForPath` behaviour, and resolves the path once instead of twice.

## Testing

- `npm run test:api` — 202/202 passing
- `npm test` — 176/176 passing
- `npm run build` — clean
- `npm run lint` — 0 errors
- `npm run typecheck` — no new errors introduced (project baseline unchanged)

The default-aliasing fix and the `getType` fallback were additionally verified end-to-end in a running editor: the unpatched resolve path shares a reference into the live catalog, the patched wrapper returns an independent copy each call, and mutating the returned default no longer affects the catalog.
