### PR TITLE
feat: add Editor 2.22 fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "monaco-editor": "0.47.0",
                 "monaco-themes": "0.4.8",
                 "ot-text": "github:playcanvas/ot-text",
-                "playcanvas": "2.22.0",
+                "playcanvas": "2.22.1",
                 "postcss": "8.5.23",
                 "prettier": "3.9.4",
                 "rollup": "4.59.0",
@@ -9636,9 +9636,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.22.0",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.22.0.tgz",
-            "integrity": "sha512-EuapzvDRVV6pO1xseTynt/1Z5dWDCEUa2KR2o6ExYrDnfRNz83kNT2ieWyQoJB6THO7GLBZbRB0EP/RZrsfUHg==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.22.1.tgz",
+            "integrity": "sha512-WvheUymrS3gBxXy9JH7TE/YFVp4ZbEgygCjqwDbOMhePazd54jkP+yo40v2vEVLJISb3IZIKOJdVKDx4SUO2og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "monaco-editor": "0.47.0",
                 "monaco-themes": "0.4.8",
                 "ot-text": "github:playcanvas/ot-text",
-                "playcanvas": "2.21.4",
+                "playcanvas": "2.22.0",
                 "postcss": "8.5.23",
                 "prettier": "3.9.4",
                 "rollup": "4.59.0",
@@ -9636,9 +9636,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.21.4",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.21.4.tgz",
-            "integrity": "sha512-L4UGy3z/YT8AaNBEY4ITsZup548UFMabF7loh0YQ0DRwQLdjIW8grmZPoQ1+B83+N6sejRS0/XlXV2Vfb11+fw==",
+            "version": "2.22.0",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.22.0.tgz",
+            "integrity": "sha512-EuapzvDRVV6pO1xseTynt/1Z5dWDCEUa2KR2o6ExYrDnfRNz83kNT2ieWyQoJB6THO7GLBZbRB0EP/RZrsfUHg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.22.0",
+        "playcanvas": "2.22.1",
         "postcss": "8.5.23",
         "prettier": "3.9.4",
         "rollup": "4.59.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "monaco-editor": "0.47.0",
         "monaco-themes": "0.4.8",
         "ot-text": "github:playcanvas/ot-text",
-        "playcanvas": "2.21.4",
+        "playcanvas": "2.22.0",
         "postcss": "8.5.23",
         "prettier": "3.9.4",
         "rollup": "4.59.0",

--- a/sass/editor/_editor-attributes-panel.scss
+++ b/sass/editor/_editor-attributes-panel.scss
@@ -2050,6 +2050,7 @@
 }
 
 .collision-component-inspector,
