### PR TITLE
feat: add GLSL shader transpilation setting

### DIFF
--- a/src/common/project-settings.ts
+++ b/src/common/project-settings.ts
@@ -1,0 +1,26 @@
+import { DEVICETYPE_WEBGPU } from 'playcanvas';
+
+type Settings = {
+    enableGlslShaderTranspilation?: boolean;
+    enableWebGpu?: boolean;
+    deviceTypes?: string[];
+};
+
+export const migrateGlslShaderTranspilation = (settings: Settings) => {
+    if (Object.prototype.hasOwnProperty.call(settings, 'enableGlslShaderTranspilation')) {
+        return;
+    }
+
+    settings.enableGlslShaderTranspilation = Object.prototype.hasOwnProperty.call(settings, 'enableWebGpu')
+        ? !!settings.enableWebGpu
+        : settings.deviceTypes?.[0] === DEVICETYPE_WEBGPU;
+    let pending = true;
+    return (data: Settings) => {
+        const value = pending && !Object.prototype.hasOwnProperty.call(data, 'enableGlslShaderTranspilation');
+        pending = false;
+        return value;
+    };
+};
+
+export const useGlslShaderTranspilation = (enableWebGpu: boolean, enableGlslShaderTranspilation?: boolean) =>
+    enableWebGpu && (enableGlslShaderTranspilation ?? enableWebGpu);

