### PR TITLE
fix: unpack legacy fonts cloned from the store

### DIFF
--- a/src/editor-api/rest/store.ts
+++ b/src/editor-api/rest/store.ts
@@ -139,8 +139,7 @@ export const storeClone = (storeId: number | string, data: StoreCloneData) => {
     return Ajax.post({
         url: `${api.apiUrl}/store/${storeId}/clone`,
         auth: true,
-        data,
-        notJson: true
+        data
     });
 };
 

--- a/src/editor/assets/assets-font-import.ts
+++ b/src/editor/assets/assets-font-import.ts
@@ -459,6 +459,8 @@ editor.once('load', () => {
             file: new Blob(['{}'], { type: 'application/json' }),
             filename: `${base}.json`,
             source_asset_id: `${sourceId}`,
+            // keep the placeholder on the referenced-font path until refs are generated
+            data: { jsonAsset: null, textureAssets: [] },
             parent,
             noConvert: true,
             preload: true

--- a/src/editor/assets/assets-font-import.ts
+++ b/src/editor/assets/assets-font-import.ts
@@ -77,6 +77,23 @@ editor.once('load', () => {
             });
         });
 
+    const waitForFile = (asset: any) =>
+        new Promise<void>((resolve, reject) => {
+            if (asset.get('file.url')) {
+                resolve();
+                return;
+            }
+            const timer = setTimeout(() => {
+                evt.unbind();
+                reject(new Error(`asset ${asset.get('id')} file never arrived`));
+            }, ASSET_ADD_TIMEOUT);
+            const evt = asset.once('file.url:set', () => {
+                clearTimeout(timer);
+                evt.unbind();
+                resolve();
+            });
+        });
+
     const updateFile = (asset: any, file: Blob, filename: string, noConvert: boolean) =>
         new Promise<void>((resolve, reject) => {
             editor.call(
@@ -410,6 +427,51 @@ editor.once('load', () => {
     editor.method('fonts:reprocess', (font: any, chars: string, invert: boolean) => {
         return reprocess(font, chars, invert).catch((err) => {
             editor.call('status:error', `Font reprocess failed: ${err?.message ?? err}`);
+        });
+    });
+
+    // unpack a raw font cloned from a legacy store item without duplicating its source asset
+    const unpackFont = async (sourceId: number) => {
+        const source = await getObserver(sourceId);
+        await waitForFile(source);
+
+        const target = editor.call(
+            'assets:find',
+            (asset: any) =>
+                asset.get('type') === 'font' &&
+                !asset.get('source') &&
+                `${asset.get('source_asset_id')}` === `${sourceId}`
+        )[0];
+        if (target) {
+            if (!isReferencedFont(target)) {
+                await reprocess(target, DEFAULT_CHARS, false);
+            }
+            return target;
+        }
+
+        const filename = source.get('name');
+        const base = filename.replace(/\.[^.]+$/, '');
+        const path = source.get('path') || [];
+        const parent = path.length ? await getObserver(path[path.length - 1]) : null;
+        const fontId = await createAsset({
+            name: filename,
+            type: 'font',
+            file: new Blob(['{}'], { type: 'application/json' }),
+            filename: `${base}.json`,
+            source_asset_id: `${sourceId}`,
+            parent,
+            noConvert: true,
+            preload: true
+        });
+        const font = await getObserver(fontId);
+        await reprocess(font, DEFAULT_CHARS, false);
+        editor.call('selector:set', 'asset', [font]);
+        return font;
+    };
+
+    editor.method('fonts:unpack', (sourceId: number) => {
+        return unpackFont(sourceId).catch((err) => {
+            editor.call('status:error', `Font unpack failed: ${err?.message ?? err}`);
         });
     });
 

--- a/src/editor/store/store.ts
+++ b/src/editor/store/store.ts
@@ -1,3 +1,7 @@
+type StoreCloneResponse = {
+    fontSources?: number[];
+};
+
 editor.once('load', () => {
     // Loads all the store's items
     editor.method('store:list', (search, skip, limit, selectedFilter, tags, sortPolicy, sortDescending) => {
@@ -111,7 +115,11 @@ editor.once('load', () => {
                     license: license
                 })
                 .on('load', (_status: number, response: unknown) => {
-                    resolve(response);
+                    const data = response as StoreCloneResponse;
+                    Promise.all((data.fontSources || []).map((id) => editor.call('fonts:unpack', id))).then(
+                        () => resolve(response),
+                        reject
+                    );
                 })
                 .on('error', (_status: number, error: unknown) => {
                     reject(error);


### PR DESCRIPTION
Fixes #

### What's Changed

- Parse the store-clone response and route legacy source-only fonts through the existing client-side font unpacker.
- Preserve the raw font source while creating the referenced runtime font, descriptor, and atlas assets.
- Skip duplicate unpacking when referenced runtime assets already exist.

### Checks

- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
- [x] Targeted font unit tests
- [x] Build
- [x] Targeted ESLint and Prettier checks

### Manual smoke test

1. Clone a legacy source-only font store item into a project.
   Expected: the raw font remains available and the runtime font plus descriptor and atlas assets are created.
2. Use the generated runtime font in a text element.
   Expected: the font loads and renders without an unpack error.