### PR TITLE
feat: relay MCP runtime calls through the editor

### DIFF
--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -9,11 +9,9 @@ const HOST = '127.0.0.1';
 const RETRY_TIMEOUT = 1000;
 const PROTOCOL_VERSION = 1;
 
-// Chromium gates a public page's connection to loopback behind a local access permission
-// (Chrome 142+, websockets from 147), granted per origin. A blocked socket is
-// indistinguishable from "nothing is listening", so probe the permission whenever we never
-// reach 'open' and tell the user which toggle to flip. The Permissions API name changed with
-// the Chrome 145 loopback/LAN split, so try each and use the first the browser recognises.
+// A blocked socket is indistinguishable from "nothing is listening", so probe the permission
+// when we never reach 'open'. The name changed with the Chrome 145 loopback/LAN split, so try
+// each and use the first the browser recognises.
 const LOCAL_ACCESS_PERMISSIONS = ['loopback-network', 'local-network', 'local-network-access'];
 
 type Status = 'connecting' | 'connected' | 'disconnected';
@@ -24,11 +22,9 @@ type Method = (...args: any[]) => MethodResult | Promise<MethodResult>;
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
 const error = (msg: unknown) => console.error(`[MCP] ${msg}`);
 
-// 'denied' or 'prompt' when the permission may be why we can't connect, null when it can't
-// be (already granted, or the browser doesn't gate local access at all). A never-asked site
-// reads 'prompt', which is also what a missing server looks like — hence the two states.
-// the server's opening frame advertises its capabilities; tool requests always carry an id.
-// an older server sends nothing, which is the signal to dial from the launch page instead
+// 'denied' or 'prompt' when the permission may be the cause, null when it can't be. A
+// never-asked site reads 'prompt', which is also what a missing server looks like.
+// the server's opening frame advertises its capabilities; tool requests always carry an id
 const greetingOf = (data: unknown) => {
     if (typeof data !== 'string' || !data.includes('"hello"')) {
         return null;
@@ -86,8 +82,8 @@ class MCPConnection extends Events {
     }
 
     /**
-     * Whether the connected server can route `runtime:*` calls through this page, letting the
-     * launch window relay over postMessage instead of opening a socket of its own.
+     * Whether the server can route `runtime:*` through this page instead of the launch page
+     * opening its own socket.
      */
     get serverRelay() {
         return this._serverRelay;
@@ -230,8 +226,7 @@ class MCPConnection extends Events {
     }
 
     /**
-     * Send a raw frame to the server, outside the request/response flow. Used for relay
-     * announcements, which the server treats as state rather than as a reply.
+     * Send a raw frame outside the request/response flow, for relay announcements.
      *
      * @param msg - The frame to send; dropped if the socket isn't open.
      */
@@ -242,8 +237,8 @@ class MCPConnection extends Events {
     }
 
     /**
-     * Register a handler for methods this page doesn't implement itself. Returning null
-     * declines, leaving the caller with the usual unknown-method error.
+     * Handle methods this page doesn't implement. Returning null declines, leaving the caller
+     * with the usual unknown-method error.
      *
      * @param fn - The handler, called with the method name and its arguments.
      */

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -4,14 +4,13 @@ import { handleRequest } from './request';
 
 const DEFAULT_PORT = 52000;
 
-// dial the address the server binds, not `localhost` (resolves to ::1 first on windows)
+// use 127.0.0.1, not localhost (resolves to ::1 first on windows)
 const HOST = '127.0.0.1';
 const RETRY_TIMEOUT = 1000;
 const PROTOCOL_VERSION = 1;
 
-// A blocked socket is indistinguishable from "nothing is listening", so probe the permission
-// when we never reach 'open'. The name changed with the Chrome 145 loopback/LAN split, so try
-// each and use the first the browser recognises.
+// a blocked socket looks like "nothing listening"; probe the permission on a failed open.
+// the name changed across the Chrome 145 loopback/LAN split, so try each, first match wins.
 const LOCAL_ACCESS_PERMISSIONS = ['loopback-network', 'local-network', 'local-network-access'];
 
 type Status = 'connecting' | 'connected' | 'disconnected';
@@ -22,8 +21,7 @@ type Method = (...args: any[]) => MethodResult | Promise<MethodResult>;
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
 const error = (msg: unknown) => console.error(`[MCP] ${msg}`);
 
-// 'denied' or 'prompt' when the permission may be the cause, null when it can't be. A
-// never-asked site reads 'prompt', which is also what a missing server looks like.
+// 'denied'/'prompt' when the permission might be blocking, null when not ('prompt' also = no server yet)
 const localAccessState = async () => {
     for (const name of LOCAL_ACCESS_PERMISSIONS) {
         const state = await navigator.permissions?.query({ name: name as PermissionName }).then(
@@ -156,11 +154,12 @@ class MCPConnection extends Events {
             }
         };
         ws.onerror = () => {
-            // a socket error is always followed by a close event, which drives the
-            // reconnect below; swallow it here so it isn't surfaced as unhandled
+
+            // swallowed: the close event that follows drives the reconnect
         };
         ws.onclose = (evt) => {
             this._methods.get('files:transfer:clear')?.();
+
             // a deliberate disconnect() (FORCE) must never reconnect
             if (this._forceClosed || evt?.reason === 'FORCE') {
                 return;

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -154,7 +154,6 @@ class MCPConnection extends Events {
             }
         };
         ws.onerror = () => {
-
             // swallowed: the close event that follows drives the reconnect
         };
         ws.onclose = (evt) => {

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -9,6 +9,13 @@ const HOST = '127.0.0.1';
 const RETRY_TIMEOUT = 1000;
 const PROTOCOL_VERSION = 1;
 
+// Chromium gates a public page's connection to loopback behind a local access permission
+// (Chrome 142+, websockets from 147), granted per origin. A blocked socket is
+// indistinguishable from "nothing is listening", so probe the permission whenever we never
+// reach 'open' and tell the user which toggle to flip. The Permissions API name changed with
+// the Chrome 145 loopback/LAN split, so try each and use the first the browser recognises.
+const LOCAL_ACCESS_PERMISSIONS = ['loopback-network', 'local-network', 'local-network-access'];
+
 type Status = 'connecting' | 'connected' | 'disconnected';
 type Role = 'editor' | 'runtime';
 type MethodResult = { data?: any; error?: string; meta?: Record<string, any> };
@@ -16,6 +23,33 @@ type Method = (...args: any[]) => MethodResult | Promise<MethodResult>;
 
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
 const error = (msg: unknown) => console.error(`[MCP] ${msg}`);
+
+// 'denied' or 'prompt' when the permission may be why we can't connect, null when it can't
+// be (already granted, or the browser doesn't gate local access at all). A never-asked site
+// reads 'prompt', which is also what a missing server looks like — hence the two states.
+// the server's opening frame advertises its capabilities; tool requests always carry an id.
+// an older server sends nothing, which is the signal to dial from the launch page instead
+const greetingOf = (data: unknown) => {
+    if (typeof data !== 'string' || !data.includes('"hello"')) {
+        return null;
+    }
+    try {
+        return JSON.parse(data)?.hello ?? null;
+    } catch {
+        return null;
+    }
+};
+
+const localAccessState = async () => {
+    for (const name of LOCAL_ACCESS_PERMISSIONS) {
+        const state = await navigator.permissions?.query({ name: name as PermissionName })
+            .then(status => status.state, () => null);
+        if (state) {
+            return state === 'granted' ? null : state;
+        }
+    }
+    return null;
+};
 
 /**
  * WebSocket client that connects the page to the external MCP server and dispatches its
@@ -39,8 +73,30 @@ class MCPConnection extends Events {
 
     private _forceClosed = false;
 
+    private _blocked: string | null = null;
+
+    private _serverRelay = false;
+
+    private _fallback: ((name: string, args: any[]) => MethodResult | Promise<MethodResult> | null) | null = null;
+
     get status() {
         return this._status;
+    }
+
+    /**
+     * Whether the connected server can route `runtime:*` calls through this page, letting the
+     * launch window relay over postMessage instead of opening a socket of its own.
+     */
+    get serverRelay() {
+        return this._serverRelay;
+    }
+
+    get methodNames() {
+        return Array.from(this._methods.keys()).sort();
+    }
+
+    get blocked() {
+        return this._blocked;
     }
 
     get port() {
@@ -50,6 +106,19 @@ class MCPConnection extends Events {
     private _setStatus(status: Status) {
         this._status = status;
         this.emit('status', status);
+    }
+
+    private _setBlocked(state: string | null) {
+        if (this._blocked === state) {
+            return;
+        }
+        this._blocked = state;
+        if (state === 'denied') {
+            error('The browser is blocking this page from reaching the MCP server. Allow local access for this site in its site settings ("Apps on device" in Chrome), then reconnect.');
+        } else if (state === 'prompt') {
+            error('This page has not been allowed to reach local servers yet. Accept the browser prompt, or allow local access for this site in its site settings ("Apps on device" in Chrome). Otherwise check that the MCP server is running.');
+        }
+        this.emit('blocked', state);
     }
 
     /**
@@ -82,8 +151,12 @@ class MCPConnection extends Events {
     private _open() {
         const ws = new WebSocket(`ws://${HOST}:${this._port}`);
         this._ws = ws;
+        this._serverRelay = false;
+        let opened = false;
 
         ws.onopen = () => {
+            opened = true;
+            this._setBlocked(null);
             ws.send(
                 JSON.stringify({
                     register: this._role,
@@ -95,6 +168,13 @@ class MCPConnection extends Events {
             log('Connected');
         };
         ws.onmessage = async (event) => {
+            const greeting = greetingOf(event.data);
+            if (greeting) {
+                this._serverRelay = !!greeting.relay;
+                log(`Server relay ${this._serverRelay ? 'available' : 'unavailable'}`);
+                this.emit('hello');
+                return;
+            }
             const msg = await handleRequest(event.data, (name, ...args) => this.call(name, ...args));
             if ('id' in msg) {
                 ws.send(JSON.stringify(msg));
@@ -112,6 +192,9 @@ class MCPConnection extends Events {
             // a deliberate disconnect() (FORCE) must never reconnect
             if (this._forceClosed || evt?.reason === 'FORCE') {
                 return;
+            }
+            if (!opened) {
+                localAccessState().then(state => this._setBlocked(state));
             }
             this._setStatus('connecting');
             log('Disconnected; reconnecting');
@@ -141,6 +224,28 @@ class MCPConnection extends Events {
     }
 
     /**
+     * Send a raw frame to the server, outside the request/response flow. Used for relay
+     * announcements, which the server treats as state rather than as a reply.
+     *
+     * @param msg - The frame to send; dropped if the socket isn't open.
+     */
+    send(msg: Record<string, any>) {
+        if (this._ws?.readyState === WebSocket.OPEN) {
+            this._ws.send(JSON.stringify(msg));
+        }
+    }
+
+    /**
+     * Register a handler for methods this page doesn't implement itself. Returning null
+     * declines, leaving the caller with the usual unknown-method error.
+     *
+     * @param fn - The handler, called with the method name and its arguments.
+     */
+    fallback(fn: (name: string, args: any[]) => MethodResult | Promise<MethodResult> | null) {
+        this._fallback = fn;
+    }
+
+    /**
      * @param name - The name of the method to register.
      * @param fn - The handler to call when the method is requested.
      */
@@ -160,7 +265,8 @@ class MCPConnection extends Events {
     call(name: string, ...args: any[]): MethodResult | Promise<MethodResult> {
         const fn = this._methods.get(name);
         if (!fn) {
-            return { error: `Unknown method: ${name}. The editor may be outdated; reload the page and reconnect.` };
+            return this._fallback?.(name, args) ??
+                { error: `Unknown method: ${name}. The editor may be outdated; reload the page and reconnect.` };
         }
         return fn(...args);
     }
@@ -172,6 +278,9 @@ editor.method('mcp:connect', (port?: number, role?: Role) => mcp.connect(port, r
 editor.method('mcp:disconnect', () => mcp.disconnect());
 editor.method('mcp:status', () => mcp.status);
 editor.method('mcp:port', () => mcp.port);
+editor.method('mcp:blocked', () => mcp.blocked);
+editor.method('mcp:relay', () => mcp.serverRelay);
 mcp.on('status', (status: Status) => editor.emit('mcp:status', status));
+mcp.on('blocked', (state: string | null) => editor.emit('mcp:blocked', state));
 
 export { mcp, DEFAULT_PORT, PROTOCOL_VERSION };

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -42,8 +42,10 @@ const greetingOf = (data: unknown) => {
 
 const localAccessState = async () => {
     for (const name of LOCAL_ACCESS_PERMISSIONS) {
-        const state = await navigator.permissions?.query({ name: name as PermissionName })
-            .then(status => status.state, () => null);
+        const state = await navigator.permissions?.query({ name: name as PermissionName }).then(
+            (status) => status.state,
+            () => null
+        );
         if (state) {
             return state === 'granted' ? null : state;
         }
@@ -114,9 +116,13 @@ class MCPConnection extends Events {
         }
         this._blocked = state;
         if (state === 'denied') {
-            error('The browser is blocking this page from reaching the MCP server. Allow local access for this site in its site settings ("Apps on device" in Chrome), then reconnect.');
+            error(
+                'The browser is blocking this page from reaching the MCP server. Allow local access for this site in its site settings ("Apps on device" in Chrome), then reconnect.'
+            );
         } else if (state === 'prompt') {
-            error('This page has not been allowed to reach local servers yet. Accept the browser prompt, or allow local access for this site in its site settings ("Apps on device" in Chrome). Otherwise check that the MCP server is running.');
+            error(
+                'This page has not been allowed to reach local servers yet. Accept the browser prompt, or allow local access for this site in its site settings ("Apps on device" in Chrome). Otherwise check that the MCP server is running.'
+            );
         }
         this.emit('blocked', state);
     }
@@ -194,7 +200,7 @@ class MCPConnection extends Events {
                 return;
             }
             if (!opened) {
-                localAccessState().then(state => this._setBlocked(state));
+                localAccessState().then((state) => this._setBlocked(state));
             }
             this._setStatus('connecting');
             log('Disconnected; reconnecting');
@@ -265,8 +271,11 @@ class MCPConnection extends Events {
     call(name: string, ...args: any[]): MethodResult | Promise<MethodResult> {
         const fn = this._methods.get(name);
         if (!fn) {
-            return this._fallback?.(name, args) ??
-                { error: `Unknown method: ${name}. The editor may be outdated; reload the page and reconnect.` };
+            return (
+                this._fallback?.(name, args) ?? {
+                    error: `Unknown method: ${name}. The editor may be outdated; reload the page and reconnect.`
+                }
+            );
         }
         return fn(...args);
     }

--- a/src/editor/mcp/connection.ts
+++ b/src/editor/mcp/connection.ts
@@ -24,18 +24,6 @@ const error = (msg: unknown) => console.error(`[MCP] ${msg}`);
 
 // 'denied' or 'prompt' when the permission may be the cause, null when it can't be. A
 // never-asked site reads 'prompt', which is also what a missing server looks like.
-// the server's opening frame advertises its capabilities; tool requests always carry an id
-const greetingOf = (data: unknown) => {
-    if (typeof data !== 'string' || !data.includes('"hello"')) {
-        return null;
-    }
-    try {
-        return JSON.parse(data)?.hello ?? null;
-    } catch {
-        return null;
-    }
-};
-
 const localAccessState = async () => {
     for (const name of LOCAL_ACCESS_PERMISSIONS) {
         const state = await navigator.permissions?.query({ name: name as PermissionName }).then(
@@ -73,20 +61,10 @@ class MCPConnection extends Events {
 
     private _blocked: string | null = null;
 
-    private _serverRelay = false;
-
     private _fallback: ((name: string, args: any[]) => MethodResult | Promise<MethodResult> | null) | null = null;
 
     get status() {
         return this._status;
-    }
-
-    /**
-     * Whether the server can route `runtime:*` through this page instead of the launch page
-     * opening its own socket.
-     */
-    get serverRelay() {
-        return this._serverRelay;
     }
 
     get methodNames() {
@@ -153,7 +131,6 @@ class MCPConnection extends Events {
     private _open() {
         const ws = new WebSocket(`ws://${HOST}:${this._port}`);
         this._ws = ws;
-        this._serverRelay = false;
         let opened = false;
 
         ws.onopen = () => {
@@ -170,13 +147,6 @@ class MCPConnection extends Events {
             log('Connected');
         };
         ws.onmessage = async (event) => {
-            const greeting = greetingOf(event.data);
-            if (greeting) {
-                this._serverRelay = !!greeting.relay;
-                log(`Server relay ${this._serverRelay ? 'available' : 'unavailable'}`);
-                this.emit('hello');
-                return;
-            }
             const msg = await handleRequest(event.data, (name, ...args) => this.call(name, ...args));
             if ('id' in msg) {
                 ws.send(JSON.stringify(msg));
@@ -283,7 +253,6 @@ editor.method('mcp:disconnect', () => mcp.disconnect());
 editor.method('mcp:status', () => mcp.status);
 editor.method('mcp:port', () => mcp.port);
 editor.method('mcp:blocked', () => mcp.blocked);
-editor.method('mcp:relay', () => mcp.serverRelay);
 mcp.on('status', (status: Status) => editor.emit('mcp:status', status));
 mcp.on('blocked', (state: string | null) => editor.emit('mcp:blocked', state));
 

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -49,7 +49,7 @@ mcp.method('launch:start', async (options: any = {}) => {
         return { error: 'No scene loaded, or launch URL unavailable. Load a scene in the editor and retry.' };
     }
     // with no options requested, adopt a running app instead of restarting the session
-    if (mcp.serverRelay && !Object.keys(options).length) {
+    if (!Object.keys(options).length) {
         const running = relay.peer && !relay.peer.window.closed ? relay.peer : null;
         if (running?.sceneId === sceneId) {
             log('Adopted the running app');
@@ -98,10 +98,6 @@ mcp.method('launch:start', async (options: any = {}) => {
         }
     }
 
-    // only older servers route to a socket the launch page opens itself
-    if (!mcp.serverRelay) {
-        params.set('mcp_port', String(mcp.port));
-    }
     const url = `${base}${sceneId}?${params.toString()}`;
 
     await closeCurrent();
@@ -112,16 +108,12 @@ mcp.method('launch:start', async (options: any = {}) => {
             error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.'
         };
     }
-    if (mcp.serverRelay) {
-        // project scripts get no handle into the editor. This also makes the window unclosable
-        // from here, so only sever where closing goes through the page (see closeCurrent).
-        runtimeWindow.opener = null;
-    }
+    // project scripts get no handle into the editor; also makes the window unclosable from
+    // here, so we only close through the page (see closeCurrent)
+    runtimeWindow.opener = null;
     runtimeWindow.location = url;
-    editor.call('launch:window:track', runtimeWindow, true);
-    if (mcp.serverRelay) {
-        relay.attach(runtimeWindow);
-    }
+    editor.call('launch:window:track', runtimeWindow);
+    relay.attach(runtimeWindow);
     log(`Launched runtime for scene(${sceneId})`);
     return { data: { url, sceneId, adopted: false } };
 });

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -14,10 +14,8 @@ const CLOSE_ATTEMPTS = 10;
 let runtimeWindow: Window | null = null;
 
 /**
- * Close whichever launch window is current — ours, or one the editor's Launch button opened
- * and handed to the relay — and confirm it actually went. Asking the page to close itself
- * comes first: a window whose opener we severed, or that a previous editor document opened,
- * can't always be closed from here.
+ * Close the current launch window — ours, or one handed to the relay by the Launch button —
+ * and confirm it went. The page closes itself where we can't.
  *
  * @returns True if a window was open and is now closed.
  */
@@ -50,8 +48,7 @@ mcp.method('launch:start', async (options: any = {}) => {
     if (!sceneId || !base) {
         return { error: 'No scene loaded, or launch URL unavailable. Load a scene in the editor and retry.' };
     }
-    // when the caller asked for nothing specific, adopt an app that is already running rather
-    // than throwing away a session in progress
+    // with no options requested, adopt a running app instead of restarting the session
     if (mcp.serverRelay && !Object.keys(options).length) {
         const running = relay.peer && !relay.peer.window.closed ? relay.peer : null;
         if (running?.sceneId === sceneId) {
@@ -66,7 +63,7 @@ mcp.method('launch:start', async (options: any = {}) => {
                 log('Adopted the app launched from the editor');
                 return { data: { url: adopted.url, sceneId, adopted: true } };
             }
-            // a different scene, or a build without the relay: leave it alone and relaunch
+            // different scene, or a build without the relay: leave it and relaunch
             relay.detach();
         }
     }
@@ -93,8 +90,7 @@ mcp.method('launch:start', async (options: any = {}) => {
         params.set('ministats', 'true');
     }
 
-    // carry the dev overrides the editor itself was loaded with, so a local build launches
-    // the local launch page (the editor's own Launch button does the same)
+    // a local build must launch the local launch page, as the Launch button does
     const search = new URLSearchParams(location.search);
     for (const flag of ['use_local_frontend', 'use_local_engine']) {
         if (search.has(flag)) {
@@ -102,16 +98,14 @@ mcp.method('launch:start', async (options: any = {}) => {
         }
     }
 
-    // a relaying server reaches the launch page through this one, so the page needs no port
-    // of its own; older servers still route to a socket the launch page opens itself
+    // only older servers route to a socket the launch page opens itself
     if (!mcp.serverRelay) {
         params.set('mcp_port', String(mcp.port));
     }
     const url = `${base}${sceneId}?${params.toString()}`;
 
     await closeCurrent();
-    // open blank first so the opener can be severed before the page loads: it runs project
-    // scripts, and with the relay it never needs a handle back into the editor
+    // open blank so the opener can be severed before the page loads
     runtimeWindow = window.open('', '_blank');
     if (!runtimeWindow) {
         return {
@@ -119,9 +113,8 @@ mcp.method('launch:start', async (options: any = {}) => {
         };
     }
     if (mcp.serverRelay) {
-        // the launch page runs project scripts and, with the relay, never needs a handle back
-        // into the editor. Severing the opener also makes the window unclosable from here, so
-        // only do it where closing goes through the page itself (see closeCurrent).
+        // project scripts get no handle into the editor. This also makes the window unclosable
+        // from here, so only sever where closing goes through the page (see closeCurrent).
         runtimeWindow.opener = null;
     }
     runtimeWindow.location = url;

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -1,19 +1,76 @@
 import { config } from '@/editor/config';
 
 import { mcp } from './connection';
+import { relay } from './relay';
 
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
+
+// how long an already-open launch window gets to answer the relay offer before we relaunch
+const ADOPT_TIMEOUT = 5000;
+const CLOSE_POLL = 100;
+const CLOSE_ATTEMPTS = 10;
 
 // remember a handle to the launched runtime window so we can stop it later
 let runtimeWindow: Window | null = null;
 
+/**
+ * Close whichever launch window is current — ours, or one the editor's Launch button opened
+ * and handed to the relay — and confirm it actually went. Asking the page to close itself
+ * comes first: a window whose opener we severed, or that a previous editor document opened,
+ * can't always be closed from here.
+ *
+ * @returns True if a window was open and is now closed.
+ */
+const closeCurrent = async () => {
+    const target = runtimeWindow && !runtimeWindow.closed ? runtimeWindow : relay.peer?.window;
+    runtimeWindow = null;
+    if (!target || target.closed) {
+        relay.detach();
+        return false;
+    }
+    let closed = await relay.close();
+    if (!closed) {
+        target.close();
+        for (let i = 0; i < CLOSE_ATTEMPTS && !target.closed; i++) {
+            await new Promise(resolve => setTimeout(resolve, CLOSE_POLL));
+        }
+        closed = target.closed;
+    }
+    relay.detach();
+    if (!closed) {
+        log('Runtime window would not close');
+    }
+    return closed;
+};
+
 // launch (runtime control)
-mcp.method('launch:start', (options: any = {}) => {
+mcp.method('launch:start', async (options: any = {}) => {
     const sceneId = config.scene?.id;
     const base = config.url?.launch;
     if (!sceneId || !base) {
         return { error: 'No scene loaded, or launch URL unavailable. Load a scene in the editor and retry.' };
     }
+    // when the caller asked for nothing specific, adopt an app that is already running rather
+    // than throwing away a session in progress
+    if (mcp.serverRelay && !Object.keys(options).length) {
+        const running = relay.peer && !relay.peer.window.closed ? relay.peer : null;
+        if (running?.sceneId === sceneId) {
+            log('Adopted the running app');
+            return { data: { url: running.url, sceneId, adopted: true } };
+        }
+        const last = editor.call('launch:window');
+        if (!running && last?.window && !last.window.closed) {
+            relay.attach(last.window);
+            const adopted = await relay.ready(ADOPT_TIMEOUT);
+            if (adopted?.sceneId === sceneId) {
+                log('Adopted the app launched from the editor');
+                return { data: { url: adopted.url, sceneId, adopted: true } };
+            }
+            // a different scene, or a build without the relay: leave it alone and relaunch
+            relay.detach();
+        }
+    }
+
     const params = new URLSearchParams();
 
     params.set('debug', String(options.debug ?? true));
@@ -36,29 +93,51 @@ mcp.method('launch:start', (options: any = {}) => {
         params.set('ministats', 'true');
     }
 
-    // pass the MCP port so the launch page can connect back as the runtime peer
-    // without any popup UI
-    params.set('mcp_port', String(mcp.port));
+    // carry the dev overrides the editor itself was loaded with, so a local build launches
+    // the local launch page (the editor's own Launch button does the same)
+    const search = new URLSearchParams(location.search);
+    for (const flag of ['use_local_frontend', 'use_local_engine']) {
+        if (search.has(flag)) {
+            params.set(flag, search.get(flag) ?? '');
+        }
+    }
+
+    // a relaying server reaches the launch page through this one, so the page needs no port
+    // of its own; older servers still route to a socket the launch page opens itself
+    if (!mcp.serverRelay) {
+        params.set('mcp_port', String(mcp.port));
+    }
     const url = `${base}${sceneId}?${params.toString()}`;
 
-    if (runtimeWindow && !runtimeWindow.closed) {
-        runtimeWindow.close();
-    }
-    runtimeWindow = window.open(url, '_blank');
+    await closeCurrent();
+    // open blank first so the opener can be severed before the page loads: it runs project
+    // scripts, and with the relay it never needs a handle back into the editor
+    runtimeWindow = window.open('', '_blank');
     if (!runtimeWindow) {
         return {
             error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.'
         };
     }
-    log(`Launched runtime for scene(${sceneId})`);
-    return { data: { url, sceneId } };
-});
-mcp.method('launch:stop', () => {
-    const wasOpen = !!(runtimeWindow && !runtimeWindow.closed);
-    if (runtimeWindow && !runtimeWindow.closed) {
-        runtimeWindow.close();
+    if (mcp.serverRelay) {
+        // the launch page runs project scripts and, with the relay, never needs a handle back
+        // into the editor. Severing the opener also makes the window unclosable from here, so
+        // only do it where closing goes through the page itself (see closeCurrent).
+        runtimeWindow.opener = null;
     }
-    runtimeWindow = null;
-    log('Stopped runtime');
-    return { data: { stopped: wasOpen } };
+    runtimeWindow.location = url;
+    editor.call('launch:window:track', runtimeWindow, true);
+    if (mcp.serverRelay) {
+        relay.attach(runtimeWindow);
+    }
+    log(`Launched runtime for scene(${sceneId})`);
+    return { data: { url, sceneId, adopted: false } };
+});
+mcp.method('launch:stop', async () => {
+    const wasOpen = !!(runtimeWindow && !runtimeWindow.closed) || !!relay.peer;
+    const closed = await closeCurrent();
+    if (wasOpen && !closed) {
+        return { data: { stopped: false }, error: 'The launch window did not close. Close it manually, then retry.' };
+    }
+    log(closed ? 'Stopped runtime' : 'No runtime to stop');
+    return { data: { stopped: closed } };
 });

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -5,12 +5,12 @@ import { relay } from './relay';
 
 const log = (msg: string) => console.log(`[MCP] ${msg}`);
 
-// how long an already-open launch window gets to answer the relay offer before we relaunch
+// how long a running window has to answer the relay offer before we relaunch
 const ADOPT_TIMEOUT = 5000;
 const CLOSE_POLL = 100;
 const CLOSE_ATTEMPTS = 10;
 
-// remember a handle to the launched runtime window so we can stop it later
+// handle to the launched window, so we can stop it later
 let runtimeWindow: Window | null = null;
 
 /**
@@ -48,7 +48,8 @@ mcp.method('launch:start', async (options: any = {}) => {
     if (!sceneId || !base) {
         return { error: 'No scene loaded, or launch URL unavailable. Load a scene in the editor and retry.' };
     }
-    // with no options requested, adopt a running app instead of restarting the session
+
+    // no options: adopt a running app instead of restarting the session
     if (!Object.keys(options).length) {
         const running = relay.peer && !relay.peer.window.closed ? relay.peer : null;
         if (running?.sceneId === sceneId) {
@@ -63,6 +64,7 @@ mcp.method('launch:start', async (options: any = {}) => {
                 log('Adopted the app launched from the editor');
                 return { data: { url: adopted.url, sceneId, adopted: true } };
             }
+
             // different scene, or a build without the relay: leave it and relaunch
             relay.detach();
         }
@@ -90,7 +92,7 @@ mcp.method('launch:start', async (options: any = {}) => {
         params.set('ministats', 'true');
     }
 
-    // a local build must launch the local launch page, as the Launch button does
+    // a local build must launch the local page, like the Launch button
     const search = new URLSearchParams(location.search);
     for (const flag of ['use_local_frontend', 'use_local_engine']) {
         if (search.has(flag)) {
@@ -101,6 +103,7 @@ mcp.method('launch:start', async (options: any = {}) => {
     const url = `${base}${sceneId}?${params.toString()}`;
 
     await closeCurrent();
+
     // open blank so the opener can be severed before the page loads
     runtimeWindow = window.open('', '_blank');
     if (!runtimeWindow) {
@@ -108,8 +111,8 @@ mcp.method('launch:start', async (options: any = {}) => {
             error: 'Could not open the launch window (popup blocked). Allow popups for the editor origin and retry.'
         };
     }
-    // project scripts get no handle into the editor; also makes the window unclosable from
-    // here, so we only close through the page (see closeCurrent)
+
+    // sever the opener: project scripts get no editor handle, and we close via the page (closeCurrent)
     runtimeWindow.opener = null;
     runtimeWindow.location = url;
     editor.call('launch:window:track', runtimeWindow);

--- a/src/editor/mcp/launch.ts
+++ b/src/editor/mcp/launch.ts
@@ -32,7 +32,7 @@ const closeCurrent = async () => {
     if (!closed) {
         target.close();
         for (let i = 0; i < CLOSE_ATTEMPTS && !target.closed; i++) {
-            await new Promise(resolve => setTimeout(resolve, CLOSE_POLL));
+            await new Promise((resolve) => setTimeout(resolve, CLOSE_POLL));
         }
         closed = target.closed;
     }

--- a/src/editor/mcp/register.ts
+++ b/src/editor/mcp/register.ts
@@ -2,6 +2,7 @@ import { driver } from '@/editor/driver';
 
 import { mcp } from './connection';
 import './launch';
+import './relay';
 
 mcp.method('ping', () => ({ data: 'pong' }));
 

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -47,7 +47,7 @@ const announce = () => {
 };
 
 const settle = (value: Peer | null) => {
-    waiters.forEach(resolve => resolve(value));
+    waiters.forEach((resolve) => resolve(value));
     waiters.clear();
 };
 
@@ -56,7 +56,7 @@ const drop = (reason: string) => {
         return;
     }
     peer = null;
-    pending.forEach(resolve => resolve({ error: 'The launched app disconnected mid-call. Run launch_start again.' }));
+    pending.forEach((resolve) => resolve({ error: 'The launched app disconnected mid-call. Run launch_start again.' }));
     pending.clear();
     if (pollTimer) {
         clearInterval(pollTimer);
@@ -97,7 +97,9 @@ window.addEventListener('message', (evt: MessageEvent) => {
         const known = peer?.window === evt.source;
         peer = {
             window: evt.source as Window,
-            methods: (msg.methods ?? []).filter((name: unknown) => typeof name === 'string' && name.startsWith('runtime:')),
+            methods: (msg.methods ?? []).filter(
+                (name: unknown) => typeof name === 'string' && name.startsWith('runtime:')
+            ),
             sceneId: msg.sceneId,
             projectId: msg.projectId,
             url: msg.url
@@ -209,7 +211,7 @@ const relay = {
         }
         win.postMessage({ mcp: 'close' }, LAUNCH_ORIGIN);
         for (let i = 0; i < CLOSE_ATTEMPTS && !win.closed; i++) {
-            await new Promise(resolve => setTimeout(resolve, CLOSE_POLL));
+            await new Promise((resolve) => setTimeout(resolve, CLOSE_POLL));
         }
         if (win.closed) {
             drop('closed on request');
@@ -235,7 +237,9 @@ const relay = {
         return new Promise<Reply>((resolve) => {
             const timer = setTimeout(() => {
                 pending.delete(callId);
-                resolve({ error: `Timed out after ${CALL_TIMEOUT}ms waiting for the launched app to handle '${name}'.` });
+                resolve({
+                    error: `Timed out after ${CALL_TIMEOUT}ms waiting for the launched app to handle '${name}'.`
+                });
             }, CALL_TIMEOUT);
             pending.set(callId, (res) => {
                 clearTimeout(timer);

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -89,7 +89,6 @@ window.addEventListener('message', (evt: MessageEvent) => {
     const msg = evt.data;
 
     if (msg.mcp === 'ready') {
-
         // the user may have another project's app running in a second window
         if (config.project?.id !== undefined && msg.projectId !== config.project.id) {
             return;

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -1,0 +1,256 @@
+import { config } from '@/editor/config';
+
+import { mcp, PROTOCOL_VERSION } from './connection';
+
+/**
+ * Editor half of the runtime relay. The launch page is a different origin, so reaching the
+ * MCP server itself would need its own local network access grant (Chrome 142+, websockets
+ * from 147). Instead the editor holds the only socket and forwards `runtime:*` frames to the
+ * launch window over postMessage, unchanged.
+ *
+ * First contact must come from the editor: the launch window's `opener` is severed, so it has
+ * no handle to post to until it receives one. After that it keeps announcing itself, which is
+ * what lets a reloaded editor re-adopt a still-running app.
+ */
+
+const LAUNCH_ORIGIN = new URL(config.url.launch).origin;
+const OFFER_INTERVAL = 250;
+const OFFER_TIMEOUT = 30_000;
+
+// under the server's 60s so the agent gets our error rather than a generic timeout
+const CALL_TIMEOUT = 55_000;
+const WINDOW_POLL = 1000;
+const CLOSE_POLL = 100;
+const CLOSE_ATTEMPTS = 20;
+
+type Reply = { data?: any; error?: string; meta?: Record<string, any> };
+type Peer = { window: Window; methods: string[]; sceneId?: string; projectId?: number; url?: string };
+
+const log = (msg: string) => console.log(`[MCP] ${msg}`);
+
+let offered: Window | null = null;
+let peer: Peer | null = null;
+let offerDeadline = 0;
+let offerTimer: ReturnType<typeof setTimeout> | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let id = 0;
+
+const pending = new Map<number, (res: Reply) => void>();
+const waiters = new Set<(peer: Peer | null) => void>();
+
+// tell the server whether a launch page is reachable through us; the frame is sent even when
+// empty so the server knows this editor relays at all
+const announce = () => {
+    mcp.send({
+        runtime: peer ? { protocolVersion: PROTOCOL_VERSION, methods: peer.methods } : null
+    });
+};
+
+const settle = (value: Peer | null) => {
+    waiters.forEach(resolve => resolve(value));
+    waiters.clear();
+};
+
+const drop = (reason: string) => {
+    if (!peer) {
+        return;
+    }
+    peer = null;
+    pending.forEach(resolve => resolve({ error: 'The launched app disconnected mid-call. Run launch_start again.' }));
+    pending.clear();
+    if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+    log(`Runtime relay dropped (${reason})`);
+    announce();
+    settle(null);
+};
+
+const offer = () => {
+    offerTimer = null;
+    if (!offered || peer) {
+        return;
+    }
+    if (offered.closed || Date.now() > offerDeadline) {
+        log('Launch page never answered the relay offer');
+        offered = null;
+        settle(null);
+        return;
+    }
+    offered.postMessage({ mcp: 'offer' }, LAUNCH_ORIGIN);
+    offerTimer = setTimeout(offer, OFFER_INTERVAL);
+};
+
+window.addEventListener('message', (evt: MessageEvent) => {
+    if (evt.origin !== LAUNCH_ORIGIN || !evt.data || !evt.source) {
+        return;
+    }
+    const msg = evt.data;
+
+    if (msg.mcp === 'ready') {
+        // only adopt launch pages from the project this editor has open — the user may well
+        // have another project's app running in a second window
+        if (config.project?.id !== undefined && msg.projectId !== config.project.id) {
+            return;
+        }
+        const known = peer?.window === evt.source;
+        peer = {
+            window: evt.source as Window,
+            methods: (msg.methods ?? []).filter((name: unknown) => typeof name === 'string' && name.startsWith('runtime:')),
+            sceneId: msg.sceneId,
+            projectId: msg.projectId,
+            url: msg.url
+        };
+        if (!known) {
+            log(`Runtime relay ready (scene ${msg.sceneId})`);
+            if (offerTimer) {
+                clearTimeout(offerTimer);
+                offerTimer = null;
+            }
+            // the launch window can be closed by the user at any point
+            pollTimer ??= setInterval(() => peer?.window.closed && drop('window closed'), WINDOW_POLL);
+            announce();
+        }
+        settle(peer);
+        return;
+    }
+
+    if (msg.mcp === 'gone' && peer?.window === evt.source) {
+        drop('launch page unloaded');
+        return;
+    }
+
+    if (msg.mcp === 'res' && peer?.window === evt.source) {
+        const resolve = pending.get(msg.id);
+        if (resolve) {
+            pending.delete(msg.id);
+            resolve(msg.res ?? {});
+        }
+    }
+});
+
+// re-announce after a reconnect (or a takeover by another MCP client instance), since the
+// server tracks the relay per connection
+mcp.on('status', (status: string) => status === 'connected' && announce());
+
+const relay = {
+    /**
+     * Start offering the relay to a launch window. Safe to call repeatedly; the newest
+     * window wins.
+     *
+     * @param win - The launch window to adopt.
+     */
+    attach(win: Window) {
+        if (peer && peer.window !== win) {
+            drop('replaced by a new launch window');
+        }
+        offered = win;
+        offerDeadline = Date.now() + OFFER_TIMEOUT;
+        if (!offerTimer) {
+            offer();
+        }
+    },
+
+    /**
+     * Stop relaying and forget the current launch window.
+     */
+    detach() {
+        offered = null;
+        if (offerTimer) {
+            clearTimeout(offerTimer);
+            offerTimer = null;
+        }
+        drop('detached');
+        settle(null);
+    },
+
+    /**
+     * The launch page currently reachable through the relay, if any.
+     */
+    get peer() {
+        return peer;
+    },
+
+    /**
+     * Wait for a launch page to answer the offer.
+     *
+     * @param timeoutMs - How long to wait before giving up.
+     * @returns The peer, or null if none answered in time.
+     */
+    ready(timeoutMs: number) {
+        if (peer) {
+            return Promise.resolve(peer);
+        }
+        return new Promise<Peer | null>((resolve) => {
+            const timer = setTimeout(() => {
+                waiters.delete(done);
+                resolve(null);
+            }, timeoutMs);
+            const done = (value: Peer | null) => {
+                clearTimeout(timer);
+                resolve(value);
+            };
+            waiters.add(done);
+        });
+    },
+
+    /**
+     * Ask the launch page to close itself and wait for it to go. A window whose opener we
+     * severed can't always be closed from here — after an editor reload it never can — so the
+     * page does it and we confirm rather than assume.
+     *
+     * @returns True once the window is gone, false if it outlived the request.
+     */
+    async close() {
+        const win = peer?.window;
+        if (!win || win.closed) {
+            return false;
+        }
+        win.postMessage({ mcp: 'close' }, LAUNCH_ORIGIN);
+        for (let i = 0; i < CLOSE_ATTEMPTS && !win.closed; i++) {
+            await new Promise(resolve => setTimeout(resolve, CLOSE_POLL));
+        }
+        if (win.closed) {
+            drop('closed on request');
+            return true;
+        }
+        return false;
+    },
+
+    /**
+     * Forward a `runtime:*` call to the launch page and await its reply.
+     *
+     * @param name - The method name.
+     * @param args - The method arguments.
+     * @returns The launch page's result, or an error result.
+     */
+    call(name: string, args: any[]): Promise<Reply> {
+        if (!peer || peer.window.closed) {
+            return Promise.resolve({
+                error: 'No running instance connected. Call launch_start first; the editor relays to the launched page automatically.'
+            });
+        }
+        const callId = id++;
+        return new Promise<Reply>((resolve) => {
+            const timer = setTimeout(() => {
+                pending.delete(callId);
+                resolve({ error: `Timed out after ${CALL_TIMEOUT}ms waiting for the launched app to handle '${name}'.` });
+            }, CALL_TIMEOUT);
+            pending.set(callId, (res) => {
+                clearTimeout(timer);
+                resolve(res);
+            });
+            peer!.window.postMessage({ mcp: 'call', id: callId, name, args }, LAUNCH_ORIGIN);
+        });
+    }
+};
+
+// the server only routes `runtime:*` here, but be explicit: everything else is not ours
+mcp.fallback((name, args) => (name.startsWith('runtime:') ? relay.call(name, args) : null));
+
+// the editor's own Launch button opens windows too, and hands them over here
+editor.method('mcp:relay:attach', (win: Window) => relay.attach(win));
+editor.method('mcp:relay:peer', () => !!peer && !peer.window.closed);
+
+export { relay };

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -3,14 +3,9 @@ import { config } from '@/editor/config';
 import { mcp, PROTOCOL_VERSION } from './connection';
 
 /**
- * Editor half of the runtime relay. The launch page is a different origin, so reaching the
- * MCP server itself would need its own local network access grant (Chrome 142+, websockets
- * from 147). Instead the editor holds the only socket and forwards `runtime:*` frames to the
- * launch window over postMessage, unchanged.
- *
- * First contact must come from the editor: the launch window's `opener` is severed, so it has
- * no handle to post to until it receives one. After that it keeps announcing itself, which is
- * what lets a reloaded editor re-adopt a still-running app.
+ * Editor half of the runtime relay: the editor holds the only socket and forwards `runtime:*`
+ * to the launch window over postMessage, so that origin needs no local access grant of its
+ * own. The editor must make first contact — the launch window's `opener` is severed.
  */
 
 const LAUNCH_ORIGIN = new URL(config.url.launch).origin;
@@ -38,8 +33,7 @@ let id = 0;
 const pending = new Map<number, (res: Reply) => void>();
 const waiters = new Set<(peer: Peer | null) => void>();
 
-// tell the server whether a launch page is reachable through us; the frame is sent even when
-// empty so the server knows this editor relays at all
+// sent even when empty, so the server knows this editor relays at all
 const announce = () => {
     mcp.send({
         runtime: peer ? { protocolVersion: PROTOCOL_VERSION, methods: peer.methods } : null
@@ -89,8 +83,7 @@ window.addEventListener('message', (evt: MessageEvent) => {
     const msg = evt.data;
 
     if (msg.mcp === 'ready') {
-        // only adopt launch pages from the project this editor has open — the user may well
-        // have another project's app running in a second window
+        // the user may have another project's app running in a second window
         if (config.project?.id !== undefined && msg.projectId !== config.project.id) {
             return;
         }
@@ -132,14 +125,12 @@ window.addEventListener('message', (evt: MessageEvent) => {
     }
 });
 
-// re-announce after a reconnect (or a takeover by another MCP client instance), since the
-// server tracks the relay per connection
+// the server tracks the relay per connection, so re-announce after a reconnect
 mcp.on('status', (status: string) => status === 'connected' && announce());
 
 const relay = {
     /**
-     * Start offering the relay to a launch window. Safe to call repeatedly; the newest
-     * window wins.
+     * Offer the relay to a launch window. Repeat calls are safe; the newest window wins.
      *
      * @param win - The launch window to adopt.
      */
@@ -198,11 +189,10 @@ const relay = {
     },
 
     /**
-     * Ask the launch page to close itself and wait for it to go. A window whose opener we
-     * severed can't always be closed from here — after an editor reload it never can — so the
-     * page does it and we confirm rather than assume.
+     * Ask the launch page to close itself and confirm it went: a window whose opener we
+     * severed can't be closed from here.
      *
-     * @returns True once the window is gone, false if it outlived the request.
+     * @returns True once the window is gone.
      */
     async close() {
         const win = peer?.window;
@@ -250,10 +240,10 @@ const relay = {
     }
 };
 
-// the server only routes `runtime:*` here, but be explicit: everything else is not ours
+// everything else is not ours
 mcp.fallback((name, args) => (name.startsWith('runtime:') ? relay.call(name, args) : null));
 
-// the editor's own Launch button opens windows too, and hands them over here
+// the Launch button hands its windows over here
 editor.method('mcp:relay:attach', (win: Window) => relay.attach(win));
 editor.method('mcp:relay:peer', () => !!peer && !peer.window.closed);
 

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -49,7 +49,12 @@ const drop = (reason: string) => {
     if (!peer) {
         return;
     }
+    const win = peer.window;
     peer = null;
+    // a still-open window we're dropping should restore its console and stop announcing
+    if (!win.closed) {
+        win.postMessage({ mcp: 'detach' }, LAUNCH_ORIGIN);
+    }
     pending.forEach((resolve) => resolve({ error: 'The launched app disconnected mid-call. Run launch_start again.' }));
     pending.clear();
     if (pollTimer) {

--- a/src/editor/mcp/relay.ts
+++ b/src/editor/mcp/relay.ts
@@ -51,6 +51,7 @@ const drop = (reason: string) => {
     }
     const win = peer.window;
     peer = null;
+
     // a still-open window we're dropping should restore its console and stop announcing
     if (!win.closed) {
         win.postMessage({ mcp: 'detach' }, LAUNCH_ORIGIN);
@@ -88,6 +89,7 @@ window.addEventListener('message', (evt: MessageEvent) => {
     const msg = evt.data;
 
     if (msg.mcp === 'ready') {
+
         // the user may have another project's app running in a second window
         if (config.project?.id !== undefined && msg.projectId !== config.project.id) {
             return;
@@ -108,6 +110,7 @@ window.addEventListener('message', (evt: MessageEvent) => {
                 clearTimeout(offerTimer);
                 offerTimer = null;
             }
+
             // the launch window can be closed by the user at any point
             pollTimer ??= setInterval(() => peer?.window.closed && drop('window closed'), WINDOW_POLL);
             announce();

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -107,7 +107,6 @@ editor.once('load', () => {
         popover.dom.style.top = `${Math.max(4, top)}px`;
     });
     popover.on('show', () => {
-
         // hide the hover tooltip while open so its arrow doesn't poke through
         tooltip.detach();
         tooltip.hidden = true;

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -8,8 +8,7 @@ import { DEFAULT_PORT } from './connection';
 const MCP_ICON =
     '<svg xmlns="http://www.w3.org/2000/svg" class="mcp-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M11.3574 2.48548C12.8602 1.12772 15.1806 1.17296 16.6289 2.62122C17.4208 3.41316 17.7931 4.46597 17.7461 5.50306C18.7835 5.45572 19.8367 5.82907 20.6289 6.62122L20.7646 6.76478C22.0784 8.21914 22.0785 10.4384 20.7646 11.8927L20.6289 12.0353L13.6641 19.0001L15.7499 21.0859L14.3358 22.5L12.25 20.4142C11.4692 19.6332 11.4692 18.3671 12.25 17.5861L19.2148 10.6212L19.3398 10.4826C19.8866 9.8123 19.8864 8.84526 19.3398 8.17494L19.2148 8.03529C18.5454 7.36591 17.4857 7.32444 16.7676 7.91029L16.6289 8.03529L9.75 14.9142L8.33594 13.5001L15.2148 6.62122L15.3398 6.48255C15.9256 5.76438 15.8843 4.70474 15.2148 4.03529C14.5454 3.36591 13.4857 3.32444 12.7676 3.91029L12.6289 4.03529L3.66406 13.0001L2.25 11.5861L11.2148 2.62122L11.3574 2.48548Z" fill="currentColor"/><path d="M12.1426 16.5145C10.6398 17.8723 8.31936 17.8271 6.87109 16.3788C5.42285 14.9304 5.37768 12.6101 6.73535 11.1073L6.87109 10.9647L13.75 4.08581L15.1641 5.49987L8.28516 12.3788L8.16016 12.5174C7.57439 13.2356 7.61576 14.2953 8.28516 14.9647C8.95454 15.6341 10.0143 15.6755 10.7324 15.0897L10.8711 14.9647L17.75 8.08581L19.1641 9.49987L12.2852 16.3788L12.1426 16.5145Z" fill="currentColor"/></svg>';
 
-// shown in the popover when an app was launched before connecting (so its URL has no
-// mcp_port), or keyed by the local access permission state when the socket can't connect
+// popover hints: a stale launch window, or why the socket can't connect
 const RELAUNCH_HINT = 'Relaunch the open app to connect it';
 const BLOCKED_HINTS: Record<string, string> = {
     denied: 'The browser is blocking this page — allow "Apps on device" for this site, then reconnect',
@@ -63,8 +62,7 @@ editor.once('load', () => {
             hint.hidden = false;
             return;
         }
-        // a relaying server adopts an app that's already open, so only the legacy path (where
-        // the launch page dials the server itself) still needs a relaunch to pick up the port
+        // a relaying server adopts an open app; only the legacy path needs a relaunch
         const last = editor.call('launch:window');
         hint.text = RELAUNCH_HINT;
         hint.hidden = !(

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -8,8 +8,7 @@ import { DEFAULT_PORT } from './connection';
 const MCP_ICON =
     '<svg xmlns="http://www.w3.org/2000/svg" class="mcp-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M11.3574 2.48548C12.8602 1.12772 15.1806 1.17296 16.6289 2.62122C17.4208 3.41316 17.7931 4.46597 17.7461 5.50306C18.7835 5.45572 19.8367 5.82907 20.6289 6.62122L20.7646 6.76478C22.0784 8.21914 22.0785 10.4384 20.7646 11.8927L20.6289 12.0353L13.6641 19.0001L15.7499 21.0859L14.3358 22.5L12.25 20.4142C11.4692 19.6332 11.4692 18.3671 12.25 17.5861L19.2148 10.6212L19.3398 10.4826C19.8866 9.8123 19.8864 8.84526 19.3398 8.17494L19.2148 8.03529C18.5454 7.36591 17.4857 7.32444 16.7676 7.91029L16.6289 8.03529L9.75 14.9142L8.33594 13.5001L15.2148 6.62122L15.3398 6.48255C15.9256 5.76438 15.8843 4.70474 15.2148 4.03529C14.5454 3.36591 13.4857 3.32444 12.7676 3.91029L12.6289 4.03529L3.66406 13.0001L2.25 11.5861L11.2148 2.62122L11.3574 2.48548Z" fill="currentColor"/><path d="M12.1426 16.5145C10.6398 17.8723 8.31936 17.8271 6.87109 16.3788C5.42285 14.9304 5.37768 12.6101 6.73535 11.1073L6.87109 10.9647L13.75 4.08581L15.1641 5.49987L8.28516 12.3788L8.16016 12.5174C7.57439 13.2356 7.61576 14.2953 8.28516 14.9647C8.95454 15.6341 10.0143 15.6755 10.7324 15.0897L10.8711 14.9647L17.75 8.08581L19.1641 9.49987L12.2852 16.3788L12.1426 16.5145Z" fill="currentColor"/></svg>';
 
-// popover hints: a stale launch window, or why the socket can't connect
-const RELAUNCH_HINT = 'Relaunch the open app to connect it';
+// popover hint: why the socket can't connect
 const BLOCKED_HINTS: Record<string, string> = {
     denied: 'The browser is blocking this page — allow "Apps on device" for this site, then reconnect',
     prompt: 'Allow "Apps on device" for this site if the browser asks, or check the server is running'
@@ -47,7 +46,7 @@ editor.once('load', () => {
 
     const toggle = new Button({ class: 'mcp-toggle', text: 'CONNECT' });
 
-    const hint = new Label({ class: 'mcp-hint', text: RELAUNCH_HINT, hidden: true });
+    const hint = new Label({ class: 'mcp-hint', hidden: true });
 
     popover.append(statusRow);
     popover.append(portRow);
@@ -57,21 +56,8 @@ editor.once('load', () => {
 
     const updateHint = () => {
         const blocked = BLOCKED_HINTS[editor.call('mcp:blocked')];
-        if (blocked) {
-            hint.text = blocked;
-            hint.hidden = false;
-            return;
-        }
-        // a relaying server adopts an open app; only the legacy path needs a relaunch
-        const last = editor.call('launch:window');
-        hint.text = RELAUNCH_HINT;
-        hint.hidden = !(
-            editor.call('mcp:status') === 'connected' &&
-            !editor.call('mcp:relay') &&
-            last &&
-            !last.window.closed &&
-            !last.mcp
-        );
+        hint.text = blocked ?? '';
+        hint.hidden = !blocked;
     };
 
     const render = (state: string) => {

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -8,6 +8,14 @@ import { DEFAULT_PORT } from './connection';
 const MCP_ICON =
     '<svg xmlns="http://www.w3.org/2000/svg" class="mcp-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M11.3574 2.48548C12.8602 1.12772 15.1806 1.17296 16.6289 2.62122C17.4208 3.41316 17.7931 4.46597 17.7461 5.50306C18.7835 5.45572 19.8367 5.82907 20.6289 6.62122L20.7646 6.76478C22.0784 8.21914 22.0785 10.4384 20.7646 11.8927L20.6289 12.0353L13.6641 19.0001L15.7499 21.0859L14.3358 22.5L12.25 20.4142C11.4692 19.6332 11.4692 18.3671 12.25 17.5861L19.2148 10.6212L19.3398 10.4826C19.8866 9.8123 19.8864 8.84526 19.3398 8.17494L19.2148 8.03529C18.5454 7.36591 17.4857 7.32444 16.7676 7.91029L16.6289 8.03529L9.75 14.9142L8.33594 13.5001L15.2148 6.62122L15.3398 6.48255C15.9256 5.76438 15.8843 4.70474 15.2148 4.03529C14.5454 3.36591 13.4857 3.32444 12.7676 3.91029L12.6289 4.03529L3.66406 13.0001L2.25 11.5861L11.2148 2.62122L11.3574 2.48548Z" fill="currentColor"/><path d="M12.1426 16.5145C10.6398 17.8723 8.31936 17.8271 6.87109 16.3788C5.42285 14.9304 5.37768 12.6101 6.73535 11.1073L6.87109 10.9647L13.75 4.08581L15.1641 5.49987L8.28516 12.3788L8.16016 12.5174C7.57439 13.2356 7.61576 14.2953 8.28516 14.9647C8.95454 15.6341 10.0143 15.6755 10.7324 15.0897L10.8711 14.9647L17.75 8.08581L19.1641 9.49987L12.2852 16.3788L12.1426 16.5145Z" fill="currentColor"/></svg>';
 
+// shown in the popover when an app was launched before connecting (so its URL has no
+// mcp_port), or keyed by the local access permission state when the socket can't connect
+const RELAUNCH_HINT = 'Relaunch the open app to connect it';
+const BLOCKED_HINTS: Record<string, string> = {
+    denied: 'The browser is blocking this page — allow "Apps on device" for this site, then reconnect',
+    prompt: 'Allow "Apps on device" for this site if the browser asks, or check the server is running'
+};
+
 editor.once('load', () => {
     const root = editor.call('layout.root');
     const toolbar = editor.call('layout.toolbar');
@@ -40,8 +48,7 @@ editor.once('load', () => {
 
     const toggle = new Button({ class: 'mcp-toggle', text: 'CONNECT' });
 
-    // shown when an app was launched before connecting, so its URL has no mcp_port
-    const hint = new Label({ class: 'mcp-hint', text: 'Relaunch the open app to connect it', hidden: true });
+    const hint = new Label({ class: 'mcp-hint', text: RELAUNCH_HINT, hidden: true });
 
     popover.append(statusRow);
     popover.append(portRow);
@@ -50,8 +57,18 @@ editor.once('load', () => {
     root.append(popover);
 
     const updateHint = () => {
+        const blocked = BLOCKED_HINTS[editor.call('mcp:blocked')];
+        if (blocked) {
+            hint.text = blocked;
+            hint.hidden = false;
+            return;
+        }
+        // a relaying server adopts an app that's already open, so only the legacy path (where
+        // the launch page dials the server itself) still needs a relaunch to pick up the port
         const last = editor.call('launch:window');
-        hint.hidden = !(editor.call('mcp:status') === 'connected' && last && !last.window.closed && !last.mcp);
+        hint.text = RELAUNCH_HINT;
+        hint.hidden = !(editor.call('mcp:status') === 'connected' && !editor.call('mcp:relay') &&
+            last && !last.window.closed && !last.mcp);
     };
 
     const render = (state: string) => {
@@ -67,6 +84,7 @@ editor.once('load', () => {
     };
     render(editor.call('mcp:status') || 'disconnected');
     editor.on('mcp:status', render);
+    editor.on('mcp:blocked', updateHint);
 
     toggle.on('click', () => {
         if (editor.call('mcp:status') === 'disconnected') {

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -18,7 +18,7 @@ editor.once('load', () => {
     const root = editor.call('layout.root');
     const toolbar = editor.call('layout.toolbar');
 
-    // toolbar button, placed below the publish button (last item in the top group)
+    // toolbar button, below publish (last in the top group)
     const button = new Button({ class: ['pc-icon', 'mcp'] });
     button.dom.appendChild(new DOMParser().parseFromString(MCP_ICON, 'image/svg+xml').documentElement);
     toolbar.append(button);
@@ -87,7 +87,7 @@ editor.once('load', () => {
         }
     });
 
-    // toggle popover, centered vertically on the button, close on outside click
+    // toggle popover (centered on the button), close on outside click
     const onOutside = (evt: MouseEvent) => {
         const target = evt.target as Node;
         if (popover.dom.contains(target) || button.dom.contains(target)) {
@@ -107,7 +107,8 @@ editor.once('load', () => {
         popover.dom.style.top = `${Math.max(4, top)}px`;
     });
     popover.on('show', () => {
-        // suppress the hover tooltip while open so its arrow doesn't poke out from under the popover
+
+        // hide the hover tooltip while open so its arrow doesn't poke through
         tooltip.detach();
         tooltip.hidden = true;
         updateHint();
@@ -118,8 +119,7 @@ editor.once('load', () => {
         window.removeEventListener('mousedown', onOutside);
     });
 
-    // reconnect automatically if the user was connected before a page reload
-    // (branch switch / checkpoint restore reload the editor and drop the socket)
+    // auto-reconnect if connected before a reload (branch switch / checkpoint restore drop the socket)
     if (editor.call('localStorage:get', 'editor:mcp:connected')) {
         const port = editor.call('localStorage:get', 'editor:mcp:port') || DEFAULT_PORT;
         portField.value = String(port);

--- a/src/editor/mcp/toolbar.ts
+++ b/src/editor/mcp/toolbar.ts
@@ -67,8 +67,13 @@ editor.once('load', () => {
         // the launch page dials the server itself) still needs a relaunch to pick up the port
         const last = editor.call('launch:window');
         hint.text = RELAUNCH_HINT;
-        hint.hidden = !(editor.call('mcp:status') === 'connected' && !editor.call('mcp:relay') &&
-            last && !last.window.closed && !last.mcp);
+        hint.hidden = !(
+            editor.call('mcp:status') === 'connected' &&
+            !editor.call('mcp:relay') &&
+            last &&
+            !last.window.closed &&
+            !last.mcp
+        );
     };
 
     const render = (state: string) => {

--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -97,10 +97,12 @@ editor.once('load', () => {
             query.push('ministats=true');
         }
 
-        // if the editor is connected to an MCP server, hand the port to the launch
-        // page so it connects back as the runtime peer
+        // if the editor is connected to an MCP server, bridge the launch page to it: a
+        // relaying server is reached through this page, older ones need the port in the URL
+        // so the launch page can dial them itself
         const withMcp = editor.call('mcp:status') === 'connected';
-        if (withMcp) {
+        const relayed = withMcp && editor.call('mcp:relay');
+        if (withMcp && !relayed) {
             query.push(`mcp_port=${editor.call('mcp:port')}`);
         }
 
@@ -130,10 +132,19 @@ editor.once('load', () => {
             launcher.opener = null;
             launcher.location = url;
             lastLaunch = { window: launcher, mcp: withMcp };
+            if (relayed) {
+                editor.call('mcp:relay:attach', launcher);
+            }
         }
     };
 
     editor.method('launch:window', () => lastLaunch);
+
+    // MCP launches go through editor/mcp/launch.ts, which records its window here so the
+    // relay and the MCP popover see a single source of truth
+    editor.method('launch:window:track', (win: Window, withMcp: boolean) => {
+        lastLaunch = { window: win, mcp: withMcp };
+    });
 
     buttonLaunch.on('click', (e: MouseEvent) => launchApp({}, e.shiftKey));
 

--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -97,9 +97,7 @@ editor.once('load', () => {
             query.push('ministats=true');
         }
 
-        // if the editor is connected to an MCP server, bridge the launch page to it: a
-        // relaying server is reached through this page, older ones need the port in the URL
-        // so the launch page can dial them itself
+        // bridge the launch page to MCP: through this page, or via a port older servers need
         const withMcp = editor.call('mcp:status') === 'connected';
         const relayed = withMcp && editor.call('mcp:relay');
         if (withMcp && !relayed) {
@@ -140,8 +138,7 @@ editor.once('load', () => {
 
     editor.method('launch:window', () => lastLaunch);
 
-    // MCP launches go through editor/mcp/launch.ts, which records its window here so the
-    // relay and the MCP popover see a single source of truth
+    // MCP launches record their window here too, so there is one source of truth
     editor.method('launch:window:track', (win: Window, withMcp: boolean) => {
         lastLaunch = { window: win, mcp: withMcp };
     });

--- a/src/editor/viewport-controls/viewport-launch.ts
+++ b/src/editor/viewport-controls/viewport-launch.ts
@@ -52,9 +52,8 @@ editor.once('load', () => {
 
     const launchOptions = {};
 
-    // last manually launched window and whether its URL carried mcp_port, so the
-    // MCP popover can hint that an already-open app needs a relaunch to connect
-    let lastLaunch: { window: Window; mcp: boolean } | null = null;
+    // the last launched window, so launch:start can adopt an already-open app
+    let lastLaunch: { window: Window } | null = null;
 
     const launchApp = (
         deviceOptions: {
@@ -97,12 +96,8 @@ editor.once('load', () => {
             query.push('ministats=true');
         }
 
-        // bridge the launch page to MCP: through this page, or via a port older servers need
+        // the editor relays the launch page to MCP, so it opens no socket of its own
         const withMcp = editor.call('mcp:status') === 'connected';
-        const relayed = withMcp && editor.call('mcp:relay');
-        if (withMcp && !relayed) {
-            query.push(`mcp_port=${editor.call('mcp:port')}`);
-        }
 
         const params = new URLSearchParams(location.search);
         if (params.has('use_local_engine')) {
@@ -129,8 +124,8 @@ editor.once('load', () => {
         if (launcher) {
             launcher.opener = null;
             launcher.location = url;
-            lastLaunch = { window: launcher, mcp: withMcp };
-            if (relayed) {
+            lastLaunch = { window: launcher };
+            if (withMcp) {
                 editor.call('mcp:relay:attach', launcher);
             }
         }
@@ -139,8 +134,8 @@ editor.once('load', () => {
     editor.method('launch:window', () => lastLaunch);
 
     // MCP launches record their window here too, so there is one source of truth
-    editor.method('launch:window:track', (win: Window, withMcp: boolean) => {
-        lastLaunch = { window: win, mcp: withMcp };
+    editor.method('launch:window:track', (win: Window) => {
+        lastLaunch = { window: win };
     });
 
     buttonLaunch.on('click', (e: MouseEvent) => launchApp({}, e.shiftKey));

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -253,7 +253,6 @@ mcp.method('runtime:state', (options: any = {}) => {
             (n: any) => typeof n.getGuid === 'function' && n.name && n.name.toLowerCase().includes(q)
         );
     } else {
-
         // no filter: every entity (paginated), minus the root
         entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n !== app.root);
     }
@@ -495,7 +494,6 @@ window.addEventListener('message', async (evt: MessageEvent) => {
         return;
     }
     if (msg.mcp === 'close') {
-
         // the editor severed our opener, so only we can close this window
         window.close();
         return;

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -441,14 +441,17 @@ let editorWindow: Window | null = null;
 let announceTimer: ReturnType<typeof setInterval> | null = null;
 
 const announce = () => {
-    editorWindow?.postMessage({
-        mcp: 'ready',
-        protocolVersion: PROTOCOL_VERSION,
-        projectId: config.project?.id,
-        sceneId: (config as { scene?: { id: number } }).scene?.id,
-        url: location.href,
-        methods: mcp.methodNames.filter(name => name.startsWith('runtime:'))
-    }, EDITOR_ORIGIN);
+    editorWindow?.postMessage(
+        {
+            mcp: 'ready',
+            protocolVersion: PROTOCOL_VERSION,
+            projectId: config.project?.id,
+            sceneId: (config as { scene?: { id: number } }).scene?.id,
+            url: location.href,
+            methods: mcp.methodNames.filter((name) => name.startsWith('runtime:'))
+        },
+        EDITOR_ORIGIN
+    );
 };
 
 window.addEventListener('message', async (evt: MessageEvent) => {

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -2,16 +2,11 @@ import { mcp, PROTOCOL_VERSION } from '@/editor/mcp/connection';
 
 /**
  * MCP "runtime" peer for the launch page (ported from the former Chrome extension's
- * launch content script). Captures console output early, screenshots the *running* app,
- * and answers `runtime:*` calls from the MCP server. Connects automatically when the
- * page is opened with `?mcp_port=<port>` (appended by the editor's `launch:start`
- * MCP method), registering as the 'runtime' peer; otherwise stays idle.
+ * launch content script). Captures console output while an MCP session owns the page,
+ * and answers `runtime:*` calls the editor relays here over postMessage — no socket of its own.
  */
 
 const LOG_CAP = 1000;
-
-// legacy: servers without relay support hand us a port to dial ourselves
-const port = new URLSearchParams(location.search).get('mcp_port');
 
 // re-announce so an editor reload can re-adopt this still-running app
 const ANNOUNCE_INTERVAL = 5000;
@@ -21,16 +16,17 @@ type LogEntry = { time: number; level: string; text: string };
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const logs: LogEntry[] = [];
-const original = {
-    log: console.log.bind(console),
-    info: console.info.bind(console),
-    warn: console.warn.bind(console),
-    error: console.error.bind(console),
-    debug: console.debug.bind(console)
+const LEVELS = ['log', 'info', 'warn', 'error', 'debug'] as const;
+const native = {
+    log: console.log,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug
 };
 
-// use the original console to avoid buffering our own output into runtime:logs
-const log = (msg: string) => original.log(`[MCP] ${msg}`);
+// our own logging always uses the native console, so it never buffers into runtime:logs
+const log = (msg: string) => native.log.call(console, `[MCP] ${msg}`);
 
 const push = (level: string, args: any[], stack?: string) => {
     const text = args
@@ -51,17 +47,42 @@ const push = (level: string, args: any[], stack?: string) => {
     }
 };
 
-(['log', 'info', 'warn', 'error', 'debug'] as const).forEach((level) => {
-    console[level] = (...args: any[]) => {
-        push(level, args);
-        original[level](...args);
-    };
-});
+// wrapping console moves every call site to this file, so we only do it while relaying (the
+// 'offer'); a plain Launch keeps native stack traces. Restored on 'detach'.
+let capturing = false;
+
+const startCapture = () => {
+    if (capturing) {
+        return;
+    }
+    capturing = true;
+    LEVELS.forEach((level) => {
+        console[level] = (...args: any[]) => {
+            push(level, args);
+            native[level].apply(console, args);
+        };
+    });
+};
+
+const stopCapture = () => {
+    if (!capturing) {
+        return;
+    }
+    capturing = false;
+    LEVELS.forEach((level) => {
+        console[level] = native[level];
+    });
+};
+
 window.addEventListener('error', (e) => {
-    push('error', [e.message], e.error?.stack || `${e.filename}:${e.lineno}:${e.colno}`);
+    if (capturing) {
+        push('error', [e.message], e.error?.stack || `${e.filename}:${e.lineno}:${e.colno}`);
+    }
 });
 window.addEventListener('unhandledrejection', (e) => {
-    push('error', [`Unhandled promise rejection: ${e.reason?.message ?? e.reason}`], e.reason?.stack);
+    if (capturing) {
+        push('error', [`Unhandled promise rejection: ${e.reason?.message ?? e.reason}`], e.reason?.stack);
+    }
 });
 
 mcp.method('runtime:ping', () => ({ data: 'pong' }));
@@ -458,9 +479,19 @@ window.addEventListener('message', async (evt: MessageEvent) => {
     const msg = evt.data;
     if (msg.mcp === 'offer') {
         editorWindow = evt.source as Window;
+        startCapture();
         log('Relay attached');
         announce();
         announceTimer ??= setInterval(announce, ANNOUNCE_INTERVAL);
+        return;
+    }
+    if (msg.mcp === 'detach') {
+        if (announceTimer) {
+            clearInterval(announceTimer);
+            announceTimer = null;
+        }
+        editorWindow = null;
+        stopCapture();
         return;
     }
     if (msg.mcp === 'close') {
@@ -474,14 +505,6 @@ window.addEventListener('message', async (evt: MessageEvent) => {
     }
 });
 
-// legacy: dial the server directly when it can't relay (older MCP server versions)
-if (port) {
-    mcp.connect(parseInt(port, 10), 'runtime');
-}
-
 window.addEventListener('beforeunload', () => {
     editorWindow?.postMessage({ mcp: 'gone' }, EDITOR_ORIGIN);
-    if (mcp.status !== 'disconnected') {
-        mcp.disconnect();
-    }
 });

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -1,4 +1,4 @@
-import { mcp } from '@/editor/mcp/connection';
+import { mcp, PROTOCOL_VERSION } from '@/editor/mcp/connection';
 
 /**
  * MCP "runtime" peer for the launch page (ported from the former Chrome extension's
@@ -9,7 +9,13 @@ import { mcp } from '@/editor/mcp/connection';
  */
 
 const LOG_CAP = 1000;
+
+// legacy: servers without relay support hand us a port to dial ourselves
 const port = new URLSearchParams(location.search).get('mcp_port');
+
+// how often we re-announce ourselves to the editor once it has made contact, so an editor
+// reload can re-adopt this still-running app
+const ANNOUNCE_INTERVAL = 5000;
 
 type LogEntry = { time: number; level: string; text: string };
 
@@ -46,20 +52,18 @@ const push = (level: string, args: any[], stack?: string) => {
     }
 };
 
-if (port) {
-    (['log', 'info', 'warn', 'error', 'debug'] as const).forEach((level) => {
-        console[level] = (...args: any[]) => {
-            push(level, args);
-            original[level](...args);
-        };
-    });
-    window.addEventListener('error', (e) => {
-        push('error', [e.message], e.error?.stack || `${e.filename}:${e.lineno}:${e.colno}`);
-    });
-    window.addEventListener('unhandledrejection', (e) => {
-        push('error', [`Unhandled promise rejection: ${e.reason?.message ?? e.reason}`], e.reason?.stack);
-    });
-}
+(['log', 'info', 'warn', 'error', 'debug'] as const).forEach((level) => {
+    console[level] = (...args: any[]) => {
+        push(level, args);
+        original[level](...args);
+    };
+});
+window.addEventListener('error', (e) => {
+    push('error', [e.message], e.error?.stack || `${e.filename}:${e.lineno}:${e.colno}`);
+});
+window.addEventListener('unhandledrejection', (e) => {
+    push('error', [`Unhandled promise rejection: ${e.reason?.message ?? e.reason}`], e.reason?.stack);
+});
 
 mcp.method('runtime:ping', () => ({ data: 'pong' }));
 
@@ -427,13 +431,56 @@ mcp.method('runtime:input', async (payload: any = {}) => {
     return { data: { dispatched } };
 });
 
-// connect automatically when opened via the editor's launch:start (which appends
-// mcp_port); otherwise stay idle
+// Relay: the editor holds the only socket and forwards `runtime:*` calls here over
+// postMessage, so this page needs no local network access of its own. First contact has to
+// come from the editor — our opener is severed — after which we keep announcing ourselves so
+// a reloaded editor can re-adopt us.
+const EDITOR_ORIGIN = new URL(config.url.home).origin;
+
+let editorWindow: Window | null = null;
+let announceTimer: ReturnType<typeof setInterval> | null = null;
+
+const announce = () => {
+    editorWindow?.postMessage({
+        mcp: 'ready',
+        protocolVersion: PROTOCOL_VERSION,
+        projectId: config.project?.id,
+        sceneId: (config as { scene?: { id: number } }).scene?.id,
+        url: location.href,
+        methods: mcp.methodNames.filter(name => name.startsWith('runtime:'))
+    }, EDITOR_ORIGIN);
+};
+
+window.addEventListener('message', async (evt: MessageEvent) => {
+    if (evt.origin !== EDITOR_ORIGIN || !evt.data || !evt.source) {
+        return;
+    }
+    const msg = evt.data;
+    if (msg.mcp === 'offer') {
+        editorWindow = evt.source as Window;
+        log('Relay attached');
+        announce();
+        announceTimer ??= setInterval(announce, ANNOUNCE_INTERVAL);
+        return;
+    }
+    if (msg.mcp === 'close') {
+        // only this page can reliably close itself: the editor severed our opener
+        window.close();
+        return;
+    }
+    if (msg.mcp === 'call') {
+        const res = await mcp.call(msg.name, ...(msg.args ?? []));
+        (evt.source as Window).postMessage({ mcp: 'res', id: msg.id, res }, EDITOR_ORIGIN);
+    }
+});
+
+// legacy: dial the server directly when it can't relay (older MCP server versions)
 if (port) {
     mcp.connect(parseInt(port, 10), 'runtime');
 }
 
 window.addEventListener('beforeunload', () => {
+    editorWindow?.postMessage({ mcp: 'gone' }, EDITOR_ORIGIN);
     if (mcp.status !== 'disconnected') {
         mcp.disconnect();
     }

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -25,7 +25,7 @@ const native = {
     debug: console.debug
 };
 
-// our own logging always uses the native console, so it never buffers into runtime:logs
+// our own logging uses the native console, so it never buffers into runtime:logs
 const log = (msg: string) => native.log.call(console, `[MCP] ${msg}`);
 
 const push = (level: string, args: any[], stack?: string) => {
@@ -47,8 +47,8 @@ const push = (level: string, args: any[], stack?: string) => {
     }
 };
 
-// wrapping console moves every call site to this file, so we only do it while relaying (the
-// 'offer'); a plain Launch keeps native stack traces. Restored on 'detach'.
+// wrapping console reassigns every call site here, so only while relaying (offer → detach);
+// a plain Launch keeps native stack traces
 let capturing = false;
 
 const startCapture = () => {
@@ -253,7 +253,8 @@ mcp.method('runtime:state', (options: any = {}) => {
             (n: any) => typeof n.getGuid === 'function' && n.name && n.name.toLowerCase().includes(q)
         );
     } else {
-        // no filter: return every entity (paginated). Excludes the root.
+
+        // no filter: every entity (paginated), minus the root
         entities = app.root.find((n: any) => typeof n.getGuid === 'function' && n !== app.root);
     }
 
@@ -339,8 +340,7 @@ const dispatchKey = (kind: string, info: { key: string; code: string; keyCode: n
         view: window
     });
 
-    // keyCode/which are read-only and not settable via the constructor, but
-    // PlayCanvas' keyboard handler reads them — so back them with getters
+    // keyCode/which are read-only in the ctor but PlayCanvas reads them, so back them with getters
     Object.defineProperty(e, 'keyCode', { get: () => info.keyCode });
     Object.defineProperty(e, 'which', { get: () => info.keyCode });
     window.dispatchEvent(e);
@@ -451,8 +451,8 @@ mcp.method('runtime:input', async (payload: any = {}) => {
     return { data: { dispatched } };
 });
 
-// The editor forwards `runtime:*` here over postMessage, so this page needs no local network
-// access. It makes first contact (our opener is severed); we then keep announcing ourselves.
+// the editor relays `runtime:*` here over postMessage; it makes first contact (opener severed),
+// then we keep announcing ourselves
 const EDITOR_ORIGIN = new URL(config.url.home).origin;
 
 let editorWindow: Window | null = null;
@@ -495,6 +495,7 @@ window.addEventListener('message', async (evt: MessageEvent) => {
         return;
     }
     if (msg.mcp === 'close') {
+
         // the editor severed our opener, so only we can close this window
         window.close();
         return;

--- a/src/launch/mcp/runtime.ts
+++ b/src/launch/mcp/runtime.ts
@@ -13,8 +13,7 @@ const LOG_CAP = 1000;
 // legacy: servers without relay support hand us a port to dial ourselves
 const port = new URLSearchParams(location.search).get('mcp_port');
 
-// how often we re-announce ourselves to the editor once it has made contact, so an editor
-// reload can re-adopt this still-running app
+// re-announce so an editor reload can re-adopt this still-running app
 const ANNOUNCE_INTERVAL = 5000;
 
 type LogEntry = { time: number; level: string; text: string };
@@ -431,10 +430,8 @@ mcp.method('runtime:input', async (payload: any = {}) => {
     return { data: { dispatched } };
 });
 
-// Relay: the editor holds the only socket and forwards `runtime:*` calls here over
-// postMessage, so this page needs no local network access of its own. First contact has to
-// come from the editor — our opener is severed — after which we keep announcing ourselves so
-// a reloaded editor can re-adopt us.
+// The editor forwards `runtime:*` here over postMessage, so this page needs no local network
+// access. It makes first contact (our opener is severed); we then keep announcing ourselves.
 const EDITOR_ORIGIN = new URL(config.url.home).origin;
 
 let editorWindow: Window | null = null;
@@ -467,7 +464,7 @@ window.addEventListener('message', async (evt: MessageEvent) => {
         return;
     }
     if (msg.mcp === 'close') {
-        // only this page can reliably close itself: the editor severed our opener
+        // the editor severed our opener, so only we can close this window
         window.close();
         return;
     }


### PR DESCRIPTION
### What's Changed

Chromium gates public→loopback behind a per-origin permission (Chrome 142+, websockets from 147). The launch page is a different origin, so runtime tools needed a second grant — requested silently while a popup loaded. The Editor now holds the only socket and relays `runtime:*` to the launch window over `postMessage`.

- `mcp/relay.ts` (new) — offers a channel to a launch window and tells the server what it can reach. The Editor makes first contact (the window's opener is severed); the page then keeps announcing itself, so a reloaded Editor re-adopts a still-running app.
- `mcp/launch.ts` — no `mcp_port` when relaying; adopts a running app when no options are requested; one verified close path for relaunch and stop, since a window whose opener we severed cannot be closed from the Editor.
- `launch/mcp/runtime.ts` — answers relayed calls, closes on request, buffers console output from the first frame. Still dials the server directly when handed a port.
- `mcp/connection.ts`, `mcp/toolbar.ts` — read the server's greeting; report when the browser is blocking the connection instead of sitting on **Connecting**.
- `viewport-launch.ts` — the Launch button hands its window to the relay.
- MCP launches carry the `use_local_frontend` / `use_local_engine` overrides, so a local build launches the local launch page.

Needs playcanvas/editor-mcp-server#102 for relay mode; both sides fall back to the old path.

### Smoke test

1. Open a project, select **MCP**, connect. Expected: **Connected**, or a popover hint to allow **Apps on device** if the browser blocks it.
2. Ask an assistant to start a Launch instance, screenshot it and read its logs. Expected: URL has no `mcp_port`; both return, logs including warnings from before the bridge attached.
3. Ask again while that app runs. Expected: it attaches, no second window.
4. Ask with mini stats enabled. Expected: the old window closes, the new one shows the overlay.
5. Reload the Editor tab, reconnect, ask for a screenshot. Expected: the running app answers, no relaunch.
6. Press the Editor's **Launch** button while connected, ask for a screenshot, then stop the instance. Expected: screenshot works; the window closes.
7. Check the launch origin in Chrome site settings. Expected: no local access grant, yet all of the above worked.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