--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -17,6 +17,7 @@ type ProjectSettings = {
     height: number;
     use3dPhysics: boolean;
     enableWebGpu: boolean;
+    enableGlslShaderTranspilation: boolean;
     enableWebGl2: boolean;
     powerPreference: string;
     preserveDrawingBuffer: boolean;

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -384,6 +384,12 @@ editor.once('load', () => {
             description: `When enabled, the application will try to use WebGPU${editor.projectEngineV2 ? '' : ' (beta)'} if available.`
         },
         {
+            name: 'settings:project:enableGlslShaderTranspilation',
+            title: 'Enable GLSL Shader Transpilation',
+            description:
+                'When enabled, GLSL-only shaders are supported under WebGPU. This adds shader compiler files to published and downloaded builds.'
+        },
+        {
             name: 'settings:project:enableWebGl2',
             title: 'Enable WebGL 2.0',
             description: 'When enabled, the application will try to use WebGL 2.0 if available.'

--- a/src/editor/inspector/settings-panels/rendering.ts
+++ b/src/editor/inspector/settings-panels/rendering.ts
@@ -470,6 +470,13 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
     },
     {
         observer: 'projectSettings',
+        label: 'Enable GLSL Shader Transpilation',
+        type: 'boolean',
+        reference: 'settings:project:enableGlslShaderTranspilation',
+        path: 'enableGlslShaderTranspilation'
+    },
+    {
+        observer: 'projectSettings',
         label: 'Enable WebGL 2.0',
         type: 'boolean',
         reference: 'settings:project:enableWebGl2',
@@ -701,9 +708,11 @@ class RenderingSettingsPanel extends BaseSettingsPanel {
         const deviceOrder = this._attributesInspector.getField('deviceOrder');
 
         const enableWebGpu = this._attributesInspector.getField('enableWebGpu');
+        const enableGlslShaderTranspilation = this._attributesInspector.getField('enableGlslShaderTranspilation');
         const enableWebGl2 = this._attributesInspector.getField('enableWebGl2');
 
         const onDeviceChange = () => {
+            enableGlslShaderTranspilation.parent.hidden = !enableWebGpu.value;
             (deviceOrder as Label).text = [
                 enableWebGpu.value ? `WebGPU${editor.projectEngineV2 ? '' : ' (beta)'}` : '',
                 enableWebGl2.value ? 'WebGL 2.0' : '',

--- a/src/editor/settings/project-settings.ts
+++ b/src/editor/settings/project-settings.ts
@@ -10,11 +10,13 @@ import {
     script
 } from 'playcanvas';
 
+import { migrateGlslShaderTranspilation } from '@/common/project-settings';
 import { deepCopy, formatter as f, insert, remove, set, unset } from '@/common/utils';
 import { config } from '@/editor/config';
 
 editor.once('load', () => {
     const schema = editor.api.globals.schema;
+    const migrateGlsl = migrateGlslShaderTranspilation(config.project.settings);
     const projectSettings = Object.assign(schema.settings.getDefaultProjectSettings(), config.project.settings);
 
     const settings = editor.call('settings:create', {
@@ -46,7 +48,7 @@ editor.once('load', () => {
     });
 
     // migrations
-    editor.on('settings:project:load', () => {
+    editor.on('settings:project:load', (data) => {
         const history = settings.history.enabled;
         const sync = settings.sync.enabled;
 
@@ -102,6 +104,10 @@ editor.once('load', () => {
             }
 
             editor.call('console:log:settings', settings, msg);
+        }
+
+        if (migrateGlsl?.(data)) {
+            settings.set('enableGlslShaderTranspilation', !!settings.get('enableWebGpu'), undefined, undefined, true);
         }
 
         if (!settings.get('batchGroups')) {

--- a/src/launch/viewport/viewport.ts
+++ b/src/launch/viewport/viewport.ts
@@ -1,6 +1,7 @@
 import type { Observer } from '@playcanvas/observer';
 import { LAYERID_DEPTH } from 'playcanvas';
 
+import { useGlslShaderTranspilation } from '@/common/project-settings';
 import { ReferencedFontHandler } from '@/common/referenced-font-handler';
 import { config } from '@/launch/config';
 
@@ -137,7 +138,7 @@ editor.once('load', () => {
     scriptPrefix = config.project.scriptPrefix;
 
     // device types
-    const { enableWebGpu, enableWebGl2 } = editor.call('settings:project').json();
+    const { enableWebGpu, enableWebGl2, enableGlslShaderTranspilation } = editor.call('settings:project').json();
     let deviceTypes = [
         enableWebGpu && pc.DEVICETYPE_WEBGPU,
         enableWebGl2 && pc.DEVICETYPE_WEBGL2,
@@ -176,8 +177,12 @@ editor.once('load', () => {
 
     const gfxOptions = {
         deviceTypes: deviceTypes,
-        glslangUrl: '/editor/scene/js/webgpu/glslang.js',
-        twgslUrl: '/editor/scene/js/webgpu/twgsl.js',
+        ...(useGlslShaderTranspilation(enableWebGpu, enableGlslShaderTranspilation)
+            ? {
+                  glslangUrl: '/editor/scene/js/webgpu/glslang.js',
+                  twgslUrl: '/editor/scene/js/webgpu/twgsl.js'
+              }
+            : {}),
         powerPreference: powerPreference,
         antialias: config.project.settings.antiAlias !== false,
         alpha: config.project.settings.transparentCanvas !== false,

--- a/test/common/project-settings.test.ts
+++ b/test/common/project-settings.test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { DEVICETYPE_WEBGL2, DEVICETYPE_WEBGPU } from 'playcanvas';
+
+import { migrateGlslShaderTranspilation, useGlslShaderTranspilation } from '../../src/common/project-settings';
+
+describe('GLSL shader transpilation', () => {
+    it('is enabled only for WebGPU when not explicitly disabled', () => {
+        expect(useGlslShaderTranspilation(true, undefined)).to.equal(true);
+        expect(useGlslShaderTranspilation(true, true)).to.equal(true);
+        expect(useGlslShaderTranspilation(true, false)).to.equal(false);
+        expect(useGlslShaderTranspilation(false, undefined)).to.equal(false);
+        expect(useGlslShaderTranspilation(false, true)).to.equal(false);
+        expect(useGlslShaderTranspilation(false, false)).to.equal(false);
+    });
+
+    it('migrates legacy device types to a definite boolean only once', () => {
+        const webgpu = { deviceTypes: [DEVICETYPE_WEBGPU] };
+        const webgl = { deviceTypes: [DEVICETYPE_WEBGL2] };
+
+        const migrateWebGpu = migrateGlslShaderTranspilation(webgpu);
+        const migrateWebGl = migrateGlslShaderTranspilation(webgl);
+
+        expect(migrateWebGpu).to.be.a('function');
+        expect(migrateWebGl).to.be.a('function');
+        expect(webgpu['enableGlslShaderTranspilation']).to.equal(true);
+        expect(webgl['enableGlslShaderTranspilation']).to.equal(false);
+        expect(migrateWebGpu({})).to.equal(true);
+        expect(migrateWebGpu({})).to.equal(false);
+        expect(migrateWebGl({})).to.equal(true);
+        expect(migrateWebGl({})).to.equal(false);
+    });
+
+    it('skips migration when realtime data has an explicit value', () => {
+        for (const value of [false, true]) {
+            const migrate = migrateGlslShaderTranspilation({});
+
+            expect(migrate?.({ enableGlslShaderTranspilation: value })).to.equal(false);
+            expect(migrate?.({})).to.equal(false);
+        }
+    });
+
+    it('migrates empty legacy settings to false', () => {
+        const settings = {};
+        const migrate = migrateGlslShaderTranspilation(settings);
+
+        expect(settings['enableGlslShaderTranspilation']).to.equal(false);
+        expect(migrate?.({})).to.equal(true);
+        expect(migrate?.({})).to.equal(false);
+    });
+
+    it('preserves explicit GLSL shader transpilation values', () => {
+        const settings = {
+            enableGlslShaderTranspilation: false,
+            enableWebGpu: true
+        };
+
+        expect(migrateGlslShaderTranspilation(settings)).to.equal(undefined);
+        expect(settings.enableGlslShaderTranspilation).to.equal(false);
+    });
+});


### PR DESCRIPTION
Fixes #1320

### What's Changed

- add an optional GLSL shader transpilation project setting beneath WebGPU
- preserve explicit values and safely migrate legacy projects from their effective WebGPU state
- load compiler URLs only when WebGPU and transpilation are both enabled

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)

### Manual Smoke Test

1. Open a legacy WebGPU project without the setting; expect the transpilation toggle to be enabled and remain enabled after reload.
2. Create a project and enable WebGPU; expect GLSL shader transpilation to remain disabled by default.
3. Disable and re-enable WebGPU after enabling transpilation; expect the child toggle to hide and then restore its stored value.
4. Launch with transpilation disabled, then enabled; expect no compiler requests when disabled and all glslang/twgsl resources to load when enabled.