+.joint-component-inspector,
 .rigidbody-component-inspector {
     .library-warning {
         background-color: $bcg-darkest;

--- a/sass/editor/_editor-common.scss
+++ b/sass/editor/_editor-common.scss
@@ -55,6 +55,7 @@ $component-icons: (
     'light': '\E194',
     'model': '\E188',
     'particlesystem': '\E199',
+    'joint': '\E426',
     'rigidbody': '\E189',
     'render': '\E190',
     'screen': '\E403',

--- a/src/common/pcui/element/element-shadow-cascade-mask-input.ts
+++ b/src/common/pcui/element/element-shadow-cascade-mask-input.ts
@@ -1,0 +1,99 @@
+import type { ElementArgs } from '@playcanvas/pcui';
+import { BooleanInput, Container, Element, Label } from '@playcanvas/pcui';
+import { SHADOW_CASCADE_0, SHADOW_CASCADE_1, SHADOW_CASCADE_2, SHADOW_CASCADE_3, SHADOW_CASCADE_ALL } from 'playcanvas';
+
+const CASCADES = [SHADOW_CASCADE_0, SHADOW_CASCADE_1, SHADOW_CASCADE_2, SHADOW_CASCADE_3];
+
+type ShadowCascadeMaskInputArgs = ElementArgs & {
+    renderChanges?: boolean;
+};
+
+class ShadowCascadeMaskInput extends Container {
+    private _inputs: BooleanInput[];
+
+    private _values: number[];
+
+    private _updating = false;
+
+    private _renderChanges = false;
+
+    constructor(args: ShadowCascadeMaskInputArgs = {}) {
+        super({
+            ...args,
+            flex: true,
+            flexDirection: 'row',
+            alignItems: 'center'
+        });
+
+        this._values = [SHADOW_CASCADE_ALL];
+        this._renderChanges = args.renderChanges ?? false;
+        this._inputs = CASCADES.map((bit, i) => {
+            const input = new BooleanInput();
+            const group = new Container({ flex: true, flexDirection: 'row', alignItems: 'center' });
+            group.append(new Label({ text: `${i}` }));
+            group.append(input);
+            this.append(group);
+
+            input.on('change', (value: boolean | null) => {
+                if (this._updating || value === null) {
+                    return;
+                }
+
+                const values = this._values.map((mask) => (value ? mask | bit : mask & ~bit));
+                this._setValues(values);
+                if (this._renderChanges) {
+                    this.flash();
+                }
+                this.emit('change', values[0]);
+                this._binding?.setValues(values);
+            });
+
+            return input;
+        });
+
+        this.value = SHADOW_CASCADE_ALL;
+    }
+
+    private _setValues(values: number[]) {
+        this._values = values;
+        this._updating = true;
+        this._inputs.forEach((input, i) => {
+            input.values = values.map((mask) => !!(mask & CASCADES[i]));
+        });
+        this._updating = false;
+    }
+
+    set value(value: number | null) {
+        const mask = value ?? SHADOW_CASCADE_ALL;
+        const changed = this._values.length !== 1 || this._values[0] !== mask;
+        this._setValues([mask]);
+        if (changed) {
+            this.emit('change', mask);
+            this._binding?.setValue(mask);
+        }
+    }
+
+    get value() {
+        return this._values[0];
+    }
+
+    set values(values: (number | null)[]) {
+        this._setValues(values.map((value) => value ?? SHADOW_CASCADE_ALL));
+    }
+
+    get values() {
+        return this._values.slice();
+    }
+
+    set renderChanges(value: boolean) {
+        this._renderChanges = value;
+    }
+
+    get renderChanges() {
+        return this._renderChanges;
+    }
+}
+
+Element.register('shadow-cascade-mask', ShadowCascadeMaskInput, { renderChanges: true });
+
+export { ShadowCascadeMaskInput };

--- a/src/common/pcui/element/element-shadow-cascade-mask-input.ts
+++ b/src/common/pcui/element/element-shadow-cascade-mask-input.ts
@@ -1,15 +1,23 @@
 import type { ElementArgs } from '@playcanvas/pcui';
-import { BooleanInput, Container, Element, Label } from '@playcanvas/pcui';
+import { Container, Element, SelectInput } from '@playcanvas/pcui';
 import { SHADOW_CASCADE_0, SHADOW_CASCADE_1, SHADOW_CASCADE_2, SHADOW_CASCADE_3, SHADOW_CASCADE_ALL } from 'playcanvas';
 
 const CASCADES = [SHADOW_CASCADE_0, SHADOW_CASCADE_1, SHADOW_CASCADE_2, SHADOW_CASCADE_3];
+const CASCADE_MASK = CASCADES.reduce((mask, bit) => mask | bit, 0);
+const CASCADE_OPTIONS = CASCADES.map((v, i) => ({ v, t: `Cascade ${i}` }));
 
 type ShadowCascadeMaskInputArgs = ElementArgs & {
     renderChanges?: boolean;
 };
 
+class CascadeSelectInput extends SelectInput {
+    get selections() {
+        return (this._values ?? [this.value]).map((values) => values?.slice() ?? []);
+    }
+}
+
 class ShadowCascadeMaskInput extends Container {
-    private _inputs: BooleanInput[];
+    private _input: CascadeSelectInput;
 
     private _values: number[];
 
@@ -18,37 +26,33 @@ class ShadowCascadeMaskInput extends Container {
     private _renderChanges = false;
 
     constructor(args: ShadowCascadeMaskInputArgs = {}) {
-        super({
-            ...args,
-            flex: true,
-            flexDirection: 'row',
-            alignItems: 'center'
-        });
+        super(args);
 
         this._values = [SHADOW_CASCADE_ALL];
         this._renderChanges = args.renderChanges ?? false;
-        this._inputs = CASCADES.map((bit, i) => {
-            const input = new BooleanInput();
-            const group = new Container({ flex: true, flexDirection: 'row', alignItems: 'center' });
-            group.append(new Label({ text: `${i}` }));
-            group.append(input);
-            this.append(group);
+        this._input = new CascadeSelectInput({
+            multiSelect: true,
+            options: CASCADE_OPTIONS,
+            type: 'number'
+        });
+        this._input.style.width = '100%';
+        this.append(this._input);
 
-            input.on('change', (value: boolean | null) => {
-                if (this._updating || value === null) {
-                    return;
-                }
+        this._input.on('change', () => {
+            if (this._updating) {
+                return;
+            }
 
-                const values = this._values.map((mask) => (value ? mask | bit : mask & ~bit));
-                this._setValues(values);
-                if (this._renderChanges) {
-                    this.flash();
-                }
-                this.emit('change', values[0]);
-                this._binding?.setValues(values);
-            });
-
-            return input;
+            const selections = this._input.selections;
+            const values = this._values.map((mask, i) =>
+                (selections[i] ?? selections[0]).reduce((value, bit) => value | bit, mask & ~CASCADE_MASK)
+            );
+            this._setValues(values);
+            if (this._renderChanges) {
+                this.flash();
+            }
+            this.emit('change', values[0]);
+            this._binding?.setValues(values);
         });
 
         this.value = SHADOW_CASCADE_ALL;
@@ -57,9 +61,7 @@ class ShadowCascadeMaskInput extends Container {
     private _setValues(values: number[]) {
         this._values = values;
         this._updating = true;
-        this._inputs.forEach((input, i) => {
-            input.values = values.map((mask) => !!(mask & CASCADES[i]));
-        });
+        this._input.values = values.map((mask) => CASCADES.filter((bit) => mask & bit));
         this._updating = false;
     }
 

--- a/src/common/pcui/pcui.ts
+++ b/src/common/pcui/pcui.ts
@@ -16,6 +16,7 @@ import { DropTarget } from './element/element-drop-target';
 import { EntityInput } from './element/element-entity-input';
 import { GradientInput } from './element/element-gradient-input';
 import { LayersInput } from './element/element-layers-input';
+import { ShadowCascadeMaskInput } from './element/element-shadow-cascade-mask-input';
 import { Table } from './element/element-table';
 import { TableCell } from './element/element-table-cell';
 import { TableRow } from './element/element-table-row';
@@ -44,6 +45,7 @@ const customElements = {
     EntityInput,
     GradientInput,
     LayersInput,
+    ShadowCascadeMaskInput,
     TableCell,
     TableRow,
     Table,

--- a/src/common/script-names.ts
+++ b/src/common/script-names.ts
@@ -15,6 +15,7 @@ const reservedScriptNames = new Set([
     '_scripts',
     '_scriptsIndex',
     '_scriptsData',
+    '_declarationOrder',
     'enabled',
     '_oldState',
     'onEnable',

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -35,6 +35,7 @@ export const COMPONENT_LOGOS = {
     model: 'E188',
     particlesystem: 'E199',
     rigidbody: 'E189',
+    joint: 'E426',
     physics: 'E426',
     capsule: 'E421',
     cone: 'E422',

--- a/src/editor-api/external-types/config.d.ts
+++ b/src/editor-api/external-types/config.d.ts
@@ -56,6 +56,8 @@ type ProjectSettings = {
     useTouch?: boolean;
     useGamepads?: boolean;
     maxAssetRetries: number;
+    withCredentials: boolean;
+    maxConcurrentRequests: number;
 };
 
 type Project = {

--- a/src/editor/animstategraph/anim-viewer.ts
+++ b/src/editor/animstategraph/anim-viewer.ts
@@ -142,8 +142,11 @@ class Skeleton {
         const axis = new Vec3().cross(new Vec3(0, 1, 0), boneDirection).normalize();
         Skeleton._rotationMatrix.setFromAxisAngle(axis, angle);
 
-        const vertexData = new Float32Array(this._mesh.vertexBuffer.lock());
-        const colorData = new Uint32Array(this._mesh.vertexBuffer.lock());
+        const data = this._mesh.vertexBuffer.lock();
+        const buffer = ArrayBuffer.isView(data) ? data.buffer : data;
+        const offset = ArrayBuffer.isView(data) ? data.byteOffset : 0;
+        const vertexData = new Float32Array(buffer, offset, data.byteLength / 4);
+        const colorData = new Uint32Array(buffer, offset, data.byteLength / 4);
 
         for (let i = 0; i < verticesPerBone; i++) {
             let boneVertex = Skeleton._boneVertex.set(...Skeleton._unitBone[i]);

--- a/src/editor/attributes/reference/assets/material.ts
+++ b/src/editor/attributes/reference/assets/material.ts
@@ -390,6 +390,37 @@ export const fields: AttributeReference[] = [
         url: 'https://api.playcanvas.com/engine/classes/StandardMaterial.html#heightmapfactor'
     },
     {
+        name: 'asset:material:parallaxMode',
+        title: 'parallaxMode',
+        subTitle: '{String}',
+        description:
+            'Selects a single height-map offset or ray-marched parallax occlusion. The mesh silhouette and depth buffer remain unchanged.',
+        url: 'https://api.playcanvas.com/engine/classes/StandardMaterial.html#parallaxmode'
+    },
+    {
+        name: 'asset:material:heightMapBase',
+        title: 'heightMapBase',
+        subTitle: '{Number}',
+        description:
+            'Height-map value that sits at the original surface. Use 1 for depth maps where white represents the flat surface.',
+        url: 'https://api.playcanvas.com/engine/classes/StandardMaterial.html#heightmapbase'
+    },
+    {
+        name: 'asset:material:parallaxSamples',
+        title: 'parallaxSamples',
+        subTitle: '{Number}',
+        description: 'Maximum height-map samples used by parallax occlusion. Higher values increase rendering cost.',
+        url: 'https://api.playcanvas.com/engine/classes/StandardMaterial.html#parallaxsamples'
+    },
+    {
+        name: 'asset:material:parallaxShadowSamples',
+        title: 'parallaxShadowSamples',
+        subTitle: '{Number}',
+        description:
+            'Maximum samples used to self-shadow parallax relief for each directional light. Set to 0 to disable it.',
+        url: 'https://api.playcanvas.com/engine/classes/StandardMaterial.html#parallaxshadowsamples'
+    },
+    {
         name: 'asset:material:heightMapOffset',
         title: 'heightMapOffset',
         subTitle: '{pc.Vec2}',

--- a/src/editor/attributes/reference/components/components.ts
+++ b/src/editor/attributes/reference/components/components.ts
@@ -9,6 +9,7 @@ import { fields as camera } from './camera';
 import { fields as collision } from './collision';
 import { fields as element } from './element';
 import { fields as gsplat } from './gsplat';
+import { fields as joint } from './joint';
 import { fields as layoutchild } from './layoutchild';
 import { fields as layoutgroup } from './layoutgroup';
 import { fields as light } from './light';
@@ -37,6 +38,7 @@ editor.once('load', () => {
         ...collision,
         ...element,
         ...gsplat,
+        ...joint,
         ...layoutchild,
         ...layoutgroup,
         ...light,

--- a/src/editor/attributes/reference/components/element.ts
+++ b/src/editor/attributes/reference/components/element.ts
@@ -234,6 +234,13 @@ export const fields: AttributeReference[] = [
         url: 'https://api.playcanvas.com/engine/classes/ElementComponent.html#wraplines'
     },
     {
+        name: 'element:justify',
+        title: 'justify',
+        subTitle: '{Boolean}',
+        description: 'Stretch wrapped text lines to both edges by widening the spaces between words.',
+        url: 'https://api.playcanvas.com/engine/classes/ElementComponent.html#justify'
+    },
+    {
         name: 'element:maxLines',
         title: 'maxLines',
         subTitle: '{Number}',

--- a/src/editor/attributes/reference/components/gsplat.ts
+++ b/src/editor/attributes/reference/components/gsplat.ts
@@ -31,18 +31,25 @@ export const fields: AttributeReference[] = [
         url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#castshadows'
     },
     {
-        name: 'gsplat:lodBaseDistance',
-        title: 'lodBaseDistance',
+        name: 'gsplat:lodRangeMin',
+        title: 'lodRangeMin',
         subTitle: '{Number}',
-        description:
-            'Distance of the first LOD transition (LOD 0 to LOD 1). Closer objects use the highest quality LOD.',
-        url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodbasedistance'
+        description: 'Lowest LOD level used when rendering this Gaussian splat.',
+        url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodrangemin'
     },
     {
-        name: 'gsplat:lodMultiplier',
-        title: 'lodMultiplier',
+        name: 'gsplat:lodRangeMax',
+        title: 'lodRangeMax',
         subTitle: '{Number}',
-        description: 'Geometric multiplier between successive LOD distance thresholds.',
-        url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodmultiplier'
+        description: 'Highest LOD level used when rendering this Gaussian splat.',
+        url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodrangemax'
+    },
+    {
+        name: 'gsplat:lodFalloff',
+        title: 'lodFalloff',
+        subTitle: '{Number}',
+        description:
+            'Controls how strongly detail is concentrated near the camera within the global splat budget. 0 spreads detail evenly.',
+        url: 'https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodfalloff'
     }
 ];

--- a/src/editor/attributes/reference/components/joint.ts
+++ b/src/editor/attributes/reference/components/joint.ts
@@ -1,0 +1,157 @@
+import type { AttributeReference } from '../reference.type';
+
+const motionFields = ['linear', 'angular'].flatMap((group) =>
+    ['X', 'Y', 'Z'].flatMap((axis) => [
+        {
+            name: `joint:${group}Motion${axis}`,
+            title: `${group}Motion${axis}`,
+            subTitle: '{String}',
+            description: `Selects whether ${group} motion on the ${axis} axis is locked, limited, or free.`,
+            url: `https://api.playcanvas.com/engine/classes/JointComponent.html#${group}motion${axis.toLowerCase()}`
+        },
+        {
+            name: `joint:${group}Limits${axis}`,
+            title: `${group}Limits${axis}`,
+            subTitle: '{pc.Vec2}',
+            description: `Lower and upper limits used when ${group} motion on the ${axis} axis is limited.`,
+            url: `https://api.playcanvas.com/engine/classes/JointComponent.html#${group}limits${axis.toLowerCase()}`
+        }
+    ])
+);
+
+export const fields: AttributeReference[] = [
+    {
+        name: 'joint:component',
+        title: 'pc.JointComponent',
+        subTitle: '{pc.Component}',
+        description: 'Constrains two rigid bodies, or constrains one rigid body to a fixed point in world space.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html'
+    },
+    {
+        name: 'joint:type',
+        title: 'type',
+        subTitle: '{String}',
+        description: 'Selects a fixed, ball, hinge, slider, or six degrees of freedom joint.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#type'
+    },
+    {
+        name: 'joint:entityA',
+        title: 'entityA',
+        subTitle: '{pc.Entity}',
+        description: 'First constrained entity. It must have a rigid body component.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#entitya'
+    },
+    {
+        name: 'joint:entityB',
+        title: 'entityB',
+        subTitle: '{pc.Entity}',
+        description: 'Second constrained entity. Leave empty to constrain Entity A to world space.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#entityb'
+    },
+    {
+        name: 'joint:enableCollision',
+        title: 'enableCollision',
+        subTitle: '{Boolean}',
+        description: 'Allow the two constrained bodies to collide with each other.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#enablecollision'
+    },
+    {
+        name: 'joint:breakImpulse',
+        title: 'breakImpulse',
+        subTitle: '{Number}',
+        description: 'Impulse above which the joint breaks. Leave empty for an unbreakable joint.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#breakimpulse'
+    },
+    {
+        name: 'joint:enableLimits',
+        title: 'enableLimits',
+        subTitle: '{Boolean}',
+        description: 'Enable the configured hinge, slider, or ball-joint limits.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#enablelimits'
+    },
+    {
+        name: 'joint:limits',
+        title: 'limits',
+        subTitle: '{pc.Vec2}',
+        description: 'Lower and upper angular hinge limits or linear slider limits.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#limits'
+    },
+    {
+        name: 'joint:motorSpeed',
+        title: 'motorSpeed',
+        subTitle: '{Number}',
+        description: 'Target angular hinge speed or linear slider speed.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#motorspeed'
+    },
+    {
+        name: 'joint:maxMotorForce',
+        title: 'maxMotorForce',
+        subTitle: '{Number}',
+        description: 'Maximum motor force or torque. Set to 0 to disable the motor.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#maxmotorforce'
+    },
+    {
+        name: 'joint:swingLimitY',
+        title: 'swingLimitY',
+        subTitle: '{Number}',
+        description: 'Maximum ball-joint swing towards its Y axis in degrees.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#swinglimity'
+    },
+    {
+        name: 'joint:swingLimitZ',
+        title: 'swingLimitZ',
+        subTitle: '{Number}',
+        description: 'Maximum ball-joint swing towards its Z axis in degrees.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#swinglimitz'
+    },
+    {
+        name: 'joint:twistLimit',
+        title: 'twistLimit',
+        subTitle: '{Number}',
+        description: 'Maximum ball-joint twist about its X axis in degrees.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#twistlimit'
+    },
+    ...motionFields,
+    {
+        name: 'joint:linearStiffness',
+        title: 'linearStiffness',
+        subTitle: '{pc.Vec3}',
+        description: 'Stiffness of the linear springs on the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#linearstiffness'
+    },
+    {
+        name: 'joint:linearDamping',
+        title: 'linearDamping',
+        subTitle: '{pc.Vec3}',
+        description: 'Damping of the linear springs on the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#lineardamping'
+    },
+    {
+        name: 'joint:linearEquilibrium',
+        title: 'linearEquilibrium',
+        subTitle: '{pc.Vec3}',
+        description: 'Rest positions of the linear springs on the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#linearequilibrium'
+    },
+    {
+        name: 'joint:angularStiffness',
+        title: 'angularStiffness',
+        subTitle: '{pc.Vec3}',
+        description: 'Stiffness of the angular springs about the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#angularstiffness'
+    },
+    {
+        name: 'joint:angularDamping',
+        title: 'angularDamping',
+        subTitle: '{pc.Vec3}',
+        description: 'Damping of the angular springs about the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#angulardamping'
+    },
+    {
+        name: 'joint:angularEquilibrium',
+        title: 'angularEquilibrium',
+        subTitle: '{pc.Vec3}',
+        description: 'Rest angles of the angular springs about the X, Y and Z axes.',
+        url: 'https://api.playcanvas.com/engine/classes/JointComponent.html#angularequilibrium'
+    }
+];

--- a/src/editor/attributes/reference/components/render.ts
+++ b/src/editor/attributes/reference/components/render.ts
@@ -48,6 +48,14 @@ export const fields: AttributeReference[] = [
         url: 'https://api.playcanvas.com/engine/classes/RenderComponent.html#castshadows'
     },
     {
+        name: 'render:shadowCascadeMask',
+        title: 'shadowCascadeMask',
+        subTitle: '{Number}',
+        description:
+            'Selects which directional-light shadow cascades receive this render component. Extra cascades are ignored.',
+        url: 'https://api.playcanvas.com/engine/classes/RenderComponent.html#shadowcascademask'
+    },
+    {
         name: 'render:receiveShadows',
         title: 'receiveShadows',
         subTitle: '{Boolean}',

--- a/src/editor/attributes/reference/settings.ts
+++ b/src/editor/attributes/reference/settings.ts
@@ -452,6 +452,18 @@ editor.once('load', () => {
                 'The maximum number of times to retry loading an asset if it fails to load. If an asset request fails, it will be retried with exponential backoff.'
         },
         {
+            name: 'settings:project:withCredentials',
+            title: 'Asset Credentials',
+            description:
+                'Send asset requests with credentials such as cookies, client certificates, or HTTP authentication. Authenticated cross-origin servers must allow credentials and return a specific origin.'
+        },
+        {
+            name: 'settings:project:maxConcurrentRequests',
+            title: 'Max Concurrent Requests',
+            description:
+                'Maximum number of asset requests that may run at once. Set to 0 to disable request throttling.'
+        },
+        {
             name: 'settings:zoomSensitivity',
             title: 'Change Zoom Sensitivity',
             description: 'Change this value if you want to adjust the zoom sensitivity in the Editor viewport.'
@@ -702,6 +714,115 @@ editor.once('load', () => {
             title: 'lightingMaxLightsPerCell',
             description: 'Maximum number of lights a cell can store.',
             url: 'https://api.playcanvas.com/engine/classes/LightingParams.html#maxlightspercell'
+        },
+        {
+            name: 'settings:lightingMaxLights',
+            title: 'lightingMaxLights',
+            description:
+                'Maximum number of clustered lights visible in a frame. Keep this as low as the scene allows; values above 255 use a larger light-index texture.',
+            url: 'https://api.playcanvas.com/engine/classes/LightingParams.html#maxlights'
+        },
+        {
+            name: 'settings:gsplatRadialSorting',
+            title: 'gsplatRadialSorting',
+            description: 'Sort splats by radial camera distance instead of view depth.'
+        },
+        {
+            name: 'settings:gsplatLodUpdateDistance',
+            title: 'gsplatLodUpdateDistance',
+            description: 'Camera travel distance that triggers a Gaussian splat LOD update.'
+        },
+        {
+            name: 'settings:gsplatLodUpdateAngle',
+            title: 'gsplatLodUpdateAngle',
+            description: 'Camera rotation in degrees that triggers an LOD update. Set to 0 to disable angle updates.'
+        },
+        {
+            name: 'settings:gsplatLodBehindPenalty',
+            title: 'gsplatLodBehindPenalty',
+            description: 'Distance multiplier used for splat nodes behind the camera during LOD selection.'
+        },
+        {
+            name: 'settings:gsplatLodUnderfillLimit',
+            title: 'gsplatLodUnderfillLimit',
+            description: 'Number of lower-detail LOD levels that can be used while optimal data loads.'
+        },
+        {
+            name: 'settings:gsplatSplatBudget',
+            title: 'gsplatSplatBudget',
+            description:
+                'Target number of splats rendered across the scene. Non-positive values use the engine default.'
+        },
+        {
+            name: 'settings:gsplatAlphaClip',
+            title: 'gsplatAlphaClip',
+            description: 'Alpha threshold for Gaussian splat shadow, picking and prepass rendering.'
+        },
+        {
+            name: 'settings:gsplatAlphaClipForward',
+            title: 'gsplatAlphaClipForward',
+            description: 'Alpha threshold below which splats are removed from the forward pass.'
+        },
+        {
+            name: 'settings:gsplatMinPixelSize',
+            title: 'gsplatMinPixelSize',
+            description: 'Minimum screen-space size below which splats are discarded.'
+        },
+        {
+            name: 'settings:gsplatMinContribution',
+            title: 'gsplatMinContribution',
+            description: 'Minimum visual contribution below which splats are culled. Set to 0 to disable it.'
+        },
+        {
+            name: 'settings:gsplatFoveationStrength',
+            title: 'gsplatFoveationStrength',
+            description: 'Strength of contribution culling towards the screen edges. Set to 0 to disable it.'
+        },
+        {
+            name: 'settings:gsplatFoveationCenter',
+            title: 'gsplatFoveationCenter',
+            description: 'Protected screen-centre radius where foveation does not apply.'
+        },
+        {
+            name: 'settings:gsplatAntiAlias',
+            title: 'gsplatAntiAlias',
+            description: 'Apply anti-aliasing compensation to splats trained with anti-aliasing.'
+        },
+        {
+            name: 'settings:gsplatUseFog',
+            title: 'gsplatUseFog',
+            description: 'Apply scene fog to Gaussian splats.'
+        },
+        {
+            name: 'settings:gsplatUseTonemap',
+            title: 'gsplatUseTonemap',
+            description:
+                'Apply camera tonemapping and scene exposure to Gaussian splats. Other scene objects are unaffected.'
+        },
+        {
+            name: 'settings:gsplatColorUpdateAngle',
+            title: 'gsplatColorUpdateAngle',
+            description: 'Viewing-angle change that triggers a spherical-harmonics color update.'
+        },
+        {
+            name: 'settings:gsplatCooldownTicks',
+            title: 'gsplatCooldownTicks',
+            description: 'Ticks an unused streamed splat resource waits before unloading.'
+        },
+        {
+            name: 'settings:gsplatDataFormat',
+            title: 'gsplatDataFormat',
+            description: 'Work-buffer format used for Gaussian splat rendering.'
+        },
+        {
+            name: 'settings:gsplatEnableIds',
+            title: 'gsplatEnableIds',
+            description: 'Store a unique component ID in the Gaussian splat work buffer.'
+        },
+        {
+            name: 'settings:gsplatLodMode',
+            title: 'gsplatLodMode',
+            description: 'Metric used to select Gaussian splat detail within the global budget.'
         },
         {
             name: 'settings:lightingCookieAtlasResolution',

--- a/src/editor/entities/entities-components-menu.ts
+++ b/src/editor/entities/entities-components-menu.ts
@@ -10,7 +10,7 @@ editor.once('load', () => {
         ) {
             return 'ui-sub-menu';
         }
-        if (['rigidbody', 'collision'].indexOf(key) >= 0) {
+        if (['rigidbody', 'collision', 'joint'].indexOf(key) >= 0) {
             return 'physics-sub-menu';
         }
 

--- a/src/editor/inspector/assets/material.ts
+++ b/src/editor/inspector/assets/material.ts
@@ -642,6 +642,19 @@ const NORMALS_ATTRIBUTES: (Attribute | Divider)[] = [
 const PARALLAX_ATTRIBUTES: (Attribute | Divider)[] = [
     ...createTextureAttribute('Heightmap', 'height', TextureTypes.Scalar),
     {
+        label: 'Mode',
+        path: 'data.parallaxMode',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                { v: pc.PARALLAX_OFFSET, t: 'Offset' },
+                { v: pc.PARALLAX_OCCLUSION, t: 'Occlusion' }
+            ]
+        },
+        reference: 'asset:material:parallaxMode'
+    },
+    {
         label: 'Strength',
         path: 'data.heightMapFactor',
         type: 'slider',
@@ -652,6 +665,42 @@ const PARALLAX_ATTRIBUTES: (Attribute | Divider)[] = [
             max: 2
         },
         reference: 'asset:material:heightMapFactor'
+    },
+    {
+        label: 'Base',
+        path: 'data.heightMapBase',
+        type: 'slider',
+        args: {
+            min: 0,
+            max: 1,
+            step: 0.01,
+            precision: 2
+        },
+        reference: 'asset:material:heightMapBase'
+    },
+    {
+        label: 'Samples',
+        path: 'data.parallaxSamples',
+        type: 'number',
+        args: {
+            min: 4,
+            max: 64,
+            step: 1,
+            precision: 0
+        },
+        reference: 'asset:material:parallaxSamples'
+    },
+    {
+        label: 'Self Shadow',
+        path: 'data.parallaxShadowSamples',
+        type: 'number',
+        args: {
+            min: 0,
+            max: 32,
+            step: 1,
+            precision: 0
+        },
+        reference: 'asset:material:parallaxShadowSamples'
     }
 ];
 
@@ -1809,6 +1858,7 @@ class MaterialAssetInspector extends Container {
         this._sheenInspector.getField('data.useSheen').on('change', toggleFields);
         this._refractionInspector.getField('data.useDynamicRefraction').on('change', toggleFields);
         this._iridescenceInspector.getField('data.useIridescence').on('change', toggleFields);
+        this._parallaxInspector.getField('data.parallaxMode').on('change', toggleFields);
 
         for (const map in MAPS) {
             const inspectors = MAPS[map];
@@ -1982,6 +2032,11 @@ class MaterialAssetInspector extends Container {
 
         const heightMap = this._parallaxInspector.getField('data.heightMap').value;
         this._parallaxInspector.getField('data.heightMapFactor').parent.hidden = !heightMap;
+        this._parallaxInspector.getField('data.parallaxMode').parent.hidden = !heightMap;
+        this._parallaxInspector.getField('data.heightMapBase').parent.hidden = !heightMap;
+        const parallaxOcclusion = this._parallaxInspector.getField('data.parallaxMode').value === pc.PARALLAX_OCCLUSION;
+        this._parallaxInspector.getField('data.parallaxSamples').parent.hidden = !heightMap || !parallaxOcclusion;
+        this._parallaxInspector.getField('data.parallaxShadowSamples').parent.hidden = !heightMap || !parallaxOcclusion;
 
         const cubeMapField = this._envInspector.getField('data.cubeMap');
         const sphereMapField = this._envInspector.getField('data.sphereMap');

--- a/src/editor/inspector/attributes-inspector.ts
+++ b/src/editor/inspector/attributes-inspector.ts
@@ -226,6 +226,9 @@ class AttributesInspector extends Container {
                     if (type === 'slider') {
                         type = 'number';
                     }
+                    if (type === 'shadow-cascade-mask') {
+                        type = 'number';
+                    }
                     if ((type === 'asset' || type === 'array:asset') && attr.args?.assetType) {
                         type += `:${attr.args.assetType}`;
                     }

--- a/src/editor/inspector/components/element.ts
+++ b/src/editor/inspector/components/element.ts
@@ -254,6 +254,12 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
         type: 'boolean'
     },
     {
+        label: 'Justify',
+        path: 'components.element.justify',
+        reference: 'element:justify',
+        type: 'boolean'
+    },
+    {
         label: 'Max Lines',
         path: 'components.element.maxLines',
         reference: 'element:maxLines',
@@ -857,6 +863,8 @@ class ElementComponentInspector extends ComponentInspector {
 
         this._field('fontAsset').hidden = !isText;
         this._field('maxLines').parent.hidden = !isText || !this._field('wrapLines').value;
+        this._field('justify').parent.hidden =
+            !isText || !this._field('wrapLines').value || this._field('autoWidth').value;
         this._field('localized').parent.hidden = !isText;
         this._field('text').parent.hidden =
             !isText || this._field('localized').value || this._field('localized').class.contains(CLASS_MULTIPLE_VALUES);

--- a/src/editor/inspector/components/gsplat.ts
+++ b/src/editor/inspector/components/gsplat.ts
@@ -23,23 +23,35 @@ const ATTRIBUTES: Attribute[] = [
         type: 'boolean'
     },
     {
-        label: 'LOD Base Distance',
-        path: 'components.gsplat.lodBaseDistance',
-        reference: 'gsplat:lodBaseDistance',
+        label: 'LOD Range Min',
+        path: 'components.gsplat.lodRangeMin',
+        reference: 'gsplat:lodRangeMin',
         type: 'number',
         args: {
-            min: 0.1,
-            step: 0.1,
-            precision: 2
+            min: 0,
+            step: 1,
+            precision: 0
         }
     },
     {
-        label: 'LOD Multiplier',
-        path: 'components.gsplat.lodMultiplier',
-        reference: 'gsplat:lodMultiplier',
+        label: 'LOD Range Max',
+        path: 'components.gsplat.lodRangeMax',
+        reference: 'gsplat:lodRangeMax',
         type: 'number',
         args: {
-            min: 1.2,
+            min: 0,
+            step: 1,
+            precision: 0
+        }
+    },
+    {
+        label: 'LOD Falloff',
+        path: 'components.gsplat.lodFalloff',
+        reference: 'gsplat:lodFalloff',
+        type: 'slider',
+        args: {
+            min: 0,
+            max: 8,
             step: 0.1,
             precision: 2
         }

--- a/src/editor/inspector/components/joint.ts
+++ b/src/editor/inspector/components/joint.ts
@@ -1,0 +1,335 @@
+import type { LabelGroup } from '@playcanvas/pcui';
+import {
+    JOINTTYPE_6DOF,
+    JOINTTYPE_BALL,
+    JOINTTYPE_FIXED,
+    JOINTTYPE_HINGE,
+    JOINTTYPE_SLIDER,
+    MOTION_FREE,
+    MOTION_LIMITED,
+    MOTION_LOCKED
+} from 'playcanvas';
+
+import { CLASS_MULTIPLE_VALUES } from '@/common/pcui/constants';
+import type { EntityObserver } from '@/editor-api';
+
+import type { Attribute } from '../attribute.type.d';
+import { AttributesInspector } from '../attributes-inspector';
+
+import { ComponentInspector } from './component';
+import type { ComponentInspectorArgs } from './component';
+
+const MOTION_OPTIONS = [
+    { v: MOTION_LOCKED, t: 'Locked' },
+    { v: MOTION_LIMITED, t: 'Limited' },
+    { v: MOTION_FREE, t: 'Free' }
+];
+
+const COMMON_FIELDS = new Set(['type', 'entityA', 'entityB', 'enableCollision', 'breakImpulse']);
+const LIMIT_FIELDS = ['limits', 'swingLimitY', 'swingLimitZ', 'twistLimit'];
+const DOF_FIELDS = [
+    'linearMotionX',
+    'linearMotionY',
+    'linearMotionZ',
+    'linearLimitsX',
+    'linearLimitsY',
+    'linearLimitsZ',
+    'linearStiffness',
+    'linearDamping',
+    'linearEquilibrium',
+    'angularMotionX',
+    'angularMotionY',
+    'angularMotionZ',
+    'angularLimitsX',
+    'angularLimitsY',
+    'angularLimitsZ',
+    'angularStiffness',
+    'angularDamping',
+    'angularEquilibrium'
+];
+
+const ATTRIBUTES: Attribute[] = [
+    {
+        label: 'Type',
+        path: 'components.joint.type',
+        reference: 'joint:type',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                { v: JOINTTYPE_FIXED, t: 'Fixed' },
+                { v: JOINTTYPE_BALL, t: 'Ball' },
+                { v: JOINTTYPE_HINGE, t: 'Hinge' },
+                { v: JOINTTYPE_SLIDER, t: 'Slider' },
+                { v: JOINTTYPE_6DOF, t: '6DoF' }
+            ]
+        }
+    },
+    {
+        label: 'Entity A',
+        path: 'components.joint.entityA',
+        reference: 'joint:entityA',
+        type: 'entity'
+    },
+    {
+        label: 'Entity B',
+        path: 'components.joint.entityB',
+        reference: 'joint:entityB',
+        type: 'entity'
+    },
+    {
+        label: 'Enable Collision',
+        path: 'components.joint.enableCollision',
+        reference: 'joint:enableCollision',
+        type: 'boolean'
+    },
+    {
+        label: 'Break Impulse',
+        path: 'components.joint.breakImpulse',
+        reference: 'joint:breakImpulse',
+        type: 'number',
+        args: {
+            allowNull: true,
+            placeholder: 'Unbreakable'
+        }
+    },
+    {
+        label: 'Enable Limits',
+        path: 'components.joint.enableLimits',
+        reference: 'joint:enableLimits',
+        type: 'boolean'
+    },
+    {
+        label: 'Limits',
+        path: 'components.joint.limits',
+        reference: 'joint:limits',
+        type: 'vec2',
+        args: {
+            placeholder: ['Lower', 'Upper']
+        }
+    },
+    {
+        label: 'Motor Speed',
+        path: 'components.joint.motorSpeed',
+        reference: 'joint:motorSpeed',
+        type: 'number'
+    },
+    {
+        label: 'Max Motor Force',
+        path: 'components.joint.maxMotorForce',
+        reference: 'joint:maxMotorForce',
+        type: 'number'
+    },
+    {
+        label: 'Swing Limit Y',
+        path: 'components.joint.swingLimitY',
+        reference: 'joint:swingLimitY',
+        type: 'number'
+    },
+    {
+        label: 'Swing Limit Z',
+        path: 'components.joint.swingLimitZ',
+        reference: 'joint:swingLimitZ',
+        type: 'number'
+    },
+    {
+        label: 'Twist Limit',
+        path: 'components.joint.twistLimit',
+        reference: 'joint:twistLimit',
+        type: 'number'
+    },
+    ...['X', 'Y', 'Z'].flatMap((axis): Attribute[] => [
+        {
+            label: `Linear Motion ${axis}`,
+            path: `components.joint.linearMotion${axis}`,
+            reference: `joint:linearMotion${axis}`,
+            type: 'select',
+            args: {
+                type: 'string',
+                options: MOTION_OPTIONS
+            }
+        },
+        {
+            label: `Linear Limits ${axis}`,
+            path: `components.joint.linearLimits${axis}`,
+            reference: `joint:linearLimits${axis}`,
+            type: 'vec2',
+            args: {
+                placeholder: ['Lower', 'Upper']
+            }
+        }
+    ]),
+    {
+        label: 'Linear Stiffness',
+        path: 'components.joint.linearStiffness',
+        reference: 'joint:linearStiffness',
+        type: 'vec3',
+        args: {
+            min: 0,
+            placeholder: ['X', 'Y', 'Z']
+        }
+    },
+    {
+        label: 'Linear Damping',
+        path: 'components.joint.linearDamping',
+        reference: 'joint:linearDamping',
+        type: 'vec3',
+        args: {
+            min: 0,
+            placeholder: ['X', 'Y', 'Z']
+        }
+    },
+    {
+        label: 'Linear Equilibrium',
+        path: 'components.joint.linearEquilibrium',
+        reference: 'joint:linearEquilibrium',
+        type: 'vec3',
+        args: {
+            placeholder: ['X', 'Y', 'Z']
+        }
+    },
+    ...['X', 'Y', 'Z'].flatMap((axis): Attribute[] => [
+        {
+            label: `Angular Motion ${axis}`,
+            path: `components.joint.angularMotion${axis}`,
+            reference: `joint:angularMotion${axis}`,
+            type: 'select',
+            args: {
+                type: 'string',
+                options: MOTION_OPTIONS
+            }
+        },
+        {
+            label: `Angular Limits ${axis}`,
+            path: `components.joint.angularLimits${axis}`,
+            reference: `joint:angularLimits${axis}`,
+            type: 'vec2',
+            args: {
+                placeholder: ['Lower', 'Upper']
+            }
+        }
+    ]),
+    {
+        label: 'Angular Stiffness',
+        path: 'components.joint.angularStiffness',
+        reference: 'joint:angularStiffness',
+        type: 'vec3',
+        args: {
+            min: 0,
+            placeholder: ['X', 'Y', 'Z']
+        }
+    },
+    {
+        label: 'Angular Damping',
+        path: 'components.joint.angularDamping',
+        reference: 'joint:angularDamping',
+        type: 'vec3',
+        args: {
+            min: 0,
+            placeholder: ['X', 'Y', 'Z']
+        }
+    },
+    {
+        label: 'Angular Equilibrium',
+        path: 'components.joint.angularEquilibrium',
+        reference: 'joint:angularEquilibrium',
+        type: 'vec3',
+        args: {
+            placeholder: ['X', 'Y', 'Z']
+        }
+    }
+];
+
+class JointComponentInspector extends ComponentInspector {
+    _suppressToggleFields = false;
+
+    _importAmmoPanel: LabelGroup;
+
+    constructor(args: ComponentInspectorArgs) {
+        args = Object.assign({}, args);
+        args.component = 'joint';
+
+        super(args);
+
+        this._attributesInspector = new AttributesInspector({
+            assets: args.assets,
+            entities: args.entities,
+            projectSettings: args.projectSettings,
+            history: args.history,
+            attributes: ATTRIBUTES,
+            templateOverridesInspector: this._templateOverridesInspector
+        });
+        this.append(this._attributesInspector);
+
+        [
+            'type',
+            'enableLimits',
+            'linearMotionX',
+            'linearMotionY',
+            'linearMotionZ',
+            'angularMotionX',
+            'angularMotionY',
+            'angularMotionZ'
+        ].forEach((field) => {
+            this._field(field).on('change', this._toggleFields.bind(this));
+        });
+
+        this._importAmmoPanel = editor.call('attributes:appendImportAmmo', this);
+        this._importAmmoPanel.hidden = true;
+        this._importAmmoPanel.label.text = 'Ammo module not found';
+        this._importAmmoPanel.class.add('library-warning');
+        this._importAmmoPanel.label.class.add('library-warning-text');
+        this._importAmmoPanel.style.margin = '6px';
+
+        this.on('show', () => {
+            this._importAmmoPanel.hidden = editor.call('project:settings:hasPhysics');
+        });
+    }
+
+    _toggleFields() {
+        if (this._suppressToggleFields) {
+            return;
+        }
+
+        const typeField = this._field('type');
+        const type = typeField.class.contains(CLASS_MULTIPLE_VALUES) ? null : typeField.value;
+        const limits = this._field('enableLimits').value;
+        const hinge = type === JOINTTYPE_HINGE || type === JOINTTYPE_SLIDER;
+        const ball = type === JOINTTYPE_BALL;
+        const dof = type === JOINTTYPE_6DOF;
+
+        ATTRIBUTES.forEach((attr) => {
+            const field = attr.path?.split('.').pop();
+            if (field && !COMMON_FIELDS.has(field)) {
+                this._field(field).parent.hidden = true;
+            }
+        });
+
+        this._field('enableLimits').parent.hidden = !hinge && !ball;
+        this._field('limits').parent.hidden = !hinge || !limits;
+        this._field('motorSpeed').parent.hidden = !hinge;
+        this._field('maxMotorForce').parent.hidden = !hinge;
+        LIMIT_FIELDS.slice(1).forEach((field) => {
+            this._field(field).parent.hidden = !ball || !limits;
+        });
+        DOF_FIELDS.forEach((field) => {
+            this._field(field).parent.hidden = !dof;
+        });
+        ['linear', 'angular'].forEach((group) => {
+            ['X', 'Y', 'Z'].forEach((axis) => {
+                const motion = `${group}Motion${axis}`;
+                this._field(`${group}Limits${axis}`).parent.hidden =
+                    !dof || this._field(motion).value !== MOTION_LIMITED;
+            });
+        });
+    }
+
+    link(entities: EntityObserver[]) {
+        this._suppressToggleFields = true;
+        super.link(entities);
+        this._suppressToggleFields = false;
+        this._toggleFields();
+    }
+}
+
+export { JointComponentInspector };

--- a/src/editor/inspector/components/joint.ts
+++ b/src/editor/inspector/components/joint.ts
@@ -260,6 +260,7 @@ class JointComponentInspector extends ComponentInspector {
             templateOverridesInspector: this._templateOverridesInspector
         });
         this.append(this._attributesInspector);
+        this._field('breakImpulse').parent.style.marginBottom = '6px';
 
         [
             'type',

--- a/src/editor/inspector/components/render.ts
+++ b/src/editor/inspector/components/render.ts
@@ -75,6 +75,12 @@ const ATTRIBUTES: Attribute[] = [
         type: 'boolean'
     },
     {
+        label: 'Shadow Cascades',
+        path: 'components.render.shadowCascadeMask',
+        reference: 'render:shadowCascadeMask',
+        type: 'shadow-cascade-mask'
+    },
+    {
         label: 'Cast Lightmap Shadows',
         path: 'components.render.castShadowsLightmap',
         reference: 'render:castShadowsLightmap',
@@ -198,7 +204,7 @@ class RenderComponentInspector extends ComponentInspector {
         this._labelUv1Missing.style.marginLeft = 'auto';
         this._field('lightmapped').parent.append(this._labelUv1Missing);
 
-        ['type', 'asset', 'lightmapped', 'lightmapSizeMultiplier', 'customAabb'].forEach((field) => {
+        ['type', 'asset', 'castShadows', 'lightmapped', 'lightmapSizeMultiplier', 'customAabb'].forEach((field) => {
             this._field(field).on('change', this._toggleFields.bind(this));
         });
 
@@ -374,6 +380,7 @@ class RenderComponentInspector extends ComponentInspector {
         this._field('lightmapSizeMultiplier').parent.hidden = fieldLightmapSize.parent.hidden;
 
         this._field('asset').hidden = this._field('type').value !== 'asset';
+        this._field('shadowCascadeMask').parent.hidden = !this._field('castShadows').value;
 
         // Show Root Bone only if all selected entities have a skinned render asset
         const showRootBone =

--- a/src/editor/inspector/entity.ts
+++ b/src/editor/inspector/entity.ts
@@ -22,6 +22,7 @@ import { CollisionComponentInspector } from './components/collision';
 import type { ComponentInspector } from './components/component';
 import { ElementComponentInspector } from './components/element';
 import { GSplatComponentInspector } from './components/gsplat';
+import { JointComponentInspector } from './components/joint';
 import { LayoutchildComponentInspector } from './components/layoutchild';
 import { LayoutgroupComponentInspector } from './components/layoutgroup';
 import { LightComponentInspector } from './components/light';
@@ -63,6 +64,7 @@ componentToConstructor.set('sound', SoundComponentInspector);
 componentToConstructor.set('sprite', SpriteComponentInspector);
 componentToConstructor.set('zone', ZoneComponentInspector);
 componentToConstructor.set('gsplat', GSplatComponentInspector);
+componentToConstructor.set('joint', JointComponentInspector);
 
 const CLASS_ROOT = 'entity-inspector';
 const CLASS_NO_COMPONENTS = `${CLASS_ROOT}-no-components`;
@@ -125,6 +127,7 @@ const getSubMenu = function (key: string) {
 
         case 'rigidbody':
         case 'collision':
+        case 'joint':
             return 'physics-sub-menu';
 
         case 'light':

--- a/src/editor/inspector/settings-panels/network.ts
+++ b/src/editor/inspector/settings-panels/network.ts
@@ -6,6 +6,24 @@ import type { BaseSettingsPanelArgs } from './base';
 const ATTRIBUTES: Attribute[] = [
     {
         observer: 'projectSettings',
+        label: 'Asset Credentials',
+        path: 'withCredentials',
+        type: 'boolean',
+        reference: 'settings:project:withCredentials'
+    },
+    {
+        observer: 'projectSettings',
+        label: 'Max Concurrent Requests',
+        path: 'maxConcurrentRequests',
+        type: 'number',
+        reference: 'settings:project:maxConcurrentRequests',
+        args: {
+            min: 0,
+            precision: 0
+        }
+    },
+    {
+        observer: 'projectSettings',
         label: 'Asset Retries',
         path: 'maxAssetRetries',
         type: 'number',

--- a/src/editor/inspector/settings-panels/rendering.ts
+++ b/src/editor/inspector/settings-panels/rendering.ts
@@ -1,4 +1,6 @@
-import { Button, Label, Overlay } from '@playcanvas/pcui';
+import type { Container } from '@playcanvas/pcui';
+import { Button, Label, Overlay, Panel } from '@playcanvas/pcui';
+import { GSPLATDATA_COMPACT, GSPLATDATA_LARGE, GSPLAT_LODMODE_DISTANCE, GSPLAT_LODMODE_ERROR } from 'playcanvas';
 
 import { TONEMAPPING } from '@/core/constants';
 
@@ -191,6 +193,18 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
     },
     {
         observer: 'sceneSettings',
+        label: 'Max Lights',
+        path: 'render.lightingMaxLights',
+        reference: 'settings:lightingMaxLights',
+        type: 'number',
+        args: {
+            min: 1,
+            step: 1,
+            precision: 0
+        }
+    },
+    {
+        observer: 'sceneSettings',
         label: 'Cookies Enabled',
         type: 'boolean',
         path: 'render.lightingCookiesEnabled',
@@ -257,6 +271,175 @@ const ATTRIBUTES: (Attribute | Divider)[] = [
         type: 'boolean',
         path: 'render.lightingAreaLightsEnabled',
         reference: 'settings:lightingAreaLightsEnabled'
+    },
+    {
+        type: 'divider'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Radial Sorting',
+        path: 'render.gsplatRadialSorting',
+        reference: 'settings:gsplatRadialSorting',
+        type: 'boolean'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'LOD Update Distance',
+        path: 'render.gsplatLodUpdateDistance',
+        reference: 'settings:gsplatLodUpdateDistance',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'LOD Update Angle',
+        path: 'render.gsplatLodUpdateAngle',
+        reference: 'settings:gsplatLodUpdateAngle',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'LOD Behind Penalty',
+        path: 'render.gsplatLodBehindPenalty',
+        reference: 'settings:gsplatLodBehindPenalty',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'LOD Underfill Limit',
+        path: 'render.gsplatLodUnderfillLimit',
+        reference: 'settings:gsplatLodUnderfillLimit',
+        type: 'number',
+        args: {
+            step: 1,
+            precision: 0
+        }
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Splat Budget',
+        path: 'render.gsplatSplatBudget',
+        reference: 'settings:gsplatSplatBudget',
+        type: 'number',
+        args: {
+            step: 1000,
+            precision: 0
+        }
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Alpha Clip',
+        path: 'render.gsplatAlphaClip',
+        reference: 'settings:gsplatAlphaClip',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Forward Alpha Clip',
+        path: 'render.gsplatAlphaClipForward',
+        reference: 'settings:gsplatAlphaClipForward',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Min Pixel Size',
+        path: 'render.gsplatMinPixelSize',
+        reference: 'settings:gsplatMinPixelSize',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Min Contribution',
+        path: 'render.gsplatMinContribution',
+        reference: 'settings:gsplatMinContribution',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Foveation Strength',
+        path: 'render.gsplatFoveationStrength',
+        reference: 'settings:gsplatFoveationStrength',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Foveation Center',
+        path: 'render.gsplatFoveationCenter',
+        reference: 'settings:gsplatFoveationCenter',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Anti-Alias',
+        path: 'render.gsplatAntiAlias',
+        reference: 'settings:gsplatAntiAlias',
+        type: 'boolean'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Use Fog',
+        path: 'render.gsplatUseFog',
+        reference: 'settings:gsplatUseFog',
+        type: 'boolean'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Use Tonemapping',
+        path: 'render.gsplatUseTonemap',
+        reference: 'settings:gsplatUseTonemap',
+        type: 'boolean'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Color Update Angle',
+        path: 'render.gsplatColorUpdateAngle',
+        reference: 'settings:gsplatColorUpdateAngle',
+        type: 'number'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Cooldown Ticks',
+        path: 'render.gsplatCooldownTicks',
+        reference: 'settings:gsplatCooldownTicks',
+        type: 'number',
+        args: {
+            step: 1,
+            precision: 0
+        }
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Data Format',
+        path: 'render.gsplatDataFormat',
+        reference: 'settings:gsplatDataFormat',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                { v: GSPLATDATA_COMPACT, t: 'Compact' },
+                { v: GSPLATDATA_LARGE, t: 'Large' }
+            ]
+        }
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'Enable IDs',
+        path: 'render.gsplatEnableIds',
+        reference: 'settings:gsplatEnableIds',
+        type: 'boolean'
+    },
+    {
+        observer: 'sceneSettings',
+        label: 'LOD Mode',
+        path: 'render.gsplatLodMode',
+        reference: 'settings:gsplatLodMode',
+        type: 'select',
+        args: {
+            type: 'string',
+            options: [
+                { v: GSPLAT_LODMODE_ERROR, t: 'Error' },
+                { v: GSPLAT_LODMODE_DISTANCE, t: 'Distance' }
+            ]
+        }
     },
     {
         type: 'divider'
@@ -571,6 +754,12 @@ class RenderingSettingsPanel extends BaseSettingsPanel {
 
         this.class.add('rendering');
 
+        const firstSplat = this._attributesInspector.getField('render.gsplatRadialSorting');
+        (firstSplat.parent.parent as Container).appendBefore(
+            new Panel({ headerText: 'Gaussian Splatting', class: 'rendering-settings-section' }),
+            firstSplat.parent
+        );
+
         const fogAttribute = this._attributesInspector.getField('render.fog');
         const fogChangeEvt = fogAttribute.on('change', (value) => {
             switch (value) {
@@ -627,6 +816,7 @@ class RenderingSettingsPanel extends BaseSettingsPanel {
         const cookieResolution = this._attributesInspector.getField('render.lightingCookieAtlasResolution');
         const cells = this._attributesInspector.getField('render.lightingCells');
         const lightsPerCell = this._attributesInspector.getField('render.lightingMaxLightsPerCell');
+        const maxLights = this._attributesInspector.getField('render.lightingMaxLights');
         const clusteredEnabled = this._attributesInspector.getField('render.clusteredLightingEnabled');
 
         const sceneSettings = editor.call('sceneSettings');
@@ -668,6 +858,8 @@ class RenderingSettingsPanel extends BaseSettingsPanel {
             cells.parent.hidden = !value;
             lightsPerCell.hidden = !value;
             lightsPerCell.parent.hidden = !value;
+            maxLights.hidden = !value;
+            maxLights.parent.hidden = !value;
 
             const shadows = shadowsEnabled.value && value;
             shadowsEnabled.hidden = !value;

--- a/src/editor/storage/clipboard-context-menu.ts
+++ b/src/editor/storage/clipboard-context-menu.ts
@@ -22,6 +22,7 @@ const types = new Set([
     'gradient',
     'batchgroup',
     'layers',
+    'shadow-cascade-mask',
     'entity',
     'array:entity',
     'asset',

--- a/src/editor/viewport/gizmo/gizmo-collision.ts
+++ b/src/editor/viewport/gizmo/gizmo-collision.ts
@@ -895,7 +895,12 @@ void main(void)
 
             const vertexCount = positions.length / 3;
             const vertexBuffer = new VertexBuffer(app.graphicsDevice, vertexFormat, vertexCount);
-            const vertexData = new Float32Array(vertexBuffer.lock());
+            const vertexStorage = vertexBuffer.lock();
+            const vertexData = new Float32Array(
+                ArrayBuffer.isView(vertexStorage) ? vertexStorage.buffer : vertexStorage,
+                ArrayBuffer.isView(vertexStorage) ? vertexStorage.byteOffset : 0,
+                vertexStorage.byteLength / 4
+            );
 
             for (let i = 0; i < vertexCount; i++) {
                 const offset = i * 7;
@@ -912,7 +917,12 @@ void main(void)
             mesh.vertexBuffer = vertexBuffer;
 
             const indexBuffer = new IndexBuffer(app.graphicsDevice, INDEXFORMAT_UINT16, indices.length);
-            const indexData = new Uint16Array(indexBuffer.lock());
+            const indexStorage = indexBuffer.lock();
+            const indexData = new Uint16Array(
+                ArrayBuffer.isView(indexStorage) ? indexStorage.buffer : indexStorage,
+                ArrayBuffer.isView(indexStorage) ? indexStorage.byteOffset : 0,
+                indexStorage.byteLength / 2
+            );
             indexData.set(indices);
             indexBuffer.unlock();
 

--- a/src/editor/viewport/viewport-application.ts
+++ b/src/editor/viewport/viewport-application.ts
@@ -16,7 +16,7 @@ class ViewportApplication extends Application {
 
         this._inTools = true;
         for (const system of this.systems.list) {
-            system._inTools = true;
+            (system as { _inTools: boolean })._inTools = true;
         }
 
         this.setEditorSettings(options.editorSettings);

--- a/src/editor/viewport/viewport.ts
+++ b/src/editor/viewport/viewport.ts
@@ -41,12 +41,6 @@ editor.once('load', () => {
         app.scene.layers.insertOpaque(depthLayer, 2);
 
         app.enableBundles = false;
-
-        // Force compatibility mode for Specular and Sheen maps when Editor is running with V2
-        // and project running on V1.
-        if (!editor.projectEngineV2) {
-            app.scene.forcePassThroughSpecular = true;
-        }
     } catch (ex) {
         editor.emit('viewport:error', ex);
         return;

--- a/src/launch/viewport/viewport.ts
+++ b/src/launch/viewport/viewport.ts
@@ -188,6 +188,8 @@ editor.once('load', () => {
     };
 
     app = new pc.AppBase(canvas);
+    app.loader.withCredentials = projectSettings.get('withCredentials');
+    app.loader.maxConcurrentRequests = projectSettings.get('maxConcurrentRequests');
 
     pc.createGraphicsDevice(canvas, gfxOptions).then((device) => {
         const createOptions = new pc.AppOptions();
@@ -480,6 +482,14 @@ editor.once('load', () => {
             } else {
                 app.loader.disableRetry();
             }
+        });
+
+        projectSettings.on('withCredentials:set', (value: boolean) => {
+            app.loader.withCredentials = value;
+        });
+
+        projectSettings.on('maxConcurrentRequests:set', (value: number) => {
+            app.loader.maxConcurrentRequests = value;
         });
 
         // locale change


### PR DESCRIPTION
Fixes #2095
Fixes #2096
Fixes #2119
Fixes #2132
Fixes #2209
Fixes #2211
Fixes #2213
Fixes #2216
Fixes #2222
Fixes #2240

### What's Changed

- update PlayCanvas Engine from 2.21.4 to 2.22.1
- add the new scene rendering and GSplat settings, including maximum clustered lights and splat budget controls
- expose the render shadow-cascade mask as a bitmask-backed multi-select
- add material parallax, Element text justification, Render cascade-mask, and GSplat LOD range/falloff controls and references
- add project settings for asset credentials and concurrent requests, and apply credentials before Launch preloading
- add JointComponent creation, references, entity bindings, type-specific controls, unbreakable impulse handling, and physics-module guidance
- hide obsolete `lodBaseDistance` and `lodMultiplier` controls without deleting or migrating stored legacy data
- update Editor call sites affected by Engine 2.22 API and typing changes

Backend schema dependency: [playcanvas-monorepo#4341](https://github.sc-corp.net/Snapchat/playcanvas-monorepo/pull/4341). Deploy that schema to DEV before frontend smoke testing and merge.

### Manual smoke test

1. Open an existing scene containing `lodBaseDistance` and `lodMultiplier`; expect it to load without mutation while the obsolete controls remain hidden.
2. Change the new rendering, GSplat, material, Element, and Render fields; expect save, reload, undo, and redo to preserve each value.
3. Select several shadow cascades on a Render component; expect the control to behave like a multi-select while persisting a single integer mask.
4. Set asset credentials and concurrent requests, then Launch and publish; expect both values in `application_properties` and credentialed loading to be configured before preload.
5. Add every Joint type, assign connected entities, and change its type-specific limits; expect the matching controls to appear and an unbreakable impulse to persist as `null`.
6. Open a Joint without a physics module; expect the standard Ammo import warning and a working import action.

### Checks

- [x] Build
- [x] Typecheck
- [x] Lint
- [x] Test
- [x] Vercel preview
- [x] I confirm I have read the [contributing guidelines](https://github.com/playcanvas/editor/blob/main/.github/CONTRIBUTING.md)
