### PR TITLE
fix: MCP client connects to 127.0.0.1 instead of localhost

### DIFF
--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -3,6 +3,9 @@ import { Events } from '@playcanvas/observer';
 import { handleRequest } from './request';
 
 const DEFAULT_PORT = 52000;
+
+// dial the address the server binds, not `localhost` (resolves to ::1 first on windows)
+const HOST = '127.0.0.1';
 const RETRY_TIMEOUT = 1000;
 const PROTOCOL_VERSION = 1;
 
@@ -63,7 +66,7 @@ class MCPConnection extends Events {
         this._forceClosed = false;
 
         this._setStatus('connecting');
-        log(`Connecting to ws://localhost:${port}`);
+        log(`Connecting to ws://${HOST}:${port}`);
 
         if (this._connectTimeout) {
             clearTimeout(this._connectTimeout);
@@ -77,7 +80,7 @@ class MCPConnection extends Events {
      * Open a single WebSocket and wire up auto-reconnect on unexpected close.
      */
     private _open() {
-        const ws = new WebSocket(`ws://localhost:${this._port}`);
+        const ws = new WebSocket(`ws://${HOST}:${this._port}`);
         this._ws = ws;
 
         ws.onopen = () => {


### PR DESCRIPTION
### What's Changed

The MCP client dialed `ws://localhost:<port>`, but the MCP server binds only `127.0.0.1`. On Windows, `localhost` typically resolves to `::1` first (nothing listens there), so the launched runtime page never connected and looped on `Disconnected; reconnecting`, leaving `launch_start` at `ready: false` and all runtime tools unusable.

- `MCPConnection` now dials `127.0.0.1` — the exact address the server binds, and the same literal the server's own yield probe uses — avoiding the `localhost` → `::1` detour. This is the shared client, so both the editor and launch (runtime) peers are fixed.

Origin allow-listing is unaffected (it checks the `Origin` header, not the dial host), and `ws://127.0.0.1` is potentially-trustworthy from an `https` page, so no mixed-content change.

Paired with playcanvas/editor-mcp-server#101 (server-side Windows port-reclaim fix).

### Manual smoke test

1. On Windows (default `hosts`, i.e. `ping localhost` shows `[::1]`), open the Editor and connect via the MCP button.
   - Expected: editor connects (console shows `Connecting to ws://127.0.0.1:52000` then `Connected`).
2. Call `launch_start`, then open the launched page.
   - Expected: `launch_start` returns `ready: true`; the launch page console shows `Connected` (no `Disconnected; reconnecting` loop).
3. Run a runtime tool (e.g. `read_runtime_logs`).
   - Expected: it returns runtime data instead of a "no running instance connected" error.
