### PR TITLE
fix: prevent simple tooltips from intercepting pointer events

### DIFF
--- a/sass/editor/_editor-tooltip.scss
+++ b/sass/editor/_editor-tooltip.scss
@@ -9,6 +9,7 @@
     position: static;
     max-width: 300px;
     flex-shrink: 0;
+    pointer-events: none;
 
     > .pcui-label {
         white-space: normal;


### PR DESCRIPTION
Partially addresses #2225 (item 2)

### What's Changed

- Added `pointer-events: none` to `.tooltip-simple` in SCSS.
- Prevents simple tooltips from intercepting pointer events and blocking UI interactions underneath.
- Scoped strictly to `.tooltip-simple` so interactive tooltips (`.tooltip-reference`, `.tooltip-override`) containing buttons remain clickable.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)