### PR TITLE
fix: re-render viewport when gizmo coordinate system changes

### DIFF
--- a/src/editor/viewport/gizmo/gizmo.ts
+++ b/src/editor/viewport/gizmo/gizmo.ts
@@ -35,6 +35,7 @@ editor.once('load', () => {
         coordSystem = system;
 
         editor.emit('gizmo:coordSystem', system);
+        editor.call('viewport:render');
     });
 
     const checkSnap = function () {


### PR DESCRIPTION
Fixes #2205

### What's Changed

- Request a viewport frame after the gizmo coordinate system changes.
- Update World/Local gizmo orientation immediately instead of waiting for hover or reselection.
- Preserve the existing no-op behavior when the coordinate system is unchanged.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- [x] `npm test` — 178 passing
- [x] `npm run test:api` — 204 passing
- [x] `npm run lint` — 0 errors
- [x] `npx eslint src/editor/viewport/gizmo/gizmo.ts`
- [x] `npx prettier --check src/editor/viewport/gizmo/gizmo.ts`
- [x] `npm run build`
- [x] Manual production/local-frontend comparison with a rotated Camera: production required reselection, while the patched build updated Translate and Rotate gizmos immediately in both World→Local and Local→World directions; 10 repeated toggles produced no console errors.