### PR TITLE
fix: omit obsolete lightmap component defaults

### DIFF
--- a/src/editor/schema/schema-components.ts
+++ b/src/editor/schema/schema-components.ts
@@ -8,6 +8,13 @@ editor.once('load', () => {
 
     const schema = config.schema.scene.entities.$of.components;
 
+    delete schema.model.castShadowsLightMap;
+    delete schema.model.lightMapped;
+    delete schema.model.lightMapSizeMultiplier;
+    delete schema.render.castShadowsLightMap;
+    delete schema.render.lightMapped;
+    delete schema.render.lightMapSizeMultiplier;
+
     let componentName;
 
     // make titles for each component


### PR DESCRIPTION
Closes #2198

### What's Changed

- Remove obsolete lightmap aliases from the shared component schema before Editor defaults are serialized to Launcher.

### Checks

- [x] I confirm I have read the contributing guidelines.

### Manual smoke test

1. Open a project in Editor and add a Box from the 3D entity menu.
2. Launch the scene and open the browser console.
3. Confirm the box renders and no errors mention castShadowsLightMap, lightMapped, or lightMapSizeMultiplier.