### PR TITLE
feat: customize editor toolbar

### DIFF
--- a/sass/editor/_editor-left-toolbar.scss
+++ b/sass/editor/_editor-left-toolbar.scss
@@ -21,13 +21,8 @@
             display: none !important;
         }
 
-        &[data-toolbar-id] {
-            cursor: grab;
-        }
-
         &.toolbar-dragging {
             opacity: 0.4;
-            cursor: grabbing;
         }
 
         &.logo {
@@ -132,6 +127,54 @@
             order: 6;
         }
     }
+
+    &.toolbar-editing {
+        > .pcui-button[data-toolbar-id]:not(.hidden) {
+            display: block !important;
+            position: relative;
+            overflow: visible;
+            cursor: move;
+        }
+
+        .toolbar-visibility {
+            display: grid;
+        }
+    }
+
+    .toolbar-visibility {
+        position: absolute;
+        z-index: 1;
+        top: 3px;
+        right: -8px;
+        display: none;
+        place-items: center;
+        box-sizing: border-box;
+        width: 17px;
+        height: 17px;
+        border: 1px solid $text-dark;
+        border-radius: 50%;
+        color: $text-primary;
+        background: $bcg-darkest;
+        line-height: 0;
+        cursor: pointer;
+
+        .toolbar-visibility-icon {
+            width: 11px;
+            height: 11px;
+            pointer-events: none;
+        }
+    }
+
+    .toolbar-user-hidden .toolbar-visibility {
+        color: $text-active;
+    }
+}
+
+#layout-root > .toolbar-edit-done {
+    position: absolute;
+    z-index: 400;
+    top: 4px;
+    left: 44px;
 }
 
 #layout-toolbar.hide-items > div {

--- a/sass/editor/_editor-left-toolbar.scss
+++ b/sass/editor/_editor-left-toolbar.scss
@@ -145,7 +145,7 @@
         position: absolute;
         z-index: 1;
         top: 3px;
-        right: -8px;
+        right: 1px;
         display: none;
         place-items: center;
         box-sizing: border-box;

--- a/sass/editor/_editor-left-toolbar.scss
+++ b/sass/editor/_editor-left-toolbar.scss
@@ -34,6 +34,20 @@
             &:hover {
                 background-position: -40px 0;
             }
+
+            &.toolbar-done {
+                color: $text-primary;
+                background-color: $bcg-darkest;
+                background-image: none;
+                font-size: 20px;
+                line-height: 38px;
+                text-align: center;
+
+                &:hover,
+                &:focus {
+                    background-color: $bcg-dark;
+                }
+            }
         }
 
         &.icon,
@@ -144,37 +158,49 @@
     .toolbar-visibility {
         position: absolute;
         z-index: 1;
-        top: 3px;
-        right: 1px;
+        top: 0;
+        right: 0;
         display: none;
-        place-items: center;
+        align-items: center;
+        justify-content: center;
         box-sizing: border-box;
-        width: 17px;
-        height: 17px;
-        border: 1px solid $text-dark;
-        border-radius: 50%;
+        width: 20px;
+        height: 20px;
+        border: none;
+        border-radius: 0;
         color: $text-primary;
         background: $bcg-darkest;
-        line-height: 0;
+        font-family: pc-icon;
+        font-size: 14px;
+        line-height: 1;
         cursor: pointer;
 
-        .toolbar-visibility-icon {
-            width: 11px;
-            height: 11px;
-            pointer-events: none;
+        &:hover,
+        &:focus {
+            background: $bcg-dark;
+        }
+
+        &.toolbar-visibility-hidden {
+            color: $text-secondary;
+
+            &::after {
+                content: '';
+                position: absolute;
+                left: 3px;
+                right: 3px;
+                top: calc(50% - 1px);
+                height: 2px;
+                background: currentcolor;
+                transform: rotate(-45deg);
+                pointer-events: none;
+            }
+
+            &:hover,
+            &:focus {
+                color: $text-primary;
+            }
         }
     }
-
-    .toolbar-user-hidden .toolbar-visibility {
-        color: $text-active;
-    }
-}
-
-#layout-root > .toolbar-edit-done {
-    position: absolute;
-    z-index: 400;
-    top: 4px;
-    left: 44px;
 }
 
 #layout-toolbar.hide-items > div {

