### PR TITLE
fix: sync scene picker name cache

### DIFF
--- a/src/editor/pickers/picker-scene.ts
+++ b/src/editor/pickers/picker-scene.ts
@@ -513,6 +513,20 @@ editor.once('load', () => {
         editor.call('picker:project:close');
     });
 
+    editor.on('scene:name', (name) => {
+        const scene = scenes.find(
+            (scene) => parseInt(String(scene.id), 10) === parseInt(String(config.scene.id), 10)
+        );
+        if (!scene) {
+            return;
+        }
+
+        scene.name = name;
+        if (!container.hidden) {
+            refreshScenes();
+        }
+    });
+
     // subscribe to messenger scene.delete
     editor.on('messenger:scene.delete', (data) => {
         if (data.scene.branchId !== config.self.branch.id) {

--- a/src/editor/pickers/picker-scene.ts
+++ b/src/editor/pickers/picker-scene.ts
@@ -514,9 +514,7 @@ editor.once('load', () => {
     });
 
     editor.on('scene:name', (name) => {
-        const scene = scenes.find(
-            (scene) => parseInt(String(scene.id), 10) === parseInt(String(config.scene.id), 10)
-        );
+        const scene = scenes.find((scene) => parseInt(String(scene.id), 10) === parseInt(String(config.scene.id), 10));
         if (!scene) {
             return;
         }


### PR DESCRIPTION
Closes #2195

### What's Changed

- Keep the cached scene picker entry in sync with current-scene rename events.
- Refresh the visible scene list immediately after a rename.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

### Manual smoke test

1. Duplicate a scene and open the duplicate.
2. Rename the duplicate in Project Settings.
3. Open the Scenes picker and verify the duplicate appears under its new name.