### PR TITLE
fix: derive material reflectivity slider bounds from the server schema

### DIFF
--- a/src/editor-api/schema.ts
+++ b/src/editor-api/schema.ts
@@ -129,6 +129,15 @@ class Schema {
         return { value: hasDefault ? field.default : undefined, hasDefault };
     }
 
+    getBounds(field: unknown) {
+        const value = jsonValue(field);
+        if (!isObject(value)) return { min: undefined, max: undefined };
+        return {
+            min: typeof value.minimum === 'number' ? value.minimum : undefined,
+            max: typeof value.maximum === 'number' ? value.maximum : undefined
+        };
+    }
+
     getScope(field: unknown) {
         if (isObject(field) && typeof field['x-scope'] === 'string') return field['x-scope'];
         const value = jsonValue(field);

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1061,9 +1061,7 @@ const ENVIRONMENT_ATTRIBUTES: (Attribute | Divider)[] = [
         type: 'slider',
         args: {
             precision: 3,
-            step: 0.01,
-            min: 0,
-            sliderMax: 8
+            step: 0.01
         },
         reference: 'asset:material:reflectivity'
     },
@@ -1481,7 +1479,13 @@ const DOM = (parent) => [
                 envInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: ENVIRONMENT_ATTRIBUTES
+                    attributes: ENVIRONMENT_ATTRIBUTES.map((attr) => {
+                        if (!('path' in attr) || attr.path !== 'data.reflectivity') {
+                            return attr;
+                        }
+                        const { min, max } = editor.call('schema:asset:getDataBounds', 'material', attr.path);
+                        return { ...attr, args: { ...attr.args, min, max, sliderMin: min, sliderMax: max } };
+                    })
                 })
             }
         ]

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -1191,6 +1191,35 @@ const OTHER_ATTRIBUTES: (Attribute | Divider)[] = [
     }
 ];
 
+/**
+ * Injects server-schema numeric bounds (min/max) onto material `data.*` controls so the
+ * schema catalog is the single source of truth for ranges. Controls the schema does not
+ * bound are returned unchanged, keeping any editor-supplied fallback range.
+ *
+ * @param attributes - The attribute list to augment.
+ * @returns The attribute list with schema bounds applied.
+ */
+const withSchemaBounds = (attributes: (Attribute | Divider)[]) =>
+    attributes.map((attr) => {
+        if (!('path' in attr) || typeof attr.path !== 'string' || !attr.path.startsWith('data.')) {
+            return attr;
+        }
+        const { min, max } = editor.call('schema:asset:getDataBounds', 'material', attr.path);
+        if (min === undefined && max === undefined) {
+            return attr;
+        }
+        const args = { ...attr.args };
+        if (min !== undefined) {
+            args.min = min;
+            args.sliderMin = min;
+        }
+        if (max !== undefined) {
+            args.max = max;
+            args.sliderMax = max;
+        }
+        return { ...attr, args };
+    });
+
 const DOM = (parent) => [
     {
         root: {
@@ -1203,7 +1232,7 @@ const DOM = (parent) => [
                 materialInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: MATERIAL_ATTRIBUTES
+                    attributes: withSchemaBounds(MATERIAL_ATTRIBUTES)
                 })
             }
         ]
@@ -1221,7 +1250,7 @@ const DOM = (parent) => [
                 offsetTilingInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: TEXTURE_TRANFORM_ATTRIBUTES
+                    attributes: withSchemaBounds(TEXTURE_TRANFORM_ATTRIBUTES)
                 })
             }
         ]
@@ -1239,7 +1268,7 @@ const DOM = (parent) => [
                 ambientInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: AMBIENT_ATTRIBUTES
+                    attributes: withSchemaBounds(AMBIENT_ATTRIBUTES)
                 })
             }
         ]
@@ -1257,7 +1286,7 @@ const DOM = (parent) => [
                 diffuseInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: DIFFUSE_ATTRIBUTES
+                    attributes: withSchemaBounds(DIFFUSE_ATTRIBUTES)
                 })
             }
         ]
@@ -1275,28 +1304,28 @@ const DOM = (parent) => [
                 specularInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: SPECULAR_ATTRIBUTES
+                    attributes: withSchemaBounds(SPECULAR_ATTRIBUTES)
                 })
             },
             {
                 metalnessWorkflowInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: METALNESS_WORKFLOW_ATTRIBUTES
+                    attributes: withSchemaBounds(METALNESS_WORKFLOW_ATTRIBUTES)
                 })
             },
             {
                 specularWorkflowInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: SPECULAR_WORKFLOW_ATTRIBUTES
+                    attributes: withSchemaBounds(SPECULAR_WORKFLOW_ATTRIBUTES)
                 })
             },
             {
                 glossInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: GLOSS_ATTRIBUTES
+                    attributes: withSchemaBounds(GLOSS_ATTRIBUTES)
                 })
             }
         ]
@@ -1314,7 +1343,7 @@ const DOM = (parent) => [
                 emissiveInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: EMISSIVE_ATTRIBUTES
+                    attributes: withSchemaBounds(EMISSIVE_ATTRIBUTES)
                 })
             }
         ]
@@ -1332,7 +1361,7 @@ const DOM = (parent) => [
                 opacityInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: OPACITY_ATTRIBUTES
+                    attributes: withSchemaBounds(OPACITY_ATTRIBUTES)
                 })
             }
         ]
@@ -1350,7 +1379,7 @@ const DOM = (parent) => [
                 normalsInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: NORMALS_ATTRIBUTES
+                    attributes: withSchemaBounds(NORMALS_ATTRIBUTES)
                 })
             }
         ]
@@ -1368,7 +1397,7 @@ const DOM = (parent) => [
                 parallaxInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: PARALLAX_ATTRIBUTES
+                    attributes: withSchemaBounds(PARALLAX_ATTRIBUTES)
                 })
             }
         ]
@@ -1386,28 +1415,28 @@ const DOM = (parent) => [
                 clearCoatFactorInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: CLEARCOAT_FACTOR_ATTRIBUTES
+                    attributes: withSchemaBounds(CLEARCOAT_FACTOR_ATTRIBUTES)
                 })
             },
             {
                 clearCoatInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: CLEARCOAT_ATTRIBUTES
+                    attributes: withSchemaBounds(CLEARCOAT_ATTRIBUTES)
                 })
             },
             {
                 clearCoatGlossInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: CLEARCOAT_GLOSS_ATTRIBUTES
+                    attributes: withSchemaBounds(CLEARCOAT_GLOSS_ATTRIBUTES)
                 })
             },
             {
                 clearCoatNormalInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: CLEARCOAT_NORMAL_ATTRIBUTES
+                    attributes: withSchemaBounds(CLEARCOAT_NORMAL_ATTRIBUTES)
                 })
             }
         ]
@@ -1425,7 +1454,7 @@ const DOM = (parent) => [
                 sheenInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: SHEEN_ATTRIBUTES
+                    attributes: withSchemaBounds(SHEEN_ATTRIBUTES)
                 })
             }
         ]
@@ -1443,7 +1472,7 @@ const DOM = (parent) => [
                 refractionInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: REFRACTION_ATTRIBUTES
+                    attributes: withSchemaBounds(REFRACTION_ATTRIBUTES)
                 })
             }
         ]
@@ -1461,7 +1490,7 @@ const DOM = (parent) => [
                 iridescenceInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: IRIDESCENCE_ATTRIBUTES
+                    attributes: withSchemaBounds(IRIDESCENCE_ATTRIBUTES)
                 })
             }
         ]
@@ -1479,13 +1508,7 @@ const DOM = (parent) => [
                 envInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: ENVIRONMENT_ATTRIBUTES.map((attr) => {
-                        if (!('path' in attr) || attr.path !== 'data.reflectivity') {
-                            return attr;
-                        }
-                        const { min, max } = editor.call('schema:asset:getDataBounds', 'material', attr.path);
-                        return { ...attr, args: { ...attr.args, min, max, sliderMin: min, sliderMax: max } };
-                    })
+                    attributes: withSchemaBounds(ENVIRONMENT_ATTRIBUTES)
                 })
             }
         ]
@@ -1503,7 +1526,7 @@ const DOM = (parent) => [
                 lightmapInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: LIGHTMAP_ATTRIBUTES
+                    attributes: withSchemaBounds(LIGHTMAP_ATTRIBUTES)
                 })
             }
         ]
@@ -1521,7 +1544,7 @@ const DOM = (parent) => [
                 otherInspector: new AttributesInspector({
                     assets: parent._args.assets,
                     history: parent._args.history,
-                    attributes: OTHER_ATTRIBUTES
+                    attributes: withSchemaBounds(OTHER_ATTRIBUTES)
                 })
             }
         ]

--- a/src/editor/schema/schema-asset.ts
+++ b/src/editor/schema/schema-asset.ts
@@ -30,6 +30,20 @@ editor.once('load', () => {
     });
 
     /**
+     * Gets the numeric bounds ({ min, max }) of a path in the asset data schema for the specified asset type.
+     *
+     * @param assetType - The type of asset (e.g. 'material', 'texture')
+     * @param path - The path in the schema separated by dots (e.g. 'data.reflectivity')
+     * @returns The resolved bounds; min/max are undefined when the field is unbounded
+     */
+    editor.method('schema:asset:getDataBounds', (assetType: string, path: string) => {
+        const data = schema.getAssetData(assetType);
+        const root = data ?? schema.getDocument('asset');
+        const resolved = schema.resolvePath(root, data ? path.substring(5) : path);
+        return schema.getBounds(resolved?.field);
+    });
+
+    /**
      * Lists all asset types defined in the schema
      *
      * @returns Array of asset type names

--- a/test/editor-api/api/test-schema.js
+++ b/test/editor-api/api/test-schema.js
@@ -240,6 +240,43 @@ describe('api.Schema tests', function () {
         expect(Object.keys(schema.getFields(editorField))).to.deep.equal(['gizmoSize']);
     });
 
+    it('reads numeric min/max bounds, including through a nullability wrapper', function () {
+        const schema = new api.Schema({
+            version: 1,
+            documents: {
+                asset: { type: 'object', properties: {} },
+                scene: { type: 'object', properties: {} },
+                settings: { type: 'object', properties: {} }
+            },
+            assetData: {
+                material: {
+                    type: 'object',
+                    properties: {
+                        reflectivity: { type: 'number', minimum: 0, maximum: 8, default: 1 },
+                        alphaDither: {
+                            default: null,
+                            anyOf: [{ type: 'number', minimum: 0, maximum: 1 }, { type: 'null' }]
+                        },
+                        name: { type: 'string' }
+                    }
+                }
+            }
+        });
+
+        expect(schema.getBounds(schema.assets.resolvePath('material', 'reflectivity').field)).to.deep.equal({
+            min: 0,
+            max: 8
+        });
+        expect(schema.getBounds(schema.assets.resolvePath('material', 'alphaDither').field)).to.deep.equal({
+            min: 0,
+            max: 1
+        });
+        expect(schema.getBounds(schema.assets.resolvePath('material', 'name').field)).to.deep.equal({
+            min: undefined,
+            max: undefined
+        });
+    });
+
     it('getAssetTypes sees through a nullability wrapper', function () {
         const schema = new api.Schema({
             version: 1,


### PR DESCRIPTION
Fixes #2228

### What's Changed

Makes the server-provided schema catalog the single source of truth for the material inspector's numeric ranges, instead of hardcoding them in the client.

- Add `Schema.getBounds(field)` — reads JSON-Schema `minimum`/`maximum` off a resolved field, seeing through a nullable `anyOf` wrapper.
- Add a `schema:asset:getDataBounds(assetType, path)` method, mirroring `schema:asset:getDataType`.
- Add a `withSchemaBounds()` helper in the material inspector that injects `min`/`max`/`sliderMin`/`sliderMax` from the schema onto every `data.*` control at construction time. It's applied to **all** material inspector sections, not just Reflectivity. Controls the schema doesn't bound keep their existing editor range.
- Unit test for `getBounds` (flat numeric field, nullable-`anyOf` unwrap, unbounded field).

Effect: every bounded material slider/number now reflects the schema's published range. Where the client range disagreed with the schema, the schema wins (e.g. AO Intensity, which the client had capped too high). Fields the schema doesn't bound are unchanged.

### Manual smoke test

1. Open a material asset and expand each section. **Expected:** each numeric slider/field's range matches the schema the server publishes for its `data.*` path.
2. Confirm a control the schema doesn't bound (e.g. a texture tiling/offset vector) is unaffected.

### Checks

- [ ] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