--- a/sass/editor/_editor-left-toolbar.scss
+++ b/sass/editor/_editor-left-toolbar.scss
@@ -17,6 +17,19 @@
             display: none;
         }
 
+        &.toolbar-user-hidden {
+            display: none !important;
+        }
+
+        &[data-toolbar-id] {
+            cursor: grab;
+        }
+
+        &.toolbar-dragging {
+            opacity: 0.4;
+            cursor: grabbing;
+        }
+
         &.logo {
             background-image: url('https://playcanvas.com/static-assets/images/editor_logo.png');
             background-size: 80px 40px;

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -289,6 +289,7 @@ import './chat/chat-system';
 import './chat/chat-notifications';
 
 // toolbar
+import './toolbar/toolbar-customization';
 import './toolbar/toolbar-logo';
 import './toolbar/toolbar-editor-settings';
 import './toolbar/toolbar-controls';

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -16,6 +16,7 @@ editor.once('load', () => {
     const button = new Button({ class: ['pc-icon', 'mcp'] });
     button.dom.appendChild(new DOMParser().parseFromString(MCP_ICON, 'image/svg+xml').documentElement);
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'mcp', label: 'MCP Server', group: 'main', button });
 
     const tooltip = TooltipHandle.attach({
         target: button.dom,

--- a/src/editor/toolbar/toolbar-code-editor.ts
+++ b/src/editor/toolbar/toolbar-code-editor.ts
@@ -15,6 +15,7 @@ editor.once('load', () => {
 
     const publishButton = toolbar.dom.querySelector('.publish-download');
     toolbar.appendBefore(button, publishButton);
+    editor.call('toolbar:register', { id: 'code-editor', label: 'Code Editor', group: 'main', button });
 
     button.on('click', (e: MouseEvent) => {
         editor.call('picker:codeeditor', undefined, undefined, e.shiftKey);

--- a/src/editor/toolbar/toolbar-controls.ts
+++ b/src/editor/toolbar/toolbar-controls.ts
@@ -10,6 +10,7 @@ editor.once('load', () => {
         icon: 'E136'
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'controls', label: 'Controls', group: 'utility', button });
 
     button.on('click', () => {
         editor.call('help:controls');

--- a/src/editor/toolbar/toolbar-customization.ts
+++ b/src/editor/toolbar/toolbar-customization.ts
@@ -1,12 +1,10 @@
-import { Button, Menu, MenuItem } from '@playcanvas/pcui';
+import { Menu, MenuItem } from '@playcanvas/pcui';
+import type { Button } from '@playcanvas/pcui';
 
 import { mergeToolbarOrder, moveToolbarItem } from './toolbar-order';
 
 const STORAGE_KEY = 'editor:toolbar';
-const EYE_ICON =
-    '<svg class="toolbar-visibility-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="2.5"/></svg>';
-const EYE_OFF_ICON =
-    '<svg class="toolbar-visibility-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l18 18"/><path d="M10.6 6.1A11 11 0 0 1 12 6c6.5 0 10 6 10 6a15 15 0 0 1-2.1 2.8M6.6 6.6C3.6 8.4 2 12 2 12s3.5 6 10 6a10 10 0 0 0 4.2-.9"/></svg>';
+const EYE_ICON = '\uE117';
 
 type Item = {
     id: string;
@@ -50,9 +48,7 @@ editor.once('loaded', () => {
     let moved = false;
     const toggles = new Map<string, HTMLSpanElement>();
     const menu = new Menu();
-    const done = new Button({ class: 'toolbar-edit-done', text: 'DONE', hidden: true });
     root.append(menu);
-    root.append(done);
 
     const save = () => {
         editor.call('localStorage:set', STORAGE_KEY, { hidden: [...hidden], order });
@@ -67,7 +63,8 @@ editor.once('loaded', () => {
             item.button.class.toggle('toolbar-user-hidden', isHidden);
             item.button.class.remove('push-top');
             if (toggle) {
-                toggle.innerHTML = isHidden ? EYE_OFF_ICON : EYE_ICON;
+                toggle.textContent = EYE_ICON;
+                toggle.classList.toggle('toolbar-visibility-hidden', isHidden);
                 toggle.ariaLabel = `${isHidden ? 'Show' : 'Hide'} ${item.label}`;
             }
         });
@@ -84,7 +81,7 @@ editor.once('loaded', () => {
     const setEditing = (value: boolean) => {
         editing = value;
         toolbar.class.toggle('toolbar-editing', value);
-        done.hidden = !value;
+        editor.call('toolbar:logo:editing', value);
         items.forEach((item) => {
             const toggle = toggles.get(item.id)!;
             item.button.dom.draggable = value;
@@ -96,6 +93,7 @@ editor.once('loaded', () => {
         });
         render();
     };
+    editor.method('toolbar:edit:done', () => setEditing(false));
 
     items.forEach((item) => {
         const toggle = document.createElement('span');
@@ -165,7 +163,6 @@ editor.once('loaded', () => {
     });
 
     render();
-    done.on('click', () => setEditing(false));
 
     toolbar.dom.addEventListener('dragover', (evt: DragEvent) => {
         const id = (evt.target as HTMLElement).closest<HTMLElement>('[data-toolbar-id]')?.dataset.toolbarId;

--- a/src/editor/toolbar/toolbar-customization.ts
+++ b/src/editor/toolbar/toolbar-customization.ts
@@ -1,9 +1,12 @@
-import { Menu, MenuItem } from '@playcanvas/pcui';
-import type { Button } from '@playcanvas/pcui';
+import { Button, Menu, MenuItem } from '@playcanvas/pcui';
 
 import { mergeToolbarOrder, moveToolbarItem } from './toolbar-order';
 
 const STORAGE_KEY = 'editor:toolbar';
+const EYE_ICON =
+    '<svg class="toolbar-visibility-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="2.5"/></svg>';
+const EYE_OFF_ICON =
+    '<svg class="toolbar-visibility-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l18 18"/><path d="M10.6 6.1A11 11 0 0 1 12 6c6.5 0 10 6 10 6a15 15 0 0 1-2.1 2.8M6.6 6.6C3.6 8.4 2 12 2 12s3.5 6 10 6a10 10 0 0 0 4.2-.9"/></svg>';
 
 type Item = {
     id: string;
@@ -42,10 +45,14 @@ editor.once('loaded', () => {
             : []
     );
     let order = mergeToolbarOrder(stored?.order, defaults);
+    let editing = false;
     let dragged: Item | null = null;
     let moved = false;
+    const toggles = new Map<string, HTMLSpanElement>();
     const menu = new Menu();
+    const done = new Button({ class: 'toolbar-edit-done', text: 'DONE', hidden: true });
     root.append(menu);
+    root.append(done);
 
     const save = () => {
         editor.call('localStorage:set', STORAGE_KEY, { hidden: [...hidden], order });
@@ -55,8 +62,14 @@ editor.once('loaded', () => {
             .map((id) => items.find((item) => item.id === id))
             .filter((item) => item?.group === 'utility');
         items.forEach((item) => {
-            item.button.class.toggle('toolbar-user-hidden', hidden.has(item.id));
+            const isHidden = hidden.has(item.id);
+            const toggle = toggles.get(item.id);
+            item.button.class.toggle('toolbar-user-hidden', isHidden);
             item.button.class.remove('push-top');
+            if (toggle) {
+                toggle.innerHTML = isHidden ? EYE_OFF_ICON : EYE_ICON;
+                toggle.ariaLabel = `${isHidden ? 'Show' : 'Hide'} ${item.label}`;
+            }
         });
         order
             .filter((id) => items.find((item) => item.id === id)?.group === 'main')
@@ -66,20 +79,68 @@ editor.once('loaded', () => {
         utilities.forEach((item, index) => {
             item.button.dom.style.order = String(index + 100);
         });
-        utilities.find((item) => !hidden.has(item.id))?.button.class.add('push-top');
+        utilities.find((item) => editing || !hidden.has(item.id))?.button.class.add('push-top');
     };
-    const show = (item: Item) => {
-        hidden.delete(item.id);
+    const setEditing = (value: boolean) => {
+        editing = value;
+        toolbar.class.toggle('toolbar-editing', value);
+        done.hidden = !value;
+        items.forEach((item) => {
+            item.button.dom.draggable = value;
+        });
         render();
-        save();
     };
-
-    render();
 
     items.forEach((item) => {
-        item.button.dom.draggable = true;
+        const toggle = document.createElement('span');
+        const toggleVisibility = () => {
+            if (hidden.has(item.id)) {
+                hidden.delete(item.id);
+            } else {
+                hidden.add(item.id);
+            }
+            render();
+            save();
+        };
+        toggle.className = 'toolbar-visibility';
+        toggle.role = 'button';
+        toggle.tabIndex = 0;
+        toggle.addEventListener('mousedown', (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+        });
+        toggle.addEventListener('click', (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            toggleVisibility();
+        });
+        toggle.addEventListener('keydown', (evt) => {
+            if (evt.key !== 'Enter' && evt.key !== ' ') {
+                return;
+            }
+            evt.preventDefault();
+            evt.stopPropagation();
+            toggleVisibility();
+        });
+        item.button.dom.append(toggle);
+        toggles.set(item.id, toggle);
+
         item.button.dom.addEventListener('mousedown', (evt) => evt.stopPropagation());
+        item.button.dom.addEventListener(
+            'click',
+            (evt) => {
+                if (editing && !(evt.target as HTMLElement).closest('.toolbar-visibility')) {
+                    evt.preventDefault();
+                    evt.stopImmediatePropagation();
+                }
+            },
+            true
+        );
         item.button.dom.addEventListener('dragstart', (evt) => {
+            if (!editing) {
+                evt.preventDefault();
+                return;
+            }
             evt.stopPropagation();
             dragged = item;
             moved = false;
@@ -97,6 +158,9 @@ editor.once('loaded', () => {
             }
         });
     });
+
+    render();
+    done.on('click', () => setEditing(false));
 
     toolbar.dom.addEventListener('dragover', (evt: DragEvent) => {
         const id = (evt.target as HTMLElement).closest<HTMLElement>('[data-toolbar-id]')?.dataset.toolbarId;
@@ -124,48 +188,13 @@ editor.once('loaded', () => {
     toolbar.dom.addEventListener('contextmenu', (evt: MouseEvent) => {
         evt.preventDefault();
         evt.stopPropagation();
-
-        const id = (evt.target as HTMLElement).closest<HTMLElement>('[data-toolbar-id]')?.dataset.toolbarId;
-        const item = items.find((item) => item.id === id);
         menu.clear();
-
-        if (item && !hidden.has(item.id)) {
-            menu.append(
-                new MenuItem({
-                    text: `Hide ${item.label}`,
-                    icon: 'E132',
-                    onSelect: () => {
-                        hidden.add(item.id);
-                        render();
-                        save();
-                    }
-                })
-            );
-        }
-        items
-            .filter((item) => hidden.has(item.id))
-            .forEach((item) => {
-                menu.append(
-                    new MenuItem({
-                        text: `Show ${item.label}`,
-                        icon: 'E133',
-                        onSelect: () => show(item)
-                    })
-                );
-            });
-        if (hidden.size > 1) {
-            menu.append(
-                new MenuItem({
-                    text: 'Show All',
-                    icon: 'E133',
-                    onSelect: () => {
-                        hidden.clear();
-                        render();
-                        save();
-                    }
-                })
-            );
-        }
+        menu.append(
+            new MenuItem({
+                text: editing ? 'Done Editing' : 'Edit Toolbar',
+                onSelect: () => setEditing(!editing)
+            })
+        );
         if (hidden.size || order.some((id, index) => id !== defaults[index])) {
             menu.append(
                 new MenuItem({
@@ -179,9 +208,7 @@ editor.once('loaded', () => {
                 })
             );
         }
-        if (item || hidden.size) {
-            menu.hidden = false;
-            menu.position(evt.clientX + 1, evt.clientY);
-        }
+        menu.hidden = false;
+        menu.position(evt.clientX + 1, evt.clientY);
     });
 });

--- a/src/editor/toolbar/toolbar-customization.ts
+++ b/src/editor/toolbar/toolbar-customization.ts
@@ -86,7 +86,13 @@ editor.once('loaded', () => {
         toolbar.class.toggle('toolbar-editing', value);
         done.hidden = !value;
         items.forEach((item) => {
+            const toggle = toggles.get(item.id)!;
             item.button.dom.draggable = value;
+            if (value) {
+                item.button.dom.append(toggle);
+            } else {
+                toggle.remove();
+            }
         });
         render();
     };
@@ -122,7 +128,6 @@ editor.once('loaded', () => {
             evt.stopPropagation();
             toggleVisibility();
         });
-        item.button.dom.append(toggle);
         toggles.set(item.id, toggle);
 
         item.button.dom.addEventListener('mousedown', (evt) => evt.stopPropagation());

--- a/src/editor/toolbar/toolbar-customization.ts
+++ b/src/editor/toolbar/toolbar-customization.ts
@@ -1,0 +1,187 @@
+import { Menu, MenuItem } from '@playcanvas/pcui';
+import type { Button } from '@playcanvas/pcui';
+
+import { mergeToolbarOrder, moveToolbarItem } from './toolbar-order';
+
+const STORAGE_KEY = 'editor:toolbar';
+
+type Item = {
+    id: string;
+    label: string;
+    group: 'main' | 'utility';
+    button: Button;
+};
+
+const items: Item[] = [];
+
+editor.method('toolbar:register', (item: Item) => {
+    item.button.dom.dataset.toolbarId = item.id;
+    items.push(item);
+});
+
+editor.once('loaded', () => {
+    const root = editor.call('layout.root');
+    const toolbar = editor.call('layout.toolbar');
+    const stored = editor.call('localStorage:get', STORAGE_KEY) as { hidden?: unknown; order?: unknown } | null;
+    const ids = new Set(items.map((item) => item.id));
+    const dom = [...toolbar.dom.children];
+    const defaults = [...items]
+        .sort((a, b) => {
+            if (a.group !== b.group) {
+                return a.group === 'main' ? -1 : 1;
+            }
+            return (
+                Number(getComputedStyle(a.button.dom).order) - Number(getComputedStyle(b.button.dom).order) ||
+                dom.indexOf(a.button.dom) - dom.indexOf(b.button.dom)
+            );
+        })
+        .map((item) => item.id);
+    const hidden = new Set(
+        Array.isArray(stored?.hidden)
+            ? stored.hidden.filter((id): id is string => typeof id === 'string' && ids.has(id))
+            : []
+    );
+    let order = mergeToolbarOrder(stored?.order, defaults);
+    let dragged: Item | null = null;
+    let moved = false;
+    const menu = new Menu();
+    root.append(menu);
+
+    const save = () => {
+        editor.call('localStorage:set', STORAGE_KEY, { hidden: [...hidden], order });
+    };
+    const render = () => {
+        const utilities = order
+            .map((id) => items.find((item) => item.id === id))
+            .filter((item) => item?.group === 'utility');
+        items.forEach((item) => {
+            item.button.class.toggle('toolbar-user-hidden', hidden.has(item.id));
+            item.button.class.remove('push-top');
+        });
+        order
+            .filter((id) => items.find((item) => item.id === id)?.group === 'main')
+            .forEach((id, index) => {
+                items.find((item) => item.id === id).button.dom.style.order = String(index + 1);
+            });
+        utilities.forEach((item, index) => {
+            item.button.dom.style.order = String(index + 100);
+        });
+        utilities.find((item) => !hidden.has(item.id))?.button.class.add('push-top');
+    };
+    const show = (item: Item) => {
+        hidden.delete(item.id);
+        render();
+        save();
+    };
+
+    render();
+
+    items.forEach((item) => {
+        item.button.dom.draggable = true;
+        item.button.dom.addEventListener('mousedown', (evt) => evt.stopPropagation());
+        item.button.dom.addEventListener('dragstart', (evt) => {
+            evt.stopPropagation();
+            dragged = item;
+            moved = false;
+            item.button.class.add('toolbar-dragging');
+            evt.dataTransfer?.setData('text/plain', item.id);
+            if (evt.dataTransfer) {
+                evt.dataTransfer.effectAllowed = 'move';
+            }
+        });
+        item.button.dom.addEventListener('dragend', () => {
+            dragged?.button.class.remove('toolbar-dragging');
+            dragged = null;
+            if (moved) {
+                save();
+            }
+        });
+    });
+
+    toolbar.dom.addEventListener('dragover', (evt: DragEvent) => {
+        const id = (evt.target as HTMLElement).closest<HTMLElement>('[data-toolbar-id]')?.dataset.toolbarId;
+        const target = items.find((item) => item.id === id);
+        if (!dragged || !target || dragged.group !== target.group) {
+            return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        const rect = target.button.dom.getBoundingClientRect();
+        const next = moveToolbarItem(order, dragged.id, target.id, evt.clientY > rect.top + rect.height / 2);
+        if (next.some((id, index) => id !== order[index])) {
+            order = next;
+            moved = true;
+            render();
+        }
+    });
+    toolbar.dom.addEventListener('drop', (evt: DragEvent) => {
+        if (dragged) {
+            evt.preventDefault();
+            evt.stopPropagation();
+        }
+    });
+
+    toolbar.dom.addEventListener('contextmenu', (evt: MouseEvent) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+
+        const id = (evt.target as HTMLElement).closest<HTMLElement>('[data-toolbar-id]')?.dataset.toolbarId;
+        const item = items.find((item) => item.id === id);
+        menu.clear();
+
+        if (item && !hidden.has(item.id)) {
+            menu.append(
+                new MenuItem({
+                    text: `Hide ${item.label}`,
+                    icon: 'E132',
+                    onSelect: () => {
+                        hidden.add(item.id);
+                        render();
+                        save();
+                    }
+                })
+            );
+        }
+        items
+            .filter((item) => hidden.has(item.id))
+            .forEach((item) => {
+                menu.append(
+                    new MenuItem({
+                        text: `Show ${item.label}`,
+                        icon: 'E133',
+                        onSelect: () => show(item)
+                    })
+                );
+            });
+        if (hidden.size > 1) {
+            menu.append(
+                new MenuItem({
+                    text: 'Show All',
+                    icon: 'E133',
+                    onSelect: () => {
+                        hidden.clear();
+                        render();
+                        save();
+                    }
+                })
+            );
+        }
+        if (hidden.size || order.some((id, index) => id !== defaults[index])) {
+            menu.append(
+                new MenuItem({
+                    text: 'Reset Toolbar',
+                    onSelect: () => {
+                        hidden.clear();
+                        order = [...defaults];
+                        render();
+                        editor.call('localStorage:unset', STORAGE_KEY);
+                    }
+                })
+            );
+        }
+        if (item || hidden.size) {
+            menu.hidden = false;
+            menu.position(evt.clientX + 1, evt.clientY);
+        }
+    });
+});

--- a/src/editor/toolbar/toolbar-discord.ts
+++ b/src/editor/toolbar/toolbar-discord.ts
@@ -35,6 +35,7 @@ editor.once('load', () => {
         class: ['pc-icon', 'discord', 'bottom']
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'discord', label: 'Discord', group: 'utility', button });
 
     // Append the discord svg to the button
     const color = '#9ba1a3';

--- a/src/editor/toolbar/toolbar-editor-settings.ts
+++ b/src/editor/toolbar/toolbar-editor-settings.ts
@@ -11,6 +11,7 @@ editor.once('load', () => {
         icon: 'E134'
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'settings', label: 'Settings', group: 'utility', button });
 
     button.on('click', () => {
         editor.call('selector:set', 'editorSettings', [editor.call('settings:projectUser')]);

--- a/src/editor/toolbar/toolbar-forum.ts
+++ b/src/editor/toolbar/toolbar-forum.ts
@@ -10,6 +10,7 @@ editor.once('load', () => {
         icon: 'E119'
     });
     toolbar.append(contact);
+    editor.call('toolbar:register', { id: 'forum', label: 'Forum', group: 'utility', button: contact });
 
     TooltipHandle.attach({
         target: contact.dom,

--- a/src/editor/toolbar/toolbar-github.ts
+++ b/src/editor/toolbar/toolbar-github.ts
@@ -10,6 +10,7 @@ editor.once('load', () => {
         icon: 'E259'
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'github', label: 'GitHub', group: 'utility', button });
 
     button.on('click', () => {
         window.open('https://github.com/playcanvas/editor/issues', '_blank');

--- a/src/editor/toolbar/toolbar-gizmos.ts
+++ b/src/editor/toolbar/toolbar-gizmos.ts
@@ -56,6 +56,12 @@ editor.once('load', () => {
         });
 
         toolbar.append(button);
+        editor.call('toolbar:register', {
+            id: `gizmo-${item.op}`,
+            label: item.tooltip,
+            group: 'main',
+            button
+        });
 
         button.tooltip = TooltipHandle.attach({
             target: button.dom,
@@ -79,6 +85,7 @@ editor.once('load', () => {
         icon: 'E118'
     });
     toolbar.append(buttonWorld);
+    editor.call('toolbar:register', { id: 'gizmo-space', label: 'World / Local', group: 'main', button: buttonWorld });
 
     buttonWorld.on('click', () => {
         if (buttonWorld.class.contains('active')) {
@@ -116,6 +123,7 @@ editor.once('load', () => {
         editor.call('gizmo:snap', buttonSnap.class.contains('active'));
     });
     toolbar.append(buttonSnap);
+    editor.call('toolbar:register', { id: 'gizmo-snap', label: 'Snap', group: 'main', button: buttonSnap });
 
     const tooltipSnap = TooltipHandle.attach({
         target: buttonSnap.dom,
@@ -144,6 +152,7 @@ editor.once('load', () => {
         editor.call('viewport:focus');
     });
     toolbar.append(buttonFocus);
+    editor.call('toolbar:register', { id: 'gizmo-focus', label: 'Focus', group: 'main', button: buttonFocus });
 
     editor.on('attributes:clear', () => {
         buttonFocus.enabled = false;

--- a/src/editor/toolbar/toolbar-help.ts
+++ b/src/editor/toolbar/toolbar-help.ts
@@ -10,6 +10,7 @@ editor.once('load', () => {
         icon: 'E138'
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'help', label: 'How Do I...?', group: 'utility', button });
 
     button.on('click', () => {
         editor.call('help:howdoi:toggle');

--- a/src/editor/toolbar/toolbar-history.ts
+++ b/src/editor/toolbar/toolbar-history.ts
@@ -15,6 +15,7 @@ editor.once('load', () => {
         icon: 'E114'
     });
     toolbar.append(buttonUndo);
+    editor.call('toolbar:register', { id: 'undo', label: 'Undo', group: 'main', button: buttonUndo });
 
     history.on('canUndo', (state) => {
         buttonUndo.enabled = state;
@@ -46,6 +47,7 @@ editor.once('load', () => {
         icon: 'E115'
     });
     toolbar.append(buttonRedo);
+    editor.call('toolbar:register', { id: 'redo', label: 'Redo', group: 'main', button: buttonRedo });
 
     history.on('canRedo', (state) => {
         buttonRedo.enabled = state;

--- a/src/editor/toolbar/toolbar-lightmapper.ts
+++ b/src/editor/toolbar/toolbar-lightmapper.ts
@@ -16,6 +16,7 @@ editor.once('load', () => {
         icon: 'E191'
     });
     toolbar.append(buttonBake);
+    editor.call('toolbar:register', { id: 'lightmapper', label: 'Bake Lightmaps', group: 'main', button: buttonBake });
 
     buttonBake.on('click', () => {
         editor.call('lightmapper:bake');

--- a/src/editor/toolbar/toolbar-logo.ts
+++ b/src/editor/toolbar/toolbar-logo.ts
@@ -3,6 +3,8 @@ import { Button, Menu } from '@playcanvas/pcui';
 import { TooltipHandle } from '@/common/tooltips';
 import { formatShortcut } from '@/common/utils';
 
+const DONE_ICON = '\uE133';
+
 editor.once('load', () => {
     const root = editor.call('layout.root');
     const toolbar = editor.call('layout.toolbar');
@@ -451,7 +453,25 @@ editor.once('load', () => {
         tooltip.disabled = false;
     });
 
+    let editing = false;
+    editor.method('toolbar:logo:editing', (value: boolean) => {
+        const label = value ? 'Done editing toolbar' : 'Menu';
+        editing = value;
+        logo.class.toggle('toolbar-done', value);
+        if (value) {
+            logo.dom.dataset.icon = DONE_ICON;
+        } else {
+            delete logo.dom.dataset.icon;
+        }
+        logo.dom.ariaLabel = label;
+        tooltip.text = label;
+    });
+
     logo.on('click', () => {
-        menu.hidden = false;
+        if (editing) {
+            editor.call('toolbar:edit:done');
+        } else {
+            menu.hidden = false;
+        }
     });
 });

--- a/src/editor/toolbar/toolbar-order.ts
+++ b/src/editor/toolbar/toolbar-order.ts
@@ -1,0 +1,15 @@
+export const mergeToolbarOrder = (value: unknown, defaults: string[]) => {
+    const order = Array.isArray(value)
+        ? value.filter((id): id is string => typeof id === 'string' && defaults.includes(id))
+        : [];
+    return [...new Set(order), ...defaults.filter((id) => !order.includes(id))];
+};
+
+export const moveToolbarItem = (order: string[], id: string, target: string, after: boolean) => {
+    if (id === target) {
+        return order;
+    }
+    const next = order.filter((item) => item !== id);
+    next.splice(next.indexOf(target) + Number(after), 0, id);
+    return next;
+};

--- a/src/editor/toolbar/toolbar-publish.ts
+++ b/src/editor/toolbar/toolbar-publish.ts
@@ -10,6 +10,7 @@ editor.once('load', () => {
         icon: 'E237'
     });
     toolbar.append(button);
+    editor.call('toolbar:register', { id: 'publish', label: 'Publish / Download', group: 'main', button });
 
     button.on('click', () => {
         editor.call('picker:builds-publish');

--- a/test/editor/toolbar-order.test.ts
+++ b/test/editor/toolbar-order.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { mergeToolbarOrder, moveToolbarItem } from '../../src/editor/toolbar/toolbar-order';
+
+describe('toolbar order', () => {
+    it('keeps valid preferences and appends new actions', () => {
+        expect(mergeToolbarOrder(['publish', 'mcp', 'publish', 'removed'], ['mcp', 'code', 'publish'])).to.deep.equal([
+            'publish',
+            'mcp',
+            'code'
+        ]);
+    });
+
+    it('moves actions before and after a target', () => {
+        expect(moveToolbarItem(['mcp', 'code', 'publish'], 'publish', 'mcp', false)).to.deep.equal([
+            'publish',
+            'mcp',
+            'code'
+        ]);
+        expect(moveToolbarItem(['mcp', 'code', 'publish'], 'mcp', 'publish', true)).to.deep.equal([
+            'code',
+            'publish',
+            'mcp'
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #2175

### What's Changed

- Add an explicit toolbar edit mode entered from the toolbar context menu.
- Replace the PlayCanvas logo with the Editor's existing check icon while editing, and reuse its native visibility icon styling.
- Persist toolbar visibility and ordering while preserving the documented default order and reset behavior.

### Manual smoke test

1. Right-click the Editor toolbar and select Edit Toolbar. The menu should dismiss, the PlayCanvas logo should become a check, and every available action should appear with a flat top-right eye control.
2. Drag MCP above Code Editor, hide MCP with its eye control, then click the check. MCP should disappear, the PlayCanvas logo should return, and the custom order should persist after reloading.
3. Re-enter edit mode, show MCP, and click the check. Right-click the toolbar and select Reset Toolbar; the default order and visibility should return.

### Checks

- [x] I confirm I have read the contributing guidelines